### PR TITLE
Add profiles for build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 before_script:
     - npm install -g @angular/cli prettier
 
-script: (mvn clean test package)
+script: (mvn clean test package -Pci)
 
 branches:
     only:

--- a/comixed-importer/src/test/resources/logback-test.xml
+++ b/comixed-importer/src/test/resources/logback-test.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <include resource="org/springframework/boot/logging/logback/base.xml"/>
+  <logger name="org.springframework"
+          level="OFF"/>
+</configuration>

--- a/comixed-library/src/test/resources/logback-test.xml
+++ b/comixed-library/src/test/resources/logback-test.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <include resource="org/springframework/boot/logging/logback/base.xml"/>
+  <logger name="org.springframework"
+          level="OFF"/>
+</configuration>

--- a/comixed-rest-api/src/test/resources/logback-test.xml
+++ b/comixed-rest-api/src/test/resources/logback-test.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <include resource="org/springframework/boot/logging/logback/base.xml"/>
+  <logger name="org.springframework"
+          level="OFF"/>
+</configuration>

--- a/comixed-services/src/test/resources/logback-test.xml
+++ b/comixed-services/src/test/resources/logback-test.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <include resource="org/springframework/boot/logging/logback/base.xml"/>
+  <logger name="org.springframework"
+          level="OFF"/>
+</configuration>

--- a/comixed-tasks/src/test/resources/logback-test.xml
+++ b/comixed-tasks/src/test/resources/logback-test.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <include resource="org/springframework/boot/logging/logback/base.xml"/>
+  <logger name="org.springframework"
+          level="OFF"/>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,71 @@
   </parent>
   <name>comixed-parent</name>
   <url>http://github.com/mcpierce/comixed</url>
+  <profiles>
+    <profile>
+      <id>dev</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.cosium.code</groupId>
+            <artifactId>maven-git-code-format</artifactId>
+            <version>1.36</version>
+            <executions>
+              <execution>
+                <id>install-formatter-hook</id>
+                <goals>
+                  <goal>install-hooks</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <googleJavaFormatOptions>
+                <aosp>false</aosp>
+                <skipSortingImports>false</skipSortingImports>
+                <skipRemovingUnusedImports>false</skipRemovingUnusedImports>
+              </googleJavaFormatOptions>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>ci</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.cosium.code</groupId>
+            <artifactId>maven-git-code-format</artifactId>
+            <version>1.36</version>
+            <executions>
+              <execution>
+                <id>install-formatter-hook</id>
+                <goals>
+                  <goal>install-hooks</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>validate-code-format</id>
+                <goals>
+                  <goal>validate-code-format</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <googleJavaFormatOptions>
+                <aosp>false</aosp>
+                <skipSortingImports>false</skipSortingImports>
+                <skipRemovingUnusedImports>false</skipRemovingUnusedImports>
+              </googleJavaFormatOptions>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
   <properties>
     <comixed.url>http://www.github.com/mcpierce/comixed</comixed.url>
     <comixed.version>0.4.9-SNAPSHOT</comixed.version>


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Adds a profile for use when running builds in CI that fails the build when the Java code violates coding conventions. Additionally adds a configuration to minimize logging output during unit tests.