### PR TITLE
CB7 archive adaptor tests use target directory.

### DIFF
--- a/comixed-library/src/test/java/org/comixed/adaptors/archive/RarArchiveAdaptorTest.java
+++ b/comixed-library/src/test/java/org/comixed/adaptors/archive/RarArchiveAdaptorTest.java
@@ -39,8 +39,8 @@ public class RarArchiveAdaptorTest {
   private static final String TEST_FILE_ENTRY_1 = "example.jpeg";
   private static final String TEST_FILE_ENTRY_2 = "example.jpg";
   private static final String TEST_FILE_ENTRY_3 = "example.png";
-  private static final String TEST_CBZ_FILE = "src/test/resources/example.cbz";
-  private static final String TEST_CBR_FILE = "src/test/resources/example.cbr";
+  private static final String TEST_CBZ_FILE = "target/test-classes/example.cbz";
+  private static final String TEST_CBR_FILE = "target/test-classes/example.cbr";
 
   @Autowired private RarArchiveAdaptor archiveAdaptor;
 

--- a/comixed-library/src/test/java/org/comixed/adaptors/archive/SevenZipArchiveAdaptorTest.java
+++ b/comixed-library/src/test/java/org/comixed/adaptors/archive/SevenZipArchiveAdaptorTest.java
@@ -39,8 +39,8 @@ public class SevenZipArchiveAdaptorTest {
   private static final String TEST_FILE_ENTRY_2 = "example.png";
   private static final String TEST_FILE_ENTRY_1 = "example.jpg";
   private static final String TEST_FILE_ENTRY_0 = "example.jpeg";
-  private static final String TEST_CB7_FILE = "src/test/resources/example.cb7";
-  private static final String TEST_CBR_FILE = "src/test/resources/example.cbr";
+  private static final String TEST_CB7_FILE = "target/test-classes/example.cb7";
+  private static final String TEST_CBR_FILE = "target/test-classes/example.cbr";
   private static final Object TEST_FILE_ENTRY_RENAMED_0 = "offset-000.jpeg";
   private static final Object TEST_FILE_ENTRY_RENAMED_1 = "offset-001.jpg";
   private static final Object TEST_FILE_ENTRY_RENAMED_2 = "offset-002.png";


### PR DESCRIPTION
## Status
**READ**

## Migrations
NO

## Description
Updated the tests to work in the target/test-classes directory rather than the src/test/resources directory.