### PR TITLE
[CVE-2019-19919] Upgrade to handlebars^4.3.0.

### DIFF
--- a/comixed-frontend/package.json
+++ b/comixed-frontend/package.json
@@ -36,6 +36,7 @@
     "chart.js": "2.7.3",
     "core-js": "^2.5.4",
     "file-saver": "^2.0.2",
+    "handlebars": "^4.3.0",
     "jquery": "3.4.0",
     "lodash": "4.17.13",
     "messageformat": "^2.3.0",

--- a/comixed-frontend/yarn.lock
+++ b/comixed-frontend/yarn.lock
@@ -3160,6 +3160,17 @@ handlebars@^4.0.1, handlebars@^4.1.2:
   optionalDependencies:
     uglify-js "^3.1.4"
 
+handlebars@^4.3.0:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
+  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
+  dependencies:
+    neo-async "^2.6.0"
+    optimist "^0.6.1"
+    source-map "^0.6.1"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"


### PR DESCRIPTION
## Status
**READY*

## Migrations
NO

## Description
Upgrade handlebars to 4.3.0.