### PR TITLE
Issue #166: Remove uniqueness constraint from book in bookmarks table.

### DIFF
--- a/comixed-importer/src/main/java/org/comixed/importer/adaptors/ComicFileImportAdaptor.java
+++ b/comixed-importer/src/main/java/org/comixed/importer/adaptors/ComicFileImportAdaptor.java
@@ -108,7 +108,7 @@ public class ComicFileImportAdaptor {
     String currentPage = currentPages.get(comic.getFilename());
     if (currentPage != null && importUser != null) {
       Comic currentComic = this.comicRepository.findByFilename(comic.getFilename());
-      importUser.setBookmark(currentComic.getId(), currentPage);
+      importUser.setBookmark(currentComic, currentPage);
       this.userRepository.save(importUser);
     } else {
       this.logger.debug("No import user defined, no bookmark saved");

--- a/comixed-library/src/main/java/org/comixed/model/user/Bookmark.java
+++ b/comixed-library/src/main/java/org/comixed/model/user/Bookmark.java
@@ -18,13 +18,13 @@
 
 package org.comixed.model.user;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonView;
 import javax.persistence.*;
+import org.comixed.model.library.Comic;
 import org.comixed.views.View.UserList;
 
 @Entity
-@Table(name = "user_bookmarks")
+@Table(name = "bookmarks")
 public class Bookmark {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,12 +32,12 @@ public class Bookmark {
 
   @ManyToOne
   @JoinColumn(name = "user_id")
-  @JsonIgnore
   private ComiXedUser user;
 
-  @Column(name = "book", nullable = false)
+  @ManyToOne
+  @JoinColumn(name = "comic_id", nullable = false, updatable = false)
   @JsonView(UserList.class)
-  private long book;
+  private Comic comic;
 
   @Column(name = "mark", updatable = true, nullable = false)
   @JsonView(UserList.class)
@@ -45,18 +45,18 @@ public class Bookmark {
 
   public Bookmark() {}
 
-  public Bookmark(ComiXedUser user, long book, String mark) {
+  public Bookmark(ComiXedUser user, Comic comic, String mark) {
     this.user = user;
-    this.book = book;
+    this.comic = comic;
     this.mark = mark;
   }
 
-  public long getBook() {
-    return book;
+  public Comic getComic() {
+    return comic;
   }
 
-  public void setBook(long book) {
-    this.book = book;
+  public void setComic(Comic comic) {
+    this.comic = comic;
   }
 
   public String getMark() {

--- a/comixed-library/src/main/java/org/comixed/model/user/ComiXedUser.java
+++ b/comixed-library/src/main/java/org/comixed/model/user/ComiXedUser.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import javax.persistence.*;
+import org.comixed.model.library.Comic;
 import org.comixed.views.View;
 
 @Entity
@@ -174,28 +175,28 @@ public class ComiXedUser {
    * Returns the user's mark with the given book.
    *
    * @param book the bookmark's book
-   * @return the value, or 0 if not found
+   * @return the value, or null if none is set
    */
-  public String getBookmark(long book) {
+  public String getBookmark(Comic comic) {
     for (Bookmark bookmark : this.bookmarks) {
-      if (bookmark.getBook() == book) return bookmark.getMark();
+      if (bookmark.getComic().getId().equals(comic.getId())) return bookmark.getMark();
     }
-    return "0";
+    return null;
   }
 
   /**
    * Sets the user bookmark for the given book.
    *
-   * @param book the bookmark book
+   * @param comic the comic
    * @param mark the bookmark mark
    */
-  public void setBookmark(long book, String mark) {
+  public void setBookmark(Comic comic, String mark) {
     for (Bookmark bookmark : this.bookmarks) {
-      if (bookmark.getBook() == book) {
+      if (bookmark.getComic() == comic) {
         bookmark.setMark(mark);
         return;
       }
     }
-    this.bookmarks.add(new Bookmark(this, book, mark));
+    this.bookmarks.add(new Bookmark(this, comic, mark));
   }
 }

--- a/comixed-library/src/main/resources/db/liquibase-changelog.xml
+++ b/comixed-library/src/main/resources/db/liquibase-changelog.xml
@@ -7,6 +7,7 @@
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
   <include file="/db/migrations/0.5.0/changelog-0.5.0.xml"/>
+  <include file="/db/migrations/0.5.1/changelog-0.5.1.xml"/>
   <include file="/db/migrations/0.6.0/changelog-0.6.0.xml"/>
 
 </databaseChangeLog>

--- a/comixed-library/src/main/resources/db/migrations/0.5.1/001_issue-166_remove_uniqueness_on_book.xml
+++ b/comixed-library/src/main/resources/db/migrations/0.5.1/001_issue-166_remove_uniqueness_on_book.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="001_issue-166_remove_uniqueness_on_book.xml"
+             author="mcpierce">
+
+    <renameTable oldTableName="user_bookmarks"
+                 newTableName="bookmarks"/>
+
+    <dropUniqueConstraint tableName="bookmarks"
+                          uniqueColumns="book"/>
+
+    <renameColumn tableName="bookmarks"
+                  oldColumnName="book"
+                  newColumnName="comic_id"/>
+
+    <!-- users can only have one bookmark per comic -->
+    <addUniqueConstraint tableName="bookmarks"
+                         columnNames="user_id,comic_id"/>
+
+  </changeSet>
+</databaseChangeLog>

--- a/comixed-library/src/main/resources/db/migrations/0.5.1/changelog-0.5.1.xml
+++ b/comixed-library/src/main/resources/db/migrations/0.5.1/changelog-0.5.1.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <include file="/db/migrations/0.5.0/001_issue-559_initial_migration.xml"/>
+  <include file="/db/migrations/0.5.0/002_issue-544_create_comic_file_details_table.xml"/>
+  <include file="/db/migrations/0.5.0/003_issue-553_added_date_deleted_to_comics.xml"/>
+  <include file="/db/migrations/0.5.0/004_issue-578_rename_order_to_sequence.xml"/>
+  <include file="/db/migrations/0.5.0/005_create_bookmarks_table.xml"/>
+  <include file="/db/migrations/0.5.0/006_issue-72_create_smartlists_table.xml"/>
+  <include file="/db/migrations/0.5.0/007_issue-27_pad_page_hash_values.xml"/>
+</databaseChangeLog>

--- a/comixed-library/src/test/java/org/comixed/model/user/BookmarkTest.java
+++ b/comixed-library/src/test/java/org/comixed/model/user/BookmarkTest.java
@@ -18,40 +18,23 @@
 
 package org.comixed.model.user;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
-import org.junit.Before;
+import org.comixed.model.library.Comic;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class BookmarkTest {
 
-  private static final long BOOK_ID = 100;
-  private static final String MARK = "10";
+  private static final long TEST_COMIC_ID = 100;
+  private static final String TEST_BOOKMARK = "10";
 
-  private Bookmark bookmark;
-
-  @Before
-  public void setUp() {
-    ComiXedUser user = new ComiXedUser();
-    bookmark = new Bookmark(user, BOOK_ID, MARK);
-  }
-
-  @Test
-  public void testHasBook() {
-    assertEquals(BOOK_ID, bookmark.getBook());
-  }
-
-  @Test
-  public void testCanUpdateBook() {
-    long newBookId = 105;
-    bookmark.setBook(newBookId);
-    assertEquals(newBookId, bookmark.getBook());
-  }
-
-  @Test
-  public void testHasMark() {
-    assertEquals(MARK, bookmark.getMark());
-  }
+  @Mock private Comic comic;
+  @Mock private ComiXedUser user;
+  private Bookmark bookmark = new Bookmark(user, comic, TEST_BOOKMARK);
 
   @Test
   public void testCanUpdateMark() {


### PR DESCRIPTION
## Status
**READY**

## Migrations
YES

## Description
1. Renamed table: **user_bookmarks** => **bookmarks**.
1. Renamed column:  **book** => **comic_id**
1. Removed uniqueness constraint from comic_id.
1. Added uniqueness constraint for user_id and comic_id to bookmarks table.
1. Refactored Bookmark to work with instances of Comic rather than an id value.