### PR TITLE
[Issue #173] Fix loading the first image from a 7zip encoded archive.

### DIFF
--- a/comixed-library/src/main/java/org/comixed/adaptors/archive/AbstractArchiveAdaptor.java
+++ b/comixed-library/src/main/java/org/comixed/adaptors/archive/AbstractArchiveAdaptor.java
@@ -283,13 +283,17 @@ public abstract class AbstractArchiveAdaptor<I> implements ArchiveAdaptor, Initi
 
   @Override
   public String getFirstImageFileName(String filename) throws ArchiveAdaptorException {
-    I archiveRef = this.openArchive(new File(filename));
+    I archiveRef = null;
 
+    // get the list of entries
+    archiveRef = this.openArchive(new File(filename));
     List<String> entries = this.getEntryFilenames(archiveRef);
     Collections.sort(entries);
     String result = null;
+    this.closeArchive(archiveRef);
 
     for (String entry : entries) {
+      archiveRef = this.openArchive(new File(filename));
       byte[] content = this.loadSingleFileInternal(archiveRef, entry);
       String contentType = this.fileTypeIdentifier.subtypeFor(new ByteArrayInputStream(content));
 

--- a/comixed-library/src/main/java/org/comixed/adaptors/archive/SevenZipArchiveAdaptor.java
+++ b/comixed-library/src/main/java/org/comixed/adaptors/archive/SevenZipArchiveAdaptor.java
@@ -128,6 +128,7 @@ public class SevenZipArchiveAdaptor extends AbstractArchiveAdaptor<SevenZFile> {
   protected byte[] loadSingleFileInternal(SevenZFile archiveReference, String entryName)
       throws ArchiveAdaptorException {
     byte[] result = null;
+
     try {
       boolean done = false;
       SevenZArchiveEntry entry = archiveReference.getNextEntry();

--- a/comixed-library/src/test/java/org/comixed/adaptors/archive/SevenZipArchiveAdaptorTest.java
+++ b/comixed-library/src/test/java/org/comixed/adaptors/archive/SevenZipArchiveAdaptorTest.java
@@ -36,16 +36,16 @@ import org.springframework.test.context.junit4.SpringRunner;
 @SpringBootTest(classes = ComiXedTestContext.class)
 @TestPropertySource(locations = "classpath:application.properties")
 public class SevenZipArchiveAdaptorTest {
-  private static final String TEST_FILE_ENTRY_3 = "exampleCBR.jpg";
-  private static final String TEST_FILE_ENTRY_2 = "example.png";
+  private static final String TEST_FILE_ENTRY_2 = "exampleCBR.jpg";
+  private static final String TEST_FILE_ENTRY_3 = "example.png";
   private static final String TEST_FILE_ENTRY_1 = "example.jpg";
   private static final String TEST_FILE_ENTRY_0 = "example.jpeg";
   private static final String TEST_CB7_FILE = "target/test-classes/example.cb7";
   private static final String TEST_CBR_FILE = "target/test-classes/example.cbr";
   private static final Object TEST_FILE_ENTRY_RENAMED_0 = "offset-000.jpeg";
   private static final Object TEST_FILE_ENTRY_RENAMED_1 = "offset-001.jpg";
-  private static final Object TEST_FILE_ENTRY_RENAMED_2 = "offset-002.png";
-  private static final Object TEST_FILE_ENTRY_RENAMED_3 = "offset-003.jpg";
+  private static final Object TEST_FILE_ENTRY_RENAMED_2 = "offset-002.jpg";
+  private static final Object TEST_FILE_ENTRY_RENAMED_3 = "offset-003.png";
 
   @Autowired private SevenZipArchiveAdaptor archiveAdaptor;
 


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Fix loading the first image for a 7zip-encoded archive.