### PR TITLE
[Issue #188] Add explicit missing comic field to comic state.

### DIFF
--- a/comixed-frontend/src/app/comics/adaptors/comic.adaptor.spec.ts
+++ b/comixed-frontend/src/app/comics/adaptors/comic.adaptor.spec.ts
@@ -28,6 +28,7 @@ import {
   ComicDeleted,
   ComicGetFormats,
   ComicGetIssue,
+  ComicGetIssueFailed,
   ComicGetPageTypes,
   ComicGetScanTypes,
   ComicGotFormats,
@@ -176,19 +177,58 @@ describe('ComicAdaptor', () => {
     });
   });
 
-  it('provides notice when fetching a comic', () => {
-    store.dispatch(new ComicGetIssue({ id: 17 }));
-    adaptor.fetchingIssue$.subscribe(result => expect(result).toBeTruthy());
-  });
+  describe('fetching a single comic', () => {
+    beforeEach(() => {
+      adaptor.getComicById(COMIC.id);
+    });
 
-  it('provides notice when the comic changes', () => {
-    store.dispatch(new ComicGotIssue({ comic: COMIC }));
-    adaptor.comic$.subscribe(result => expect(result).toEqual(COMIC));
-  });
+    it('fires an action', () => {
+      expect(store.dispatch).toHaveBeenCalledWith(
+        new ComicGetIssue({ id: COMIC.id })
+      );
+    });
 
-  it('can get a comic by id', () => {
-    adaptor.getComicById(17);
-    expect(store.dispatch).toHaveBeenCalledWith(new ComicGetIssue({ id: 17 }));
+    it('provides updates on fetching', () => {
+      adaptor.fetchingIssue$.subscribe(response =>
+        expect(response).toBeTruthy()
+      );
+    });
+
+    it('provides updates on no comic', () => {
+      adaptor.noComic$.subscribe(response => expect(response).toBeFalsy());
+    });
+
+    describe('success', () => {
+      beforeEach(() => {
+        store.dispatch(new ComicGotIssue({ comic: COMIC }));
+      });
+
+      it('provides updates on fetching', () => {
+        adaptor.fetchingIssue$.subscribe(response =>
+          expect(response).toBeFalsy()
+        );
+      });
+
+      it('provides updates on the comic', () => {
+        adaptor.comic$.subscribe(result => expect(result).toEqual(COMIC));
+      });
+    });
+
+    describe('failure', () => {
+      beforeEach(() => {
+        store.dispatch(new ComicGetIssueFailed());
+      });
+
+      it('provides updates on fetching', () => {
+        adaptor.fetchingIssue$.subscribe(response =>
+          expect(response).toBeFalsy()
+        );
+      });
+
+      it('provides updates on no comic', () => {
+        adaptor.noComic$.subscribe(response => expect(response).toBeTruthy());
+      });
+    });
   });
 
   it('can save changes to a page', () => {

--- a/comixed-frontend/src/app/comics/adaptors/comic.adaptor.ts
+++ b/comixed-frontend/src/app/comics/adaptors/comic.adaptor.ts
@@ -53,6 +53,7 @@ export class ComicAdaptor {
   private _formatsLoaded$ = new BehaviorSubject<boolean>(false);
   private _formats$ = new BehaviorSubject<ComicFormat[]>([]);
   private _fetchingIssue$ = new BehaviorSubject<boolean>(false);
+  private _noComic$ = new BehaviorSubject<boolean>(false);
   private _fetchingPageTypes$ = new BehaviorSubject<boolean>(false);
   private _pageTypes$ = new BehaviorSubject<PageType[]>([]);
   private _pageTypesLoaded$ = new BehaviorSubject<boolean>(false);
@@ -89,6 +90,9 @@ export class ComicAdaptor {
         }
         if (state.fetchingComic !== this._fetchingIssue$.getValue()) {
           this._fetchingIssue$.next(state.fetchingComic);
+        }
+        if (state.noComic !== this._noComic$.getValue()) {
+          this._noComic$.next(state.noComic);
         }
         if (state.deletingComic !== this._deletingComic$.getValue()) {
           this._deletingComic$.next(state.deletingComic);
@@ -146,6 +150,10 @@ export class ComicAdaptor {
 
   get fetchingIssue$(): Observable<boolean> {
     return this._fetchingIssue$.asObservable();
+  }
+
+  get noComic$(): Observable<boolean> {
+    return this._noComic$.asObservable();
   }
 
   get comic$(): Observable<Comic> {

--- a/comixed-frontend/src/app/comics/reducers/comic.reducer.spec.ts
+++ b/comixed-frontend/src/app/comics/reducers/comic.reducer.spec.ts
@@ -121,6 +121,10 @@ describe('Comic Reducer', () => {
       expect(state.fetchingComic).toBeFalsy();
     });
 
+    it('clears the no comic flag', () => {
+      expect(state.noComic).toBeFalsy();
+    });
+
     it('has no comic loaded', () => {
       expect(state.comic).toBeNull();
     });
@@ -326,9 +330,13 @@ describe('Comic Reducer', () => {
   describe('when loading a comic', () => {
     beforeEach(() => {
       state = reducer(
-        { ...state, fetchingComic: false },
+        { ...state, fetchingComic: false, noComic: true },
         new ComicGetIssue({ id: 17 })
       );
+    });
+
+    it('clears the no comic flag', () => {
+      expect(state.noComic).toBeFalsy();
     });
 
     it('sets the fetching comic flag', () => {
@@ -356,9 +364,13 @@ describe('Comic Reducer', () => {
   describe('when getting a comic fails', () => {
     beforeEach(() => {
       state = reducer(
-        { ...state, fetchingComic: true },
+        { ...state, fetchingComic: true, noComic: false },
         new ComicGetIssueFailed()
       );
+    });
+
+    it('sets the no comic flag', () => {
+      expect(state.noComic).toBeTruthy();
     });
 
     it('clears the fetching comic flag', () => {

--- a/comixed-frontend/src/app/comics/reducers/comic.reducer.ts
+++ b/comixed-frontend/src/app/comics/reducers/comic.reducer.ts
@@ -32,6 +32,7 @@ export interface ComicState {
   pageTypes: PageType[];
   pageTypesLoaded: boolean;
   fetchingComic: boolean;
+  noComic: boolean;
   comic: Comic;
   savingPage: boolean;
   blockingPageHash: boolean;
@@ -53,6 +54,7 @@ export const initialState: ComicState = {
   pageTypes: [],
   pageTypesLoaded: false,
   fetchingComic: false,
+  noComic: false,
   comic: null,
   savingPage: false,
   blockingPageHash: false,
@@ -111,13 +113,13 @@ export function reducer(
       return { ...state, fetchingPageTypes: false, pageTypesLoaded: false };
 
     case ComicActionTypes.GetIssue:
-      return { ...state, fetchingComic: true };
+      return { ...state, fetchingComic: true, noComic: false };
 
     case ComicActionTypes.GotIssue:
       return { ...state, fetchingComic: false, comic: action.payload.comic };
 
     case ComicActionTypes.GetIssueFailed:
-      return { ...state, fetchingComic: false };
+      return { ...state, fetchingComic: false, noComic: true };
 
     case ComicActionTypes.SavePage:
       return { ...state, savingPage: true };

--- a/comixed-frontend/src/assets/i18n/comics-en.json
+++ b/comixed-frontend/src/assets/i18n/comics-en.json
@@ -206,11 +206,6 @@
     },
     "text": {
       "download-link": "Download This Comic"
-    },
-    "error": {
-      "no-such-comic": {
-        "detail": "No such comic found: id={id}."
-      }
     }
   },
   "comic-list-item": {


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Add a new field to the comics state to track when a comic is actually not found. Only show toaster in that case.