### PR TITLE
[Issue #120] Add persistent Publisher data model.

### DIFF
--- a/comixed-library/src/main/java/org/comixed/model/comic/Publisher.java
+++ b/comixed-library/src/main/java/org/comixed/model/comic/Publisher.java
@@ -1,0 +1,113 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixed.model.comic;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.persistence.*;
+
+@Entity
+@Table(name = "publishers")
+public class Publisher {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @JsonProperty("id")
+  private Long id;
+
+  @Column(name = "name", length = 256, updatable = true, nullable = false, unique = true)
+  @JsonProperty("name")
+  private String name;
+
+  @Column(name = "comic_vine_id", length = 64, updatable = false, nullable = false, unique = true)
+  @JsonProperty("comic_vine_id")
+  private String comicVineId;
+
+  @Column(name = "comic_vine_url", length = 256, updatable = true, nullable = false)
+  @JsonProperty("comic_vine_url")
+  private String comicVineUrl;
+
+  @Lob
+  @Column(name = "description")
+  @JsonProperty("description")
+  private String description;
+
+  @Lob
+  @Column(name = "thumbnail")
+  @JsonIgnore
+  private byte[] thumbnail;
+
+  @Lob
+  @Column(name = "logo")
+  @JsonIgnore
+  private byte[] logo;
+
+  public Publisher() {}
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getComicVineId() {
+    return comicVineId;
+  }
+
+  public void setComicVineId(String comicVineId) {
+    this.comicVineId = comicVineId;
+  }
+
+  public String getComicVineUrl() {
+    return comicVineUrl;
+  }
+
+  public void setComicVineUrl(String comicVineUrl) {
+    this.comicVineUrl = comicVineUrl;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public byte[] getThumbnail() {
+    return thumbnail;
+  }
+
+  public void setThumbnail(byte[] thumbnail) {
+    this.thumbnail = thumbnail;
+  }
+
+  public byte[] getLogo() {
+    return logo;
+  }
+
+  public void setLogo(byte[] logo) {
+    this.logo = logo;
+  }
+}

--- a/comixed-library/src/main/java/org/comixed/repositories/comic/PublisherRepository.java
+++ b/comixed-library/src/main/java/org/comixed/repositories/comic/PublisherRepository.java
@@ -1,0 +1,33 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixed.repositories.comic;
+
+import org.comixed.model.comic.Publisher;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PublisherRepository extends CrudRepository<Publisher, Long> {
+  @Query("SELECT p FROM Publisher p WHERE p.id = :id")
+  Publisher getById(@Param("id") Long id);
+
+  Publisher findByComicVineId(@Param("comicVineId") String comicVineId);
+}

--- a/comixed-library/src/main/resources/db/migrations/0.6.0/002_issue-120_add_publisher_details_fields.xml
+++ b/comixed-library/src/main/resources/db/migrations/0.6.0/002_issue-120_add_publisher_details_fields.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+  <changeSet id="002_isue-120_add_publisher_details_fields.xml"
+             author="mcpierce">
+
+    <createTable tableName="publishers">
+      <column name="id"
+              type="bigint">
+        <constraints nullable="false"
+                     unique="true"
+                     primaryKey="true"/>
+      </column>
+      <column name="name"
+              type="varchar(256)">
+        <constraints nullable="false"
+                     unique="true"/>
+      </column>
+      <column name="comic_vine_id"
+              type="varchar(64)">
+        <constraints unique="true"
+                     nullable="false"/>
+      </column>
+      <column name="comic_vine_url"
+              type="varchar(256)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="description"
+              type="clob">
+        <constraints nullable="true"/>
+      </column>
+      <column name="thumbnail"
+              type="blob">
+        <constraints nullable="true"/>
+      </column>
+      <column name="logo"
+              type="blob">
+        <constraints nullable="true"/>
+      </column>
+    </createTable>
+
+    <addAutoIncrement tableName="publishers"
+                      columnName="id"
+                      columnDataType="bigint"
+                      startWith="100"/>
+
+    <createIndex tableName="publishers"
+                 indexName="publisher_name_idx">
+      <column name="name"/>
+    </createIndex>
+
+    <createIndex tableName="publishers"
+                 indexName="publisher_comic_vine_id_idx">
+      <column name="comic_vine_id"></column>
+    </createIndex>
+
+  </changeSet>
+</databaseChangeLog>

--- a/comixed-library/src/main/resources/db/migrations/0.6.0/changelog-0.6.0.xml
+++ b/comixed-library/src/main/resources/db/migrations/0.6.0/changelog-0.6.0.xml
@@ -7,5 +7,6 @@
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
   <include file="/db/migrations/0.6.0/001_issue-143_add_persisted_task_tables.xml"/>
+  <include file="/db/migrations/0.6.0/002_issue-120_add_publisher_details_fields.xml"/>
 
 </databaseChangeLog>

--- a/comixed-library/src/test/java/org/comixed/repositories/comic/PublisherRepositoryTest.java
+++ b/comixed-library/src/test/java/org/comixed/repositories/comic/PublisherRepositoryTest.java
@@ -1,0 +1,75 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixed.repositories.comic;
+
+import static junit.framework.TestCase.*;
+
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import org.comixed.model.comic.Publisher;
+import org.comixed.repositories.RepositoryContext;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
+import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = RepositoryContext.class)
+@TestPropertySource(locations = "classpath:application.properties")
+@DatabaseSetup("classpath:test-comics.xml")
+@TestExecutionListeners({
+  DependencyInjectionTestExecutionListener.class,
+  DirtiesContextTestExecutionListener.class,
+  TransactionalTestExecutionListener.class,
+  DbUnitTestExecutionListener.class
+})
+public class PublisherRepositoryTest {
+  private static final Long TEST_PUBLISHER_ID = 1000L;
+  private static final String TEST_COMIC_VINE_ID = "23173";
+  @Autowired private PublisherRepository publisherRepository;
+
+  @Test
+  public void testGetById() {
+    Publisher result = publisherRepository.getById(TEST_PUBLISHER_ID);
+
+    assertNotNull(result);
+    assertEquals(TEST_PUBLISHER_ID, result.getId());
+  }
+
+  @Test
+  public void testFindByComicVineIdNoSuchId() {
+    Publisher result = publisherRepository.findByComicVineId(TEST_COMIC_VINE_ID.substring(1));
+
+    assertNull(result);
+  }
+
+  @Test
+  public void testFindByComicVineId() {
+    Publisher result = publisherRepository.findByComicVineId(TEST_COMIC_VINE_ID);
+
+    assertNotNull(result);
+    assertEquals(TEST_COMIC_VINE_ID, result.getComicVineId());
+  }
+}

--- a/comixed-library/src/test/resources/test-comics.xml
+++ b/comixed-library/src/test/resources/test-comics.xml
@@ -432,4 +432,9 @@
                                  sequence="2"
                                  created="2019-11-01 09:14:00"
                                  content="Third entry"/>
+  <publishers ID="1000"
+              NAME="Super Soft Publishing"
+              COMIC_VINE_ID="23173"
+              COMIC_VINE_URL="http://localhost"
+              DESCRIPTION="This is a publisher"/>
 </dataset>

--- a/comixed-rest-api/src/main/java/org/comixed/web/comicvine/ComicVineQueryForPublisherDetailsAdaptor.java
+++ b/comixed-rest-api/src/main/java/org/comixed/web/comicvine/ComicVineQueryForPublisherDetailsAdaptor.java
@@ -55,7 +55,7 @@ public class ComicVineQueryForPublisherDetailsAdaptor {
 
       request.setApiKey(apiKey);
       request.setPublisherId(publisherId);
-      request.addFilter("field_list", "id,name,image");
+      request.addFilter("field_list", "id,name,image,api_detail_url,deck");
 
       try {
         content = this.webRequestProcessor.execute(request);

--- a/comixed-rest-api/src/test/java/org/comixed/web/comicvine/ComicVinePublisherDetailsResponseProcessorTest.java
+++ b/comixed-rest-api/src/test/java/org/comixed/web/comicvine/ComicVinePublisherDetailsResponseProcessorTest.java
@@ -20,12 +20,14 @@ package org.comixed.web.comicvine;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.comixed.model.library.Comic;
+import org.comixed.repositories.comic.PublisherRepository;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
@@ -38,14 +40,15 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class ComicVinePublisherDetailsResponseProcessorTest {
   private static final byte[] BAD_DATA = "This is not a valid response".getBytes();
   private static final byte[] GOOD_DATA =
-      "{\"error\":\"OK\",\"limit\":1,\"offset\":0,\"number_of_page_results\":1,\"number_of_total_results\":1,\"status_code\":1,\"results\":{\"name\":\"DC Comics\"},\"version\":\"1.0\"}"
+      "{\"error\":\"OK\",\"limit\":1,\"offset\":0,\"number_of_page_results\":1,\"number_of_total_results\":1,\"status_code\":1,\"results\":{\"api_detail_url\":\"https:\\/\\/comicvine.gamespot.com\\/api\\/publisher\\/4010-10\\/\",\"deck\":\"Originally known as \\\"National Publications\\\", DC is a publisher of comic books featuring iconic characters and teams such as Superman, Batman, Wonder Woman, Green Lantern, the Justice League of America, and the Teen Titans, and is considered the originator of the American superhero genre. DC, along with rival Marvel Comics, is one of the \\\"big two\\\" American comic book publishers. DC Entertainment is a subsidiary of Warner Brothers and its parent company Time Warner.\",\"id\":10,\"image\":{\"icon_url\":\"https:\\/\\/comicvine1.cbsistatic.com\\/uploads\\/square_avatar\\/0\\/40\\/5213245-dc_logo_blue_final.jpg\",\"medium_url\":\"https:\\/\\/comicvine1.cbsistatic.com\\/uploads\\/scale_medium\\/0\\/40\\/5213245-dc_logo_blue_final.jpg\",\"screen_url\":\"https:\\/\\/comicvine1.cbsistatic.com\\/uploads\\/screen_medium\\/0\\/40\\/5213245-dc_logo_blue_final.jpg\",\"screen_large_url\":\"https:\\/\\/comicvine1.cbsistatic.com\\/uploads\\/screen_kubrick\\/0\\/40\\/5213245-dc_logo_blue_final.jpg\",\"small_url\":\"https:\\/\\/comicvine1.cbsistatic.com\\/uploads\\/scale_small\\/0\\/40\\/5213245-dc_logo_blue_final.jpg\",\"super_url\":\"https:\\/\\/comicvine1.cbsistatic.com\\/uploads\\/scale_large\\/0\\/40\\/5213245-dc_logo_blue_final.jpg\",\"thumb_url\":\"https:\\/\\/comicvine1.cbsistatic.com\\/uploads\\/scale_avatar\\/0\\/40\\/5213245-dc_logo_blue_final.jpg\",\"tiny_url\":\"https:\\/\\/comicvine1.cbsistatic.com\\/uploads\\/square_mini\\/0\\/40\\/5213245-dc_logo_blue_final.jpg\",\"original_url\":\"https:\\/\\/comicvine1.cbsistatic.com\\/uploads\\/original\\/0\\/40\\/5213245-dc_logo_blue_final.jpg\",\"image_tags\":\"All Images,DC Comics logo\"},\"name\":\"DC Comics\"},\"version\":\"1.0\"}"
           .getBytes();
   private static final byte[] IMPRINT_DATA =
-      "{\"error\":\"OK\",\"limit\":1,\"offset\":0,\"number_of_page_results\":1,\"number_of_total_results\":1,\"status_code\":1,\"results\":{\"name\":\"Vertigo\"},\"version\":\"1.0\"}"
+      "{\"error\":\"OK\",\"limit\":1,\"offset\":0,\"number_of_page_results\":1,\"number_of_total_results\":1,\"status_code\":1,\"results\":{\"api_detail_url\":\"https:\\/\\/comicvine.gamespot.com\\/api\\/publisher\\/4010-521\\/\",\"deck\":\"Vertigo is an imprint of  DC Comics suggested for mature readers and is a continuity separate from the DC Universe that has included Sandman, Swamp Thing, John Constantine (Hellblazer) and many others. However, nowadays the imprint is mostly focused upon creator-owned material.\",\"id\":521,\"image\":{\"icon_url\":\"https:\\/\\/comicvine1.cbsistatic.com\\/uploads\\/square_avatar\\/6\\/67663\\/4717683-logo.jpg\",\"medium_url\":\"https:\\/\\/comicvine1.cbsistatic.com\\/uploads\\/scale_medium\\/6\\/67663\\/4717683-logo.jpg\",\"screen_url\":\"https:\\/\\/comicvine1.cbsistatic.com\\/uploads\\/screen_medium\\/6\\/67663\\/4717683-logo.jpg\",\"screen_large_url\":\"https:\\/\\/comicvine1.cbsistatic.com\\/uploads\\/screen_kubrick\\/6\\/67663\\/4717683-logo.jpg\",\"small_url\":\"https:\\/\\/comicvine1.cbsistatic.com\\/uploads\\/scale_small\\/6\\/67663\\/4717683-logo.jpg\",\"super_url\":\"https:\\/\\/comicvine1.cbsistatic.com\\/uploads\\/scale_large\\/6\\/67663\\/4717683-logo.jpg\",\"thumb_url\":\"https:\\/\\/comicvine1.cbsistatic.com\\/uploads\\/scale_avatar\\/6\\/67663\\/4717683-logo.jpg\",\"tiny_url\":\"https:\\/\\/comicvine1.cbsistatic.com\\/uploads\\/square_mini\\/6\\/67663\\/4717683-logo.jpg\",\"original_url\":\"https:\\/\\/comicvine1.cbsistatic.com\\/uploads\\/original\\/6\\/67663\\/4717683-logo.jpg\",\"image_tags\":\"All Images\"},\"name\":\"Vertigo\"},\"version\":\"1.0\"}"
           .getBytes();
 
   @Autowired private ComicVinePublisherDetailsResponseProcessor processor;
   @Mock private Comic comic;
+  @MockBean private PublisherRepository publisherRepository;
 
   @Test(expected = ComicVineAdaptorException.class)
   public void testProcessBadData() throws ComicVineAdaptorException {


### PR DESCRIPTION
## Status
**READY**

## Migrations
YES

## Description
Stores the name, comic vine id, thumbnail and logo for publishers as their details are scraped for a comic.