### PR TITLE
[Issue #197] Move image type identification in the base archive adaptor.

### DIFF
--- a/comixed-library/src/main/java/org/comixed/adaptors/archive/ArchiveEntryType.java
+++ b/comixed-library/src/main/java/org/comixed/adaptors/archive/ArchiveEntryType.java
@@ -1,0 +1,24 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixed.adaptors.archive;
+
+public enum ArchiveEntryType {
+  FILE,
+  IMAGE;
+}

--- a/comixed-library/src/main/java/org/comixed/utils/FileTypeIdentifier.java
+++ b/comixed-library/src/main/java/org/comixed/utils/FileTypeIdentifier.java
@@ -20,8 +20,6 @@ package org.comixed.utils;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
-import java.util.List;
 import lombok.extern.log4j.Log4j2;
 import org.apache.tika.Tika;
 import org.apache.tika.metadata.Metadata;
@@ -37,10 +35,6 @@ import org.springframework.stereotype.Component;
 @Component
 @Log4j2
 public class FileTypeIdentifier {
-  // TODO this needs to be loaded from the entryloaders.properties file
-  public static final List<String> IMAGE_TYPES =
-      Arrays.asList(new String[] {"jpeg", "png", "gif", "webp"});
-
   @Autowired private Tika tika;
   @Autowired private Metadata metadata;
 

--- a/comixed-library/src/main/resources/entryloaders.properties
+++ b/comixed-library/src/main/resources/entryloaders.properties
@@ -1,10 +1,14 @@
 # Comic entry loaders
 comic.entry.loaders[0].type=xml
+comic.entry.loaders[0].entryType=FILE
 comic.entry.loaders[0].bean=filenameEntryLoader
+comic.entry.loaders[1].entryType=IMAGE
 comic.entry.loaders[1].type=jpeg
 comic.entry.loaders[1].bean=imageEntryLoader
+comic.entry.loaders[2].entryType=IMAGE
 comic.entry.loaders[2].type=png
 comic.entry.loaders[2].bean=imageEntryLoader
+comic.entry.loaders[3].entryType=IMAGE
 comic.entry.loaders[3].type=webp
 comic.entry.loaders[3].bean=imageEntryLoader
 


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Move the list of image mime types to a single set of properties.