### PR TITLE
[Issue #205] Store imprints as their own records in the publishers details table.

### DIFF
--- a/comixed-rest-api/src/main/java/org/comixed/web/comicvine/ComicVinePublisherDetailsResponseProcessor.java
+++ b/comixed-rest-api/src/main/java/org/comixed/web/comicvine/ComicVinePublisherDetailsResponseProcessor.java
@@ -108,15 +108,16 @@ public class ComicVinePublisherDetailsResponseProcessor {
       String description = jsonNode.get("results").get("deck").asText();
       String thumbnailUrl = jsonNode.get("results").get("image").get("thumb_url").asText();
       String logoUrl = jsonNode.get("results").get("image").get("original_url").asText();
-      String imprint = null;
 
       if (IMPRINT_MAPPINGS.containsKey(publisher)) {
-        imprint = publisher;
-        publisher = IMPRINT_MAPPINGS.get(publisher);
+        this.log.debug("Publisher is an imprint");
+        comic.setPublisher(IMPRINT_MAPPINGS.get(publisher));
+        comic.setImprint(publisher);
+      } else {
+        this.log.debug("Publisher is not an imprint");
+        comic.setPublisher(publisher);
+        comic.setImprint("");
       }
-
-      comic.setPublisher(publisher);
-      comic.setImprint(imprint);
 
       // create or update the publisher record
       this.log.debug("Updating publisher record");

--- a/comixed-services/src/main/java/org/comixed/service/library/ComicService.java
+++ b/comixed-services/src/main/java/org/comixed/service/library/ComicService.java
@@ -164,6 +164,7 @@ public class ComicService {
     return this.lastReadDatesRepository.findAllForUser(user.getId());
   }
 
+  @Transactional
   public Comic save(final Comic comic) {
     this.log.debug("Saving comic: filename={}", comic.getFilename());
 


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
When a publisher is an imprint, create or update that imprint's own record in the publishers table.