### PR TITLE
[Issue #221] Show comics selected from the navigation tree.

### DIFF
--- a/comixed-frontend/src/app/library/actions/library.actions.ts
+++ b/comixed-frontend/src/app/library/actions/library.actions.ts
@@ -36,7 +36,8 @@ export enum LibraryActionTypes {
   ConvertComicsFailed = '[LIBRARY] Failed to convert comics',
   Consolidate = '[LIBRARY] Consolidate the library',
   Consolidated = '[LIBRARY] Library is consolidated',
-  ConsolidateFailed = '[LIBRARY] Failed to consolidate libary'
+  ConsolidateFailed = '[LIBRARY] Failed to consolidate library',
+  DisplayComics = '[LIBRARY] Set the list of comics to be displayed'
 }
 
 export class LibraryReset implements Action {
@@ -158,6 +159,12 @@ export class LibraryConsolidateFailed implements Action {
   constructor() {}
 }
 
+export class LibraryDisplayComics implements Action {
+  readonly type = LibraryActionTypes.DisplayComics;
+
+  constructor(public payload: { title: string; comics: Comic[] }) {}
+}
+
 export type LibraryActions =
   | LibraryReset
   | LibraryGetUpdates
@@ -174,4 +181,5 @@ export type LibraryActions =
   | LibraryConvertComicsFailed
   | LibraryConsolidate
   | LibraryConsolidated
-  | LibraryConsolidateFailed;
+  | LibraryConsolidateFailed
+  | LibraryDisplayComics;

--- a/comixed-frontend/src/app/library/adaptors/library.adaptor.spec.ts
+++ b/comixed-frontend/src/app/library/adaptors/library.adaptor.spec.ts
@@ -50,6 +50,7 @@ import {
   LibraryConsolidateFailed,
   LibraryConvertComics,
   LibraryConvertComicsFailed,
+  LibraryDisplayComics,
   LibraryGetUpdates,
   LibraryUpdatesReceived
 } from '../actions/library.actions';
@@ -67,6 +68,7 @@ describe('LibraryAdaptor', () => {
   const IDS = [7, 17, 65, 1, 29, 71];
   const ARCHIVE_TYPE = 'CBZ';
   const RENAME_PAGES = true;
+  const TITLE = 'The Title';
 
   let adaptor: LibraryAdaptor;
   let store: Store<AppState>;
@@ -377,6 +379,30 @@ describe('LibraryAdaptor', () => {
           expect(response).toBeFalsy()
         );
       });
+    });
+  });
+
+  describe('setting the list of comics to display', () => {
+    beforeEach(() => {
+      adaptor.displayComics(COMICS, TITLE);
+    });
+
+    it('fires an action', () => {
+      expect(store.dispatch).toHaveBeenCalledWith(
+        new LibraryDisplayComics({ title: TITLE, comics: COMICS })
+      );
+    });
+
+    it('provides updates on the display title', () => {
+      adaptor.displayTitle$.subscribe(response =>
+        expect(response).toEqual(TITLE)
+      );
+    });
+
+    it('provides updates on the display comics', () => {
+      adaptor.displayComics$.subscribe(response =>
+        expect(response).toEqual(COMICS)
+      );
     });
   });
 });

--- a/comixed-frontend/src/app/library/adaptors/library.adaptor.ts
+++ b/comixed-frontend/src/app/library/adaptors/library.adaptor.ts
@@ -33,6 +33,7 @@ import {
   LibraryConsolidate,
   LibraryConvertComics,
   LibraryDeleteMultipleComics,
+  LibraryDisplayComics,
   LibraryGetUpdates,
   LibraryReset,
   LibraryStartRescan
@@ -62,6 +63,8 @@ export class LibraryAdaptor {
   private _maximum = 100;
   private _converting$ = new BehaviorSubject<boolean>(false);
   private _consolidating$ = new BehaviorSubject<boolean>(false);
+  private _displayTitle$ = new BehaviorSubject<string>('');
+  private _displayComics$ = new BehaviorSubject<Comic[]>(null);
 
   constructor(
     private store: Store<AppState>,
@@ -104,7 +107,9 @@ export class LibraryAdaptor {
         this._fetchingUpdate$.next(state.fetchingUpdates);
         if (!_.isEqual(this._comic$.getValue(), state.comics)) {
           this._comic$.next(state.comics);
-          this._publishers$.next(extractField(state.comics, 'publisher', 'imprint'));
+          this._publishers$.next(
+            extractField(state.comics, 'publisher', 'imprint')
+          );
           this._series$.next(extractField(state.comics, 'series'));
           this._characters$.next(extractField(state.comics, 'characters'));
           this._teams$.next(extractField(state.comics, 'teams'));
@@ -122,6 +127,12 @@ export class LibraryAdaptor {
         }
         if (state.consolidating !== this._consolidating$.getValue()) {
           this._consolidating$.next(state.consolidating);
+        }
+        if (state.displayTitle !== this._displayTitle$.getValue()) {
+          this._displayTitle$.next(state.displayTitle);
+        }
+        if (!_.isEqual(state.displayComics, this._displayComics$.getValue())) {
+          this._displayComics$.next(state.displayComics);
         }
       });
   }
@@ -258,5 +269,24 @@ export class LibraryAdaptor {
 
   get consolidating$(): Observable<boolean> {
     return this._consolidating$.asObservable();
+  }
+
+  displayComics(comics: Comic[], title: string) {
+    this.logger.debug(
+      'firing action to update displayed comics:',
+      comics,
+      title
+    );
+    this.store.dispatch(
+      new LibraryDisplayComics({ comics: comics, title: title })
+    );
+  }
+
+  get displayTitle$(): Observable<string> {
+    return this._displayTitle$.asObservable();
+  }
+
+  get displayComics$(): Observable<Comic[]> {
+    return this._displayComics$.asObservable();
   }
 }

--- a/comixed-frontend/src/app/library/components/comic-list-toolbar/comic-list-toolbar.component.spec.ts
+++ b/comixed-frontend/src/app/library/components/comic-list-toolbar/comic-list-toolbar.component.spec.ts
@@ -31,6 +31,7 @@ import {
   AppState,
   LibraryAdaptor,
   LibraryDisplayAdaptor,
+  ReadingListAdaptor,
   SelectionAdaptor
 } from 'app/library';
 import { LibraryEffects } from 'app/library/effects/library.effects';
@@ -103,6 +104,7 @@ describe('ComicListToolbarComponent', () => {
         SelectionAdaptor,
         LibraryAdaptor,
         LibraryDisplayAdaptor,
+        ReadingListAdaptor,
         ConfirmationService,
         MessageService
       ]

--- a/comixed-frontend/src/app/library/components/library-navigation-tree/library-navigation-tree.component.html
+++ b/comixed-frontend/src/app/library/components/library-navigation-tree/library-navigation-tree.component.html
@@ -2,5 +2,7 @@
   <h3>{{'library-navigation-tree.title'|translate}}</h3>
   <p-tree #navigationTree
           [value]='nodes'
-          filter='true'></p-tree>
+          selectionMode='single'
+          filter='true'
+          (onNodeSelect)='setDisplayComics($event.node)'></p-tree>
 </p-scrollPanel>

--- a/comixed-frontend/src/app/library/components/library-navigation-tree/library-navigation-tree.component.spec.ts
+++ b/comixed-frontend/src/app/library/components/library-navigation-tree/library-navigation-tree.component.spec.ts
@@ -23,7 +23,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MessageService, ScrollPanelModule, TreeModule } from 'primeng/primeng';
 import { LoggerModule } from '@angular-ru/logger';
 import { TranslateModule } from '@ngx-translate/core';
-import { LibraryAdaptor } from 'app/library';
+import { LibraryAdaptor, ReadingListAdaptor } from 'app/library';
 import {
   LIBRARY_FEATURE_KEY,
   reducer
@@ -54,7 +54,7 @@ describe('LibraryNavigationTreeComponent', () => {
         ScrollPanelModule
       ],
       declarations: [LibraryNavigationTreeComponent],
-      providers: [LibraryAdaptor, MessageService]
+      providers: [LibraryAdaptor, ReadingListAdaptor, MessageService]
     }).compileComponents();
 
     fixture = TestBed.createComponent(LibraryNavigationTreeComponent);

--- a/comixed-frontend/src/app/library/components/library-navigation-tree/library-navigation-tree.component.ts
+++ b/comixed-frontend/src/app/library/components/library-navigation-tree/library-navigation-tree.component.ts
@@ -70,6 +70,7 @@ export class LibraryNavigationTreeComponent implements OnInit, OnDestroy {
         // all comics
         label: '',
         icon: 'pi pi-folder',
+        selectable: true,
         children: [
           {
             // publishers
@@ -107,7 +108,8 @@ export class LibraryNavigationTreeComponent implements OnInit, OnDestroy {
               'library-navigation-tree.label.reading-lists',
               { count: 0 }
             ),
-            icon: 'pi pi-folder'
+            icon: 'pi pi-folder',
+            selectable: false
           } as TreeNode
         ]
       } as TreeNode
@@ -120,7 +122,12 @@ export class LibraryNavigationTreeComponent implements OnInit, OnDestroy {
             'library-navigation-tree.label.all-comics',
             { count: comics.length }
           ),
-          data: comics,
+          data: {
+            title: this.translateService.instant(
+              'library-navigation-tree.label.all-comics-title'
+            ),
+            comics: comics
+          } as NavigationDataPayload,
           children: this.nodes[0].children
         })
     );
@@ -167,6 +174,7 @@ export class LibraryNavigationTreeComponent implements OnInit, OnDestroy {
           count: collection.length
         }
       ),
+      selectable: false,
       children: collection.map(entry => {
         let entryName = entry.name;
         if (!entryName || entryName.length === 0) {
@@ -185,7 +193,7 @@ export class LibraryNavigationTreeComponent implements OnInit, OnDestroy {
           label: title,
           key: entry.name || 'unnammed',
           data: {
-            title: title,
+            title: entryName,
             comics: entry.comics
           } as NavigationDataPayload,
           icon: 'pi pi-list',
@@ -193,5 +201,12 @@ export class LibraryNavigationTreeComponent implements OnInit, OnDestroy {
         } as TreeNode;
       })
     } as TreeNode;
+  }
+
+  setDisplayComics(node: TreeNode) {
+    this.libraryAdaptor.displayComics(
+      (node.data as NavigationDataPayload).comics,
+      (node.data as NavigationDataPayload).title
+    );
   }
 }

--- a/comixed-frontend/src/app/library/components/library-navigation-tree/library-navigation-tree.component.ts
+++ b/comixed-frontend/src/app/library/components/library-navigation-tree/library-navigation-tree.component.ts
@@ -18,12 +18,13 @@
 
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { LoggerService } from '@angular-ru/logger';
-import { LibraryAdaptor } from 'app/library';
+import { LibraryAdaptor, ReadingListAdaptor } from 'app/library';
 import { TreeNode } from 'primeng/api';
 import { Subscription } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
 import { ComicCollectionEntry } from 'app/library/models/comic-collection-entry';
 import { NavigationDataPayload } from 'app/library/models/navigation-data-payload';
+import { ReadingList } from 'app/library/models/reading-list/reading-list';
 
 const PUBLISHER_NODE = 0;
 const SERIES_NODE = 1;
@@ -56,6 +57,7 @@ export class LibraryNavigationTreeComponent implements OnInit, OnDestroy {
   private teamSubscription: Subscription;
   private locationSubscription: Subscription;
   private storiesSubscription: Subscription;
+  private readingListSubscription: Subscription;
 
   nodes: TreeNode[];
   treeFilter = '';
@@ -63,7 +65,8 @@ export class LibraryNavigationTreeComponent implements OnInit, OnDestroy {
   constructor(
     private logger: LoggerService,
     private translateService: TranslateService,
-    private libraryAdaptor: LibraryAdaptor
+    private libraryAdaptor: LibraryAdaptor,
+    private readingListAdaptor: ReadingListAdaptor
   ) {
     this.nodes = [
       {
@@ -149,6 +152,9 @@ export class LibraryNavigationTreeComponent implements OnInit, OnDestroy {
     this.storiesSubscription = this.libraryAdaptor.stories$.subscribe(stories =>
       this.createChildNodes(STORY_NODE, stories)
     );
+    this.readingListSubscription = this.readingListAdaptor.reading_list$.subscribe(
+      lists => this.loadReadingLists(lists)
+    );
   }
 
   ngOnInit() {}
@@ -208,5 +214,33 @@ export class LibraryNavigationTreeComponent implements OnInit, OnDestroy {
       (node.data as NavigationDataPayload).comics,
       (node.data as NavigationDataPayload).title
     );
+  }
+
+  private loadReadingLists(lists: ReadingList[]) {
+    this.nodes[0].children[READING_LISTS] = {
+      label: this.translateService.instant(
+        'library-navigation-tree.label.reading-lists',
+        { count: lists.length }
+      ),
+      children: lists.map(list => {
+        return {
+          label: this.translateService.instant(
+            'library-navigation-tree.label.reading-list',
+            {
+              name: list.name,
+              count: list.entries.length
+            }
+          ),
+          key: list.name,
+          data: {
+            title: list.name,
+            comics: list.entries.map(entry => entry.comic)
+          } as NavigationDataPayload,
+          icon: 'pi pi-list',
+          expanded: false,
+          selectable: list.entries.length > 0
+        } as TreeNode;
+      })
+    } as TreeNode;
   }
 }

--- a/comixed-frontend/src/app/library/pages/library-page/library-page.component.html
+++ b/comixed-frontend/src/app/library/pages/library-page/library-page.component.html
@@ -1,3 +1,4 @@
+<h2 *ngIf='title'>{{'library-page.title'|translate:{title: title, count: comics.length} }}</h2>
 <app-comic-list *ngIf='comics'
                 [comics]='comics'
                 [selectedComics]='selectedComics'></app-comic-list>

--- a/comixed-frontend/src/app/library/pages/library-page/library-page.component.ts
+++ b/comixed-frontend/src/app/library/pages/library-page/library-page.component.ts
@@ -27,6 +27,7 @@ import { AuthenticationAdaptor, User } from 'app/user';
 import { Title } from '@angular/platform-browser';
 import { BreadcrumbAdaptor } from 'app/adaptors/breadcrumb.adaptor';
 import { Comic } from 'app/comics';
+import { filter } from 'rxjs/operators';
 
 @Component({
   selector: 'app-library-page',
@@ -37,12 +38,16 @@ export class LibraryPageComponent implements OnInit, OnDestroy {
   authSubscription: Subscription;
   user: User;
   comicsSubscription: Subscription;
+  displayComicsSubscription: Subscription;
+  displayTitleSubscription: Subscription;
   comics: Comic[] = [];
   selectedComicsSubscription: Subscription;
   selectedComics: Comic[] = [];
   processingCount = 0;
   importCountSubscription: Subscription;
   langChangeSubscription: Subscription;
+
+  title: string;
 
   constructor(
     private titleService: Title,
@@ -54,9 +59,7 @@ export class LibraryPageComponent implements OnInit, OnDestroy {
     private confirmationService: ConfirmationService,
     private translateService: TranslateService,
     private breadcrumbAdaptor: BreadcrumbAdaptor
-  ) {}
-
-  ngOnInit() {
+  ) {
     this.authSubscription = this.authenticationAdaptor.user$.subscribe(
       user => (this.user = user)
     );
@@ -68,6 +71,14 @@ export class LibraryPageComponent implements OnInit, OnDestroy {
         })
       );
     });
+    this.displayComicsSubscription = this.libraryAdaptor.displayComics$
+      .pipe(filter(comics => !!comics))
+      .subscribe(comics => {
+        this.comics = comics;
+      });
+    this.displayTitleSubscription = this.libraryAdaptor.displayTitle$
+      .pipe(filter(title => !!title && title.length > 0))
+      .subscribe(title => (this.title = title));
     this.selectedComicsSubscription = this.selectionAdaptor.comicSelection$.subscribe(
       selected_comics => (this.selectedComics = selected_comics)
     );
@@ -80,9 +91,13 @@ export class LibraryPageComponent implements OnInit, OnDestroy {
     this.loadTranslations();
   }
 
+  ngOnInit() {}
+
   ngOnDestroy() {
     this.authSubscription.unsubscribe();
     this.comicsSubscription.unsubscribe();
+    this.displayComicsSubscription.unsubscribe();
+    this.displayTitleSubscription.unsubscribe();
     this.selectedComicsSubscription.unsubscribe();
     this.importCountSubscription.unsubscribe();
   }

--- a/comixed-frontend/src/app/library/reducers/library.reducer.spec.ts
+++ b/comixed-frontend/src/app/library/reducers/library.reducer.spec.ts
@@ -32,6 +32,7 @@ import {
   LibraryConvertComicsFailed,
   LibraryDeleteMultipleComics,
   LibraryDeleteMultipleComicsFailed,
+  LibraryDisplayComics,
   LibraryGetUpdates,
   LibraryGetUpdatesFailed,
   LibraryMultipleComicsDeleted,
@@ -56,6 +57,7 @@ describe('Library Reducer', () => {
   const ASCENDING = true;
   const COMIC_COUNT = 2372;
   const LATEST_UPDATED_DATE = new Date();
+  const TITLE = 'The Display Title';
 
   let state: LibraryState;
 
@@ -74,6 +76,14 @@ describe('Library Reducer', () => {
 
     it('has an empty array of comics', () => {
       expect(state.comics).toEqual([]);
+    });
+
+    it('has no display comics', () => {
+      expect(state.displayComics).toBeNull();
+    });
+
+    it('has no display title', () => {
+      expect(state.displayTitle).toEqual('');
     });
 
     it('has a zero last comic id', () => {
@@ -386,6 +396,23 @@ describe('Library Reducer', () => {
 
     it('clears the consolidating library flag', () => {
       expect(state.consolidating).toBeFalsy();
+    });
+  });
+
+  describe('setting the comics to display', () => {
+    beforeEach(() => {
+      state = reducer(
+        { ...state, displayComics: null },
+        new LibraryDisplayComics({ title: TITLE, comics: COMICS })
+      );
+    });
+
+    it('updates the set of display comics', () => {
+      expect(state.displayComics).toEqual(COMICS);
+    });
+
+    it('updates the display title', () => {
+      expect(state.displayTitle).toEqual(TITLE);
     });
   });
 });

--- a/comixed-frontend/src/app/library/reducers/library.reducer.ts
+++ b/comixed-frontend/src/app/library/reducers/library.reducer.ts
@@ -17,7 +17,7 @@
  */
 
 import { LibraryActions, LibraryActionTypes } from '../actions/library.actions';
-import {deleteComics, mergeComics} from 'app/library/utility.functions';
+import { deleteComics, mergeComics } from 'app/library/utility.functions';
 import { Comic } from 'app/comics';
 import { LastReadDate } from 'app/library/models/last-read-date';
 
@@ -26,6 +26,8 @@ export const LIBRARY_FEATURE_KEY = 'library_state';
 export interface LibraryState {
   fetchingUpdates: boolean;
   comics: Comic[];
+  displayComics: Comic[];
+  displayTitle: string;
   lastComicId: number;
   moreUpdates: boolean;
   updatedIds: number[];
@@ -42,6 +44,8 @@ export interface LibraryState {
 export const initialState: LibraryState = {
   fetchingUpdates: false,
   comics: [],
+  displayComics: null,
+  displayTitle: '',
   lastComicId: 0,
   moreUpdates: false,
   updatedIds: [],
@@ -125,6 +129,13 @@ export function reducer(
 
     case LibraryActionTypes.ConsolidateFailed:
       return { ...state, consolidating: false };
+
+    case LibraryActionTypes.DisplayComics:
+      return {
+        ...state,
+        displayComics: action.payload.comics,
+        displayTitle: action.payload.title
+      };
 
     default:
       return state;

--- a/comixed-frontend/src/assets/i18n/library-en.json
+++ b/comixed-frontend/src/assets/i18n/library-en.json
@@ -118,7 +118,7 @@
     }
   },
   "library-page": {
-    "title": "ComiXed: Library - {count, plural, =1{One Comic} other{# Comics}}"
+    "title": "ComiXed: {title} - {count, plural, =1{One Comic} other{# Comics}}"
   },
   "reading-lists-page": {
     "title": "ComiXed: Reading Lists - {count, plural, =1{One List} other{# Lists}}"
@@ -458,6 +458,7 @@
     "label": {
       "unnamed-entry": "Unnamed",
       "all-comics": "All Comics ({count})",
+      "all-comics-title": "All Comics",
       "publishers": "Publishers ({count})",
       "series": "Series ({count})",
       "characters": "Characters ({count})",

--- a/comixed-frontend/src/assets/i18n/library-en.json
+++ b/comixed-frontend/src/assets/i18n/library-en.json
@@ -466,6 +466,7 @@
       "locations": "Locations ({count})",
       "stories": "Stories ({count})",
       "reading-lists": "Reading Lists ({count})",
+      "reading-list": "{name} ({count})",
       "leaf-entry": "{name} ({count})"
     }
   }


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Displays all comics by default. Shows only the selected comics after the user clicks a node in the navigation tree.