### PR TITLE
[Issue #248] Bump WebP-ImageIO to v0.1.2.

### DIFF
--- a/comixed-library/pom.xml
+++ b/comixed-library/pom.xml
@@ -71,9 +71,9 @@
       <artifactId>commons-codec</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.sejda.webp-imageio</groupId>
-      <artifactId>webp-imageio-sejda</artifactId>
-      <version>0.1.0</version>
+      <groupId>org.sejda.imageio</groupId>
+      <artifactId>webp-imageio</artifactId>
+      <version>0.1.2</version>
     </dependency>
     <dependency>
       <groupId>com.github.springtestdbunit</groupId>


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Bumped the dependency to v0.1.2.