### PR TITLE
[Issue #282] Switch reading lists to using sets.

### DIFF
--- a/comixed-library/src/main/java/org/comixed/model/comic/Comic.java
+++ b/comixed-library/src/main/java/org/comixed/model/comic/Comic.java
@@ -283,7 +283,7 @@ public class Comic {
   @ManyToMany(mappedBy = "comics", cascade = CascadeType.ALL)
   @JsonProperty("readingLists")
   @JsonView(View.ComicList.class)
-  private List<ReadingList> readingLists = new ArrayList<>();
+  private Set<ReadingList> readingLists = new HashSet<>();
 
   @OneToMany(mappedBy = "comic", cascade = CascadeType.REMOVE, orphanRemoval = true)
   private List<Task> tasks = new ArrayList<>();
@@ -1100,7 +1100,7 @@ public class Comic {
     return (this.duplicateCount != null) ? (this.duplicateCount - 1) : 0;
   }
 
-  public List<ReadingList> getReadingLists() {
+  public Set<ReadingList> getReadingLists() {
     return this.readingLists;
   }
 

--- a/comixed-library/src/main/java/org/comixed/model/library/ReadingList.java
+++ b/comixed-library/src/main/java/org/comixed/model/library/ReadingList.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import javax.persistence.*;
 import org.comixed.model.comic.Comic;
 import org.comixed.model.user.ComiXedUser;
@@ -114,5 +115,22 @@ public class ReadingList {
 
   public void removeComic(Comic comic) {
     this.comics.remove(comic);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ReadingList that = (ReadingList) o;
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(summary, that.summary)
+        && Objects.equals(owner, that.owner)
+        && Objects.equals(lastUpdated, that.lastUpdated);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, summary, owner, lastUpdated);
   }
 }

--- a/comixed-services/src/test/java/org/comixed/service/library/ReadingListServiceTest.java
+++ b/comixed-services/src/test/java/org/comixed/service/library/ReadingListServiceTest.java
@@ -225,7 +225,7 @@ public class ReadingListServiceTest {
 
   @Test
   public void getReadingListsForComics() {
-    List<ReadingList> comicReadingList = new ArrayList<>();
+    Set<ReadingList> comicReadingList = new HashSet<>();
 
     for (int index = 0; index < 25; index++) {
       comicList.add(comic);
@@ -239,8 +239,6 @@ public class ReadingListServiceTest {
         .thenReturn(readingListList);
 
     readingListService.getReadingListsForComics(TEST_USER_EMAIL, comicList);
-
-    assertEquals(comicList.size(), comicReadingList.size());
 
     Mockito.verify(readingListRepository, Mockito.times(comicList.size()))
         .findByOwnerAndComic(TEST_USER_EMAIL, comic);

--- a/comixed-tasks/src/main/java/org/comixed/task/model/DeleteComicWorkerTask.java
+++ b/comixed-tasks/src/main/java/org/comixed/task/model/DeleteComicWorkerTask.java
@@ -54,11 +54,15 @@ public class DeleteComicWorkerTask extends AbstractWorkerTask implements WorkerT
           comic.getReadingLists().size(),
           comic.getReadingLists().size() == 1 ? "" : "s");
       while (!comic.getReadingLists().isEmpty()) {
-        ReadingList readingList = comic.getReadingLists().get(0);
-        readingList.removeComic(comic);
-        comic.getReadingLists().remove(0);
-        this.log.debug("Updating reading list: {}", readingList.getName());
-        this.readingListRepository.save(readingList);
+        ReadingList[] readingLists =
+            comic.getReadingLists().toArray(new ReadingList[comic.getReadingLists().size()]);
+        for (int index = 0; index < readingLists.length; index++) {
+          ReadingList readingList = readingLists[index];
+          readingList.removeComic(comic);
+          comic.getReadingLists().remove(readingList);
+          this.log.debug("Updating reading list: {}", readingList.getName());
+          this.readingListRepository.save(readingList);
+        }
       }
     }
 

--- a/comixed-tasks/src/test/java/org/comixed/task/model/DeleteComicWorkerTaskTest.java
+++ b/comixed-tasks/src/test/java/org/comixed/task/model/DeleteComicWorkerTaskTest.java
@@ -23,7 +23,9 @@ import static junit.framework.TestCase.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.comixed.model.comic.Comic;
 import org.comixed.model.library.ReadingList;
@@ -64,8 +66,14 @@ public class DeleteComicWorkerTaskTest {
 
   @Test
   public void testStartTask() throws WorkerTaskException {
-    List<ReadingList> readingLists = new ArrayList<>();
-    for (int index = 0; index < TEST_READING_LIST_COUNT; index++) readingLists.add(readingList);
+    Set<ReadingList> readingLists = new HashSet<>();
+    for (int index = 0; index < TEST_READING_LIST_COUNT; index++) {
+      ReadingList list = new ReadingList();
+      list.setName("List" + index);
+      list.setSummary("List" + index);
+      readingLists.add(list);
+      readingList.getComics().add(comic);
+    }
     Mockito.when(comic.getReadingLists()).thenReturn(readingLists);
 
     workerTask.setComic(comic);
@@ -75,8 +83,8 @@ public class DeleteComicWorkerTaskTest {
 
     assertTrue(readingLists.isEmpty());
 
-    Mockito.verify(readingList, Mockito.times(TEST_READING_LIST_COUNT)).removeComic(comic);
-    Mockito.verify(readingListRepository, Mockito.times(TEST_READING_LIST_COUNT)).save(readingList);
+    Mockito.verify(readingListRepository, Mockito.times(TEST_READING_LIST_COUNT))
+        .save(Mockito.any(ReadingList.class));
     Mockito.verify(comic, Mockito.times(1)).setDateDeleted(Mockito.any());
     Mockito.verify(comic, Mockito.times(1)).setDateLastUpdated(Mockito.any());
     Mockito.verify(comicRepository, Mockito.times(1)).save(comic);


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Fixed loading reading lists for comics from the database so it uses a Set instead of a List.