### PR TITLE
Changed the main menu component to Menu. [#297]

### DIFF
--- a/comixed-frontend/src/app/app.component.html
+++ b/comixed-frontend/src/app/app.component.html
@@ -1,31 +1,31 @@
-<app-main-menu #mainmenu></app-main-menu>
 <p-breadcrumb [model]='breadcrumbs'
               [home]='home'></p-breadcrumb>
+<app-main-menu #mainmenu></app-main-menu>
 <p-toast position='top-right'
          styleClass='cx-alerts'></p-toast>
 <p-confirmDialog></p-confirmDialog>
 <app-login [show_login_dialog]='showLogin'></app-login>
 <div [style]='{top:0,bottom:0,width:"100%"}'
      class='ui-g'>
-    <div class='ui-g-12 ui-sm-12'>
-        <router-outlet></router-outlet>
-    </div>
-    <div id='comixed-footer'
-         class='ui-g'>
-        <div class='ui-g-4'>
-            <div *ngIf='user'
-                 [innerHTML]='"app-component.library-counts"|translate:{
+  <div class='ui-g-12 ui-sm-12'>
+    <router-outlet></router-outlet>
+  </div>
+  <div id='comixed-footer'
+       class='ui-g'>
+    <div class='ui-g-4'>
+      <div *ngIf='user'
+           [innerHTML]='"app-component.library-counts"|translate:{
                 comic_count: comicCount,
                 read_count: 0,
                 import_count: processingCount
               }'
-            >
-            </div>
-        </div>
-        <div class='ui-g-4'></div>
-        <div class='ui-g-4'>
-            <div [innerHTML]='"app-component.copyright"|translate:{ years: "2017-2019" }'>
-            </div>
-        </div>
+      >
+      </div>
     </div>
+    <div class='ui-g-4'></div>
+    <div class='ui-g-4'>
+      <div [innerHTML]='"app-component.copyright"|translate:{ years: "2017-2019" }'>
+      </div>
+    </div>
+  </div>
 </div>

--- a/comixed-frontend/src/app/app.component.spec.ts
+++ b/comixed-frontend/src/app/app.component.spec.ts
@@ -46,7 +46,7 @@ import { MenubarModule } from 'primeng/menubar';
 import {
   BreadcrumbModule,
   ConfirmDialogModule,
-  TieredMenuModule
+  MenuModule
 } from 'primeng/primeng';
 import { ToastModule } from 'primeng/toast';
 
@@ -87,7 +87,7 @@ describe('AppComponent', () => {
         DialogModule,
         ConfirmDialogModule,
         BreadcrumbModule,
-        TieredMenuModule
+        MenuModule
       ],
       declarations: [AppComponent, LoginComponent, MainMenuComponent],
       providers: [

--- a/comixed-frontend/src/app/app.component.ts
+++ b/comixed-frontend/src/app/app.component.ts
@@ -46,7 +46,7 @@ export class AppComponent implements OnInit {
   fetchingUpdateSubscription: Subscription;
   breadcrumbs = [];
   home = {
-    icon: 'fa fas fa-bars',
+    icon: 'fa fa-fw fas fa-bars',
     command: (event: any) => this.mainmenu.toggle(event)
   } as MenuItem;
 

--- a/comixed-frontend/src/app/app.module.ts
+++ b/comixed-frontend/src/app/app.module.ts
@@ -68,7 +68,7 @@ import { PickListModule } from 'primeng/picklist';
 import {
   BreadcrumbModule,
   ContextMenuModule,
-  TieredMenuModule
+  MenuModule
 } from 'primeng/primeng';
 import { ProgressBarModule } from 'primeng/progressbar';
 import { ScrollPanelModule } from 'primeng/scrollpanel';
@@ -143,7 +143,6 @@ import { LoggerModule } from '@angular-ru/logger';
     CommonModule,
     FormsModule,
     ReactiveFormsModule,
-    TieredMenuModule,
     TranslateModule.forRoot({
       loader: {
         provide: TranslateLoader,
@@ -156,7 +155,8 @@ import { LoggerModule } from '@angular-ru/logger';
       }
     }),
     LoggerModule.forRoot(),
-    BreadcrumbModule
+    BreadcrumbModule,
+    MenuModule
   ],
   providers: [
     BreadcrumbAdaptor,

--- a/comixed-frontend/src/app/components/main-menu/main-menu.component.html
+++ b/comixed-frontend/src/app/components/main-menu/main-menu.component.html
@@ -1,3 +1,3 @@
-<p-tieredMenu #menu
-              [popup]='true'
-              [model]='items'></p-tieredMenu>
+<p-menu #menu
+        [model]='items'
+        [popup]='true'></p-menu>

--- a/comixed-frontend/src/app/components/main-menu/main-menu.component.spec.ts
+++ b/comixed-frontend/src/app/components/main-menu/main-menu.component.spec.ts
@@ -22,11 +22,7 @@ import { MainMenuComponent } from './main-menu.component';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { Store, StoreModule } from '@ngrx/store';
 import { EffectsModule } from '@ngrx/effects';
-import {
-  ButtonModule,
-  MessageService,
-  TieredMenuModule
-} from 'primeng/primeng';
+import { ButtonModule, MenuModule, MessageService } from 'primeng/primeng';
 import { UserModule } from 'app/user/user.module';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -53,7 +49,7 @@ describe('MainMenuComponent', () => {
         LoggerModule.forRoot(),
         StoreModule.forRoot({}),
         EffectsModule.forRoot([]),
-        TieredMenuModule,
+        MenuModule,
         ButtonModule
       ],
       declarations: [MainMenuComponent],

--- a/comixed-frontend/src/app/components/main-menu/main-menu.component.ts
+++ b/comixed-frontend/src/app/components/main-menu/main-menu.component.ts
@@ -20,7 +20,7 @@ import { Component, OnInit, ViewChild } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { MenuItem } from 'primeng/api';
 import { AuthenticationAdaptor, User } from 'app/user';
-import { TieredMenu } from 'primeng/primeng';
+import { Menu } from 'primeng/primeng';
 import { LoggerLevel, LoggerService } from '@angular-ru/logger';
 
 @Component({
@@ -29,8 +29,8 @@ import { LoggerLevel, LoggerService } from '@angular-ru/logger';
   styleUrls: ['./main-menu.component.scss']
 })
 export class MainMenuComponent implements OnInit {
-  @ViewChild(TieredMenu, { static: false })
-  menu: TieredMenu;
+  @ViewChild(Menu, { static: false })
+  menu: Menu;
 
   items: MenuItem[];
   debugging = false;
@@ -59,7 +59,6 @@ export class MainMenuComponent implements OnInit {
       {
         label: this.translateService.instant('main-menu.item.library.root'),
         icon: 'fa fa-fw fa-book',
-        visible: this.authenticationAdaptor.authenticated,
         items: [
           {
             label: this.translateService.instant(
@@ -80,6 +79,14 @@ export class MainMenuComponent implements OnInit {
             icon: 'fa fw fas fa-clone',
             routerLink: ['/comics/duplicates'],
             visible: this.authenticationAdaptor.authenticated
+          },
+          {
+            label: this.translateService.instant(
+              'main-menu.item.account.login'
+            ),
+            icon: 'fa fa-fw fa-sign-in-alt',
+            command: () => this.authenticationAdaptor.startLogin(),
+            visible: !this.authenticationAdaptor.authenticated
           }
         ]
       },
@@ -135,10 +142,27 @@ export class MainMenuComponent implements OnInit {
         visible: this.authenticationAdaptor.authenticated
       },
       {
-        label: this.translateService.instant('main-menu.item.account'),
+        label: this.translateService.instant('main-menu.item.account.root'),
         icon: 'fa fa-fw fa-user',
-        routerLink: ['/account'],
-        visible: this.authenticationAdaptor.authenticated
+        visible: this.authenticationAdaptor.authenticated,
+        items: [
+          {
+            label: this.translateService.instant(
+              'main-menu.item.account.details'
+            ),
+            routerLink: ['/account'],
+            icon: 'fa fa-fw fa-user',
+            visible: this.authenticationAdaptor.authenticated
+          },
+          {
+            label: this.translateService.instant(
+              'main-menu.item.account.logout'
+            ),
+            icon: 'fa fa-fw fa-sign-in-alt',
+            command: () => this.authenticationAdaptor.startLogout(),
+            visible: this.authenticationAdaptor.authenticated
+          }
+        ]
       },
       {
         separator: true,
@@ -172,18 +196,6 @@ export class MainMenuComponent implements OnInit {
             command: () => this.toggleDebugging(false)
           }
         ]
-      },
-      {
-        label: this.translateService.instant('main-menu.item.login'),
-        icon: 'fa fa-fw fa-sign-in-alt',
-        command: () => this.authenticationAdaptor.startLogin(),
-        visible: !this.authenticationAdaptor.authenticated
-      },
-      {
-        label: this.translateService.instant('main-menu.item.logout'),
-        icon: 'fa fa-fw fa-sign-in-alt',
-        command: () => this.authenticationAdaptor.startLogout(),
-        visible: this.authenticationAdaptor.authenticated
       }
     ];
   }

--- a/comixed-frontend/src/assets/i18n/common-en.json
+++ b/comixed-frontend/src/assets/i18n/common-en.json
@@ -1,9 +1,7 @@
 {
   "main-menu": {
     "item": {
-      "login": "Login",
       "account": "Account",
-      "logout": "Logout",
       "library": {
         "root": "Library",
         "comics": "Comics",
@@ -18,6 +16,12 @@
         "teams": "Teams",
         "locations": "Locations",
         "story-arcs": "Story Arcs"
+      },
+      "account": {
+        "root": "Account",
+        "login": "Login",
+        "logout": "Logout",
+        "details": "Details"
       },
       "admin": {
         "root": "Admin",


### PR DESCRIPTION
The previous widget would cover the menu poup button, so needed
to be replaced.

## Status
**READY**

## Migrations
NO

## Description
Replaced the TieredMenu widget with a simpler Menu. Menus are no longer tiered, but they also no longer hide the navigation bar.