### PR TITLE
Allow Imprint to replace Publisher in breadcrumb trail and on comic details page.

### DIFF
--- a/comixed-frontend/src/app/comics/comics.constants.ts
+++ b/comixed-frontend/src/app/comics/comics.constants.ts
@@ -41,4 +41,4 @@ export const GET_ISSUE_URL = `${API_ROOT_URL}/scraping/volumes/\${volume}/issues
 
 export const LOAD_METADATA_URL = `${API_ROOT_URL}/scraping/comics/\${comicId}/issue/\${issueId}`;
 
-export const PUBLISHER_IMPRINT_FORMAT = `\${publisher} (\${imprint})`;
+export const PUBLISHER_IMPRINT_FORMAT = `\${imprint} (\${publisher})`;

--- a/comixed-frontend/src/app/comics/components/comic-overview/comic-overview.component.html
+++ b/comixed-frontend/src/app/comics/components/comic-overview/comic-overview.component.html
@@ -63,7 +63,7 @@
                            (onActivate)='startEditing()'
                            [active]='editing'>
           <span pInplaceDisplay>
-          <a [routerLink]='["/comics", "publishers", comic.publisher||"undefined"]'>{{comic|publisher}}</a>
+          <a [routerLink]='["/comics", "publishers", comic.imprint||comic.publisher||"undefined"]'>{{comic|publisher}}</a>
             <span class='pi pi-pencil'></span>
           </span>
                   <span pInplaceContent>

--- a/comixed-frontend/src/app/comics/pages/comic-details-page/comic-details-page.component.ts
+++ b/comixed-frontend/src/app/comics/pages/comic-details-page/comic-details-page.component.ts
@@ -208,7 +208,15 @@ export class ComicDetailsPageComponent implements OnInit, OnDestroy {
       }
     ];
 
-    if (this.comic.publisher) {
+    if (this.comic.imprint) {
+      entries.push({
+        label: this.translateService.instant(
+          'breadcrumb.entry.comic-details-page.publisher',
+          { name: this.comic.imprint }
+        ),
+        routerLink: ['/comics/publishers', this.comic.imprint]
+      });
+    } else if (this.comic.publisher) {
       entries.push({
         label: this.translateService.instant(
           'breadcrumb.entry.comic-details-page.publisher',


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Fixed the two mentioned locations where the publisher was shown when an imprint was defined.