### PR TITLE
Changed the order when retrieving next and previous comics [#329]

### DIFF
--- a/comixed-library/src/main/java/org/comixed/repositories/comic/ComicRepository.java
+++ b/comixed-library/src/main/java/org/comixed/repositories/comic/ComicRepository.java
@@ -88,14 +88,14 @@ public interface ComicRepository extends JpaRepository<Comic, Long> {
   Comic getById(@Param("id") long id);
 
   @Query(
-      "SELECT c FROM Comic c WHERE c.series = :series AND c.volume = :volume AND c.issueNumber <> :issueNumber AND c.coverDate <= (SELECT DISTINCT d.coverDate FROM Comic d WHERE d.series = :series AND d.volume = :volume AND d.issueNumber = :issueNumber) ORDER BY c.issueNumber,c.coverDate DESC")
+      "SELECT c FROM Comic c WHERE c.series = :series AND c.volume = :volume AND c.issueNumber <> :issueNumber AND c.coverDate <= (SELECT DISTINCT d.coverDate FROM Comic d WHERE d.series = :series AND d.volume = :volume AND d.issueNumber = :issueNumber) ORDER BY c.coverDate,c.issueNumber DESC")
   List<Comic> findIssuesBeforeComic(
       @Param("series") String series,
       @Param("volume") String volume,
       @Param("issueNumber") String issueNumber);
 
   @Query(
-      "SELECT c FROM Comic c WHERE c.series = :series AND c.volume = :volume AND c.issueNumber <> :issueNumber AND c.coverDate >= (SELECT DISTINCT d.coverDate FROM Comic d WHERE d.series = :series AND d.volume = :volume AND d.issueNumber = :issueNumber) ORDER BY c.issueNumber,c.coverDate ASC")
+      "SELECT c FROM Comic c WHERE c.series = :series AND c.volume = :volume AND c.issueNumber <> :issueNumber AND c.coverDate >= (SELECT DISTINCT d.coverDate FROM Comic d WHERE d.series = :series AND d.volume = :volume AND d.issueNumber = :issueNumber) ORDER BY c.coverDate,c.issueNumber ASC")
   List<Comic> findIssuesAfterComic(
       @Param("series") String series,
       @Param("volume") String volume,


### PR DESCRIPTION
Sorting them first by cover date and then by issue number.

## Status
**READY**

## Migrations
NO

## Description
Swapped the ordering of results to put cover date before issue number.
