### PR TITLE
Users can view the list of files in a comic archive

### DIFF
--- a/comixed-frontend/src/app/comics/comics.module.ts
+++ b/comixed-frontend/src/app/comics/comics.module.ts
@@ -61,6 +61,7 @@ import { PanelModule } from 'primeng/panel';
 import {
   AutoCompleteModule,
   ContextMenuModule,
+  DialogModule,
   InputTextModule,
   ProgressBarModule,
   ProgressSpinnerModule,

--- a/comixed-frontend/src/app/comics/comics.module.ts
+++ b/comixed-frontend/src/app/comics/comics.module.ts
@@ -64,6 +64,7 @@ import {
   InputTextModule,
   ProgressBarModule,
   ProgressSpinnerModule,
+  ScrollPanelModule,
   SplitButtonModule,
   TabViewModule,
   ToolbarModule,
@@ -76,6 +77,7 @@ import * as fromScraping from './reducers/scraping.reducer';
 import { PublisherThumbnailUrlPipe } from './pipes/publisher-thumbnail-url.pipe';
 import { PublisherPipe } from './pipes/publisher.pipe';
 import { SeriesCollectionNamePipe } from './pipes/series-collection-name.pipe';
+import { FileEntryListComponent } from './components/file-entry-list/file-entry-list.component';
 
 @NgModule({
   declarations: [
@@ -96,7 +98,8 @@ import { SeriesCollectionNamePipe } from './pipes/series-collection-name.pipe';
     ScrapingIssueCoverUrlPipe,
     PublisherThumbnailUrlPipe,
     PublisherPipe,
-    SeriesCollectionNamePipe
+    SeriesCollectionNamePipe,
+    FileEntryListComponent
   ],
   imports: [
     UserModule,
@@ -129,7 +132,9 @@ import { SeriesCollectionNamePipe } from './pipes/series-collection-name.pipe';
     InputTextModule,
     ToolbarModule,
     ContextMenuModule,
-    AutoCompleteModule
+    AutoCompleteModule,
+    DialogModule,
+    ScrollPanelModule
   ],
   exports: [
     CommonModule,

--- a/comixed-frontend/src/app/comics/components/comic-overview/comic-overview.component.html
+++ b/comixed-frontend/src/app/comics/components/comic-overview/comic-overview.component.html
@@ -1,3 +1,13 @@
+<p-dialog [visible]='showFileEntriesDialog'
+          [modal]='true'
+          [header]='"comic-overview.show-file-entries.title"|translate'
+          [resizable]='false'
+          [draggable]='false'
+          [maximizable]='true'
+          [closable]='false'>
+  <app-file-entry-list [entries]='comic.fileEntries'
+                       (close)='toggleFileEntriesDialog(false)'></app-file-entry-list>
+</p-dialog>
 <p-toolbar>
   <div *ngIf='is_admin'
        class='ui-toolbar-group-left'>
@@ -176,6 +186,14 @@
         <strong>{{"comic-overview.label.page-count"|translate}}</strong>
       </div>
       <div class='ui-g-12'>{{comic.pageCount}}</div>
+      <div class='ui-g-12'>
+        <strong>{{"comic-overview.label.file-entry-count"|translate}}</strong>
+      </div>
+      <div class='ui-g-12'>{{comic.fileEntries.length}}
+        <span *ngIf='!!comic.fileEntries && comic.fileEntries.length > 0'
+              (click)='toggleFileEntriesDialog(true)'
+              class='fa fa-fw fa-eye'></span>
+      </div>
       <div class='ui-g-12'>
         <strong>{{"comic-overview.label.comicvine-details-link"|translate}}</strong>
       </div>

--- a/comixed-frontend/src/app/comics/components/comic-overview/comic-overview.component.scss
+++ b/comixed-frontend/src/app/comics/components/comic-overview/comic-overview.component.scss
@@ -6,3 +6,8 @@
   background-color: $cx-information-panel-background-color;
   color: $cx-information-panel-text-primary-color;
 }
+
+:host ::ng-deep .ui-scrollpanel {
+  width: 50vw;
+  height: 50vh;
+}

--- a/comixed-frontend/src/app/comics/components/comic-overview/comic-overview.component.spec.ts
+++ b/comixed-frontend/src/app/comics/components/comic-overview/comic-overview.component.spec.ts
@@ -34,6 +34,8 @@ import { DropdownModule } from 'primeng/dropdown';
 import { InplaceModule } from 'primeng/inplace';
 import {
   AutoCompleteModule,
+  DialogModule,
+  ScrollPanelModule,
   ToolbarModule,
   TooltipModule
 } from 'primeng/primeng';
@@ -44,6 +46,8 @@ import { PublisherThumbnailUrlPipe } from 'app/comics/pipes/publisher-thumbnail-
 import { PublisherPipe } from 'app/comics/pipes/publisher.pipe';
 import { CollectionType } from 'app/library/models/collection-type.enum';
 import { SeriesCollectionNamePipe } from 'app/comics/pipes/series-collection-name.pipe';
+import { FileEntryListComponent } from 'app/comics/components/file-entry-list/file-entry-list.component';
+import { TableModule } from 'primeng/table';
 
 describe('ComicOverviewComponent', () => {
   const COMIC = Object.assign({}, COMIC_1);
@@ -73,10 +77,14 @@ describe('ComicOverviewComponent', () => {
         DropdownModule,
         TooltipModule,
         AutoCompleteModule,
-        ToolbarModule
+        ToolbarModule,
+        DialogModule,
+        TableModule,
+        ScrollPanelModule
       ],
       declarations: [
         ComicOverviewComponent,
+        FileEntryListComponent,
         PublisherThumbnailUrlPipe,
         PublisherPipe,
         SeriesCollectionNamePipe

--- a/comixed-frontend/src/app/comics/components/comic-overview/comic-overview.component.ts
+++ b/comixed-frontend/src/app/comics/components/comic-overview/comic-overview.component.ts
@@ -48,6 +48,7 @@ export class ComicOverviewComponent implements OnInit, OnDestroy {
   seriesSubscription: Subscription;
   seriesNames: string[] = [];
   seriesNameOptions: string[] = [];
+  showFileEntriesDialog = false;
 
   constructor(
     private logger: LoggerService,
@@ -190,5 +191,10 @@ export class ComicOverviewComponent implements OnInit, OnDestroy {
     this.seriesNameOptions = this.seriesNames.filter(name =>
       name.toLowerCase().startsWith(nameEntered.toLowerCase())
     );
+  }
+
+  toggleFileEntriesDialog(show: boolean) {
+    this.logger.debug(`${show ? 'showing' : 'hiding'} file entries dialog`);
+    this.showFileEntriesDialog = show;
   }
 }

--- a/comixed-frontend/src/app/comics/components/file-entry-list/file-entry-list.component.html
+++ b/comixed-frontend/src/app/comics/components/file-entry-list/file-entry-list.component.html
@@ -1,0 +1,40 @@
+<div class='ui-g'>
+  <div class='ui-g-12 ui-fluid'>
+    <p-scrollPanel>
+      <p-table [value]='entries'>
+        <ng-template pTemplate='colgroup'>
+          <colgroup>
+            <col class='cx-table-column-smallest'>
+            <col class='cx-table-column-large'>
+            <col class='cx-table-column-medium'>
+            <col class='cx-table-column-medium'>
+          </colgroup>
+        </ng-template>
+        <ng-template pTemplate='header'>
+          <tr>
+            <th id='cx-file-entry-number-header'>{{'file-entry-list.table.header.file-number'|translate}}</th>
+            <th id='cx-file-entry-name-header'>{{'file-entry-list.table.header.file-name'|translate}}</th>
+            <th id='cx-file-entry-size-header'>{{'file-entry-list.table.header.file-size'|translate}}</th>
+            <th id='cx-file-entry-type-header'>{{'file-entry-list.table.header.file-type'|translate}}</th>
+          </tr>
+        </ng-template>
+        <ng-template pTemplate='body'
+                     let-entry>
+          <tr>
+            <td class='cx-table-column-align-center'>{{entry.fileNumber}}</td>
+            <td>{{entry.fileName}}</td>
+            <td>{{"file-entry-list.table.column.file-size"|translate:{size: entry.fileSize|number} }}</td>
+            <td class='cx-table-column-align-center'>{{entry.fileType}}</td>
+          </tr>
+        </ng-template>
+      </p-table>
+    </p-scrollPanel>
+  </div>
+  <div class='ui-g-12 ui-'>
+    <button pButton
+            type='button'
+            icon='fa fa-fw fa-window-close'
+            (click)='close.emit(true)'
+            [label]='"button.close"|translate'></button>
+  </div>
+</div>

--- a/comixed-frontend/src/app/comics/components/file-entry-list/file-entry-list.component.spec.ts
+++ b/comixed-frontend/src/app/comics/components/file-entry-list/file-entry-list.component.spec.ts
@@ -1,0 +1,51 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2019, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FileEntryListComponent } from './file-entry-list.component';
+import { TableModule } from 'primeng/table';
+import { ButtonModule, ScrollPanelModule } from 'primeng/primeng';
+import { TranslateModule } from '@ngx-translate/core';
+
+describe('FileEntryListComponent', () => {
+  let component: FileEntryListComponent;
+  let fixture: ComponentFixture<FileEntryListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        TranslateModule.forRoot(),
+        TableModule,
+        ScrollPanelModule,
+        ButtonModule
+      ],
+      declarations: [FileEntryListComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FileEntryListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/comixed-frontend/src/app/comics/components/file-entry-list/file-entry-list.component.ts
+++ b/comixed-frontend/src/app/comics/components/file-entry-list/file-entry-list.component.ts
@@ -1,0 +1,34 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2019, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { ComicFileEntry } from 'app/comics/models/comic-file-entry';
+
+@Component({
+  selector: 'app-file-entry-list',
+  templateUrl: './file-entry-list.component.html',
+  styleUrls: ['./file-entry-list.component.scss']
+})
+export class FileEntryListComponent implements OnInit {
+  @Input() entries: ComicFileEntry[];
+  @Output() close = new EventEmitter<boolean>();
+
+  constructor() {}
+
+  ngOnInit() {}
+}

--- a/comixed-frontend/src/app/comics/models/comic-file-entry.ts
+++ b/comixed-frontend/src/app/comics/models/comic-file-entry.ts
@@ -1,0 +1,24 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2019, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+export interface ComicFileEntry {
+  fileNumber: number;
+  fileName: string;
+  fileSize: number;
+  fileType: string;
+}

--- a/comixed-frontend/src/app/comics/models/comic.fixtures.ts
+++ b/comixed-frontend/src/app/comics/models/comic.fixtures.ts
@@ -64,6 +64,7 @@ export const COMIC_1: Comic = {
   nextIssueId: null,
   previousIssueId: null,
   fileDetails: FILE_DETAILS_1,
+  fileEntries: [],
   readingLists: []
 };
 
@@ -146,6 +147,7 @@ export const COMIC_3: Comic = {
   nextIssueId: null,
   previousIssueId: null,
   fileDetails: FILE_DETAILS_1,
+  fileEntries: [],
   readingLists: []
 };
 
@@ -187,6 +189,7 @@ export const COMIC_4: Comic = {
   nextIssueId: null,
   previousIssueId: null,
   fileDetails: FILE_DETAILS_1,
+  fileEntries: [],
   readingLists: []
 };
 
@@ -228,5 +231,6 @@ export const COMIC_5: Comic = {
   nextIssueId: null,
   previousIssueId: null,
   fileDetails: FILE_DETAILS_1,
+  fileEntries: [],
   readingLists: []
 };

--- a/comixed-frontend/src/app/comics/models/comic.fixtures.ts
+++ b/comixed-frontend/src/app/comics/models/comic.fixtures.ts
@@ -106,6 +106,7 @@ export const COMIC_2: Comic = {
   nextIssueId: null,
   previousIssueId: null,
   fileDetails: FILE_DETAILS_1,
+  fileEntries: [],
   readingLists: []
 };
 

--- a/comixed-frontend/src/app/comics/models/comic.ts
+++ b/comixed-frontend/src/app/comics/models/comic.ts
@@ -22,6 +22,7 @@ import { Page } from './page';
 import { ComicCredit } from './comic-credit';
 import { FileDetails } from 'app/comics/models/file-details';
 import { ReadingList } from 'app/comics/models/reading-list';
+import { ComicFileEntry } from 'app/comics/models/comic-file-entry';
 
 export interface Comic {
   id: number;
@@ -32,6 +33,7 @@ export interface Comic {
   baseFilename: string;
   missing: boolean;
   fileDetails: FileDetails;
+  fileEntries: ComicFileEntry[];
   addedDate: string;
   deletedDate: number;
   lastUpdatedDate: number;

--- a/comixed-frontend/src/app/comics/pages/comic-details-page/comic-details-page.component.spec.ts
+++ b/comixed-frontend/src/app/comics/pages/comic-details-page/comic-details-page.component.spec.ts
@@ -55,7 +55,9 @@ import { DropdownModule } from 'primeng/dropdown';
 import { InplaceModule } from 'primeng/inplace';
 import {
   AutoCompleteModule,
+  DialogModule,
   ProgressBarModule,
+  ScrollPanelModule,
   SplitButtonModule,
   ToolbarModule
 } from 'primeng/primeng';
@@ -70,6 +72,7 @@ import {
 import { PublisherThumbnailUrlPipe } from 'app/comics/pipes/publisher-thumbnail-url.pipe';
 import { PublisherPipe } from 'app/comics/pipes/publisher.pipe';
 import { SeriesCollectionNamePipe } from 'app/comics/pipes/series-collection-name.pipe';
+import { FileEntryListComponent } from 'app/comics/components/file-entry-list/file-entry-list.component';
 
 describe('ComicDetailsPageComponent', () => {
   const COMIC = COMIC_2;
@@ -105,7 +108,9 @@ describe('ComicDetailsPageComponent', () => {
         ProgressBarModule,
         SplitButtonModule,
         ToolbarModule,
-        AutoCompleteModule
+        AutoCompleteModule,
+        DialogModule,
+        ScrollPanelModule
       ],
       declarations: [
         ComicDetailsPageComponent,
@@ -116,6 +121,7 @@ describe('ComicDetailsPageComponent', () => {
         ComicDetailsEditorComponent,
         ComicGroupingCardComponent,
         VolumeListComponent,
+        FileEntryListComponent,
         ComicTitlePipe,
         ComicCoverUrlPipe,
         ComicDownloadLinkPipe,

--- a/comixed-frontend/src/assets/i18n/en/comics.json
+++ b/comixed-frontend/src/assets/i18n/en/comics.json
@@ -280,5 +280,18 @@
     "option": {
       "skip-cache": "Skip cache"
     }
+  },
+  "file-entry-list": {
+    "table": {
+      "header": {
+        "file-number": "#",
+        "file-name": "Filename",
+        "file-size": "Size",
+        "file-type": "Type"
+      },
+      "column": {
+        "file-size": "{size, plural, =1{One byte} other{# bytes}}"
+      }
+    }
   }
 }

--- a/comixed-frontend/src/assets/i18n/en/comics.json
+++ b/comixed-frontend/src/assets/i18n/en/comics.json
@@ -82,6 +82,9 @@
       "header": "Save Changes",
       "message": "Are you sure you want to save the changes made to this comic?"
     },
+    "show-file-entries": {
+      "title": "Archive File List"
+    },
     "label": {
       "filename": "The filename is <strong>{filename}</strong> on the host machine.",
       "publisher": "Publisher",
@@ -94,6 +97,7 @@
       "added-date": "Added to library on",
       "last-read-date": "Last read on",
       "page-count": "# Of Pages",
+      "file-entry-count": "# Of Files",
       "comicvine-details-link": "ComicVine Details Page",
       "format": "Format",
       "scan-type": "Scan Type",

--- a/comixed-frontend/src/assets/i18n/es/comics.json
+++ b/comixed-frontend/src/assets/i18n/es/comics.json
@@ -280,5 +280,18 @@
     "option": {
       "skip-cache": "Skip cache"
     }
+  },
+  "file-entry-list": {
+    "table": {
+      "header": {
+        "file-number": "#",
+        "file-name": "Filename",
+        "file-size": "Size",
+        "file-type": "Type"
+      },
+      "column": {
+        "file-size": "{size, plural, =1{One byte} other{# bytes}}"
+      }
+    }
   }
 }

--- a/comixed-frontend/src/assets/i18n/es/comics.json
+++ b/comixed-frontend/src/assets/i18n/es/comics.json
@@ -82,6 +82,9 @@
       "header": "Save Changes",
       "message": "Are you sure you want to save the changes made to this comic?"
     },
+    "show-file-entries": {
+      "title": "Archive File List"
+    },
     "label": {
       "filename": "The filename is <strong>{filename}</strong> on the host machine.",
       "publisher": "Publisher",
@@ -94,6 +97,7 @@
       "added-date": "Added to library on",
       "last-read-date": "Last read on",
       "page-count": "# Of Pages",
+      "file-entry-count": "# Of Files",
       "comicvine-details-link": "ComicVine Details Page",
       "format": "Format",
       "scan-type": "Scan Type",

--- a/comixed-frontend/src/assets/i18n/fr/comics.json
+++ b/comixed-frontend/src/assets/i18n/fr/comics.json
@@ -280,5 +280,18 @@
     "option": {
       "skip-cache": "Skip cache"
     }
+  },
+  "file-entry-list": {
+    "table": {
+      "header": {
+        "file-number": "#",
+        "file-name": "Filename",
+        "file-size": "Size",
+        "file-type": "Type"
+      },
+      "column": {
+        "file-size": "{size, plural, =1{One byte} other{# bytes}}"
+      }
+    }
   }
 }

--- a/comixed-frontend/src/assets/i18n/fr/comics.json
+++ b/comixed-frontend/src/assets/i18n/fr/comics.json
@@ -82,6 +82,9 @@
       "header": "Save Changes",
       "message": "Are you sure you want to save the changes made to this comic?"
     },
+    "show-file-entries": {
+      "title": "Archive File List"
+    },
     "label": {
       "filename": "The filename is <strong>{filename}</strong> on the host machine.",
       "publisher": "Publisher",
@@ -94,6 +97,7 @@
       "added-date": "Added to library on",
       "last-read-date": "Last read on",
       "page-count": "# Of Pages",
+      "file-entry-count": "# Of Files",
       "comicvine-details-link": "ComicVine Details Page",
       "format": "Format",
       "scan-type": "Scan Type",

--- a/comixed-library/src/main/java/org/comixed/model/comic/Comic.java
+++ b/comixed-library/src/main/java/org/comixed/model/comic/Comic.java
@@ -78,6 +78,9 @@ public class Comic {
 
   @OneToMany(mappedBy = "comic", cascade = CascadeType.ALL, orphanRemoval = true)
   @OrderColumn(name = "file_number")
+  @JsonView({
+    View.ComicDetails.class,
+  })
   List<ComicFileEntry> fileEntries = new ArrayList<>();
 
   @Id

--- a/comixed-library/src/main/java/org/comixed/model/comic/ComicFileEntry.java
+++ b/comixed-library/src/main/java/org/comixed/model/comic/ComicFileEntry.java
@@ -18,7 +18,10 @@
 
 package org.comixed.model.comic;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonView;
 import javax.persistence.*;
+import org.comixed.views.View;
 
 @Entity
 @Table(name = "comic_file_entries")
@@ -32,15 +35,31 @@ public class ComicFileEntry {
   private Comic comic;
 
   @Column(name = "file_number", nullable = false, updatable = false)
+  @JsonProperty("fileNumber")
+  @JsonView({
+    View.ComicDetails.class,
+  })
   private Integer fileNumber;
 
   @Column(name = "file_name", nullable = false, updatable = false, length = 1024)
+  @JsonProperty("fileName")
+  @JsonView({
+    View.ComicDetails.class,
+  })
   private String fileName;
 
   @Column(name = "file_size", nullable = false, updatable = false)
+  @JsonProperty("fileSize")
+  @JsonView({
+    View.ComicDetails.class,
+  })
   private Integer fileSize;
 
   @Column(name = "file_type", nullable = false, updatable = false, length = 256)
+  @JsonProperty("fileType")
+  @JsonView({
+    View.ComicDetails.class,
+  })
   private String fileType;
 
   public ComicFileEntry() {}


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Added a dialog box to the comic overview tab and an entry showing the number of files in the archive. Clicking the view icon next to the number opens a dialog that lists the files in the archive with their size, MIME type and filename.