### PR TITLE
Added exclusions to SonarCloud for jasmine tests [#350]

### DIFF
--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -29,8 +29,8 @@ jobs:
           -Dsonar.organization=comixed
           -Dsonar.projectKey=comixed_comixed
           -Dsonar.sources=./src
-          -Dsonar.exclusions=**/*test*/**
-          -Dsonar.test.inclusions=**/*test*/**
+          -Dsonar.exclusions=**/*test*/**,**/*spec.ts
+          -Dsonar.test.inclusions=**/*test*/**,**/*spec.ts
           -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
           -Pci
         env:


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Exclude Jasmine tests from coverage statistics, but include them when checking for how much code is covered.