### PR TITLE
Users can set or clear the last read date for a comic

### DIFF
--- a/comixed-frontend/src/app/comics/actions/comic.actions.ts
+++ b/comixed-frontend/src/app/comics/actions/comic.actions.ts
@@ -49,7 +49,10 @@ export enum ComicActionTypes {
   DeleteComicFailed = '[COMIC] Failed to delete comic from the library',
   RestoreComic = '[COMIC] Unmark a comic for deletion',
   RestoreComicSucceeded = '[COMIC] Comic unmarked for deletion',
-  RestoreComicFailed = '[COMIC] Failed to unmark a comic for deletion'
+  RestoreComicFailed = '[COMIC] Failed to unmark a comic for deletion',
+  MarkAsRead = '[COMIC] Change the read state of a comic',
+  MarkedAsRead = '[COMIC} The read state of a comic was changed',
+  MarkAsReadFailed = '[COMIC] Changing the read state of a comic failed'
 }
 
 export class ComicGetScanTypes implements Action {
@@ -232,6 +235,24 @@ export class ComicRestoreFailed implements Action {
   constructor() {}
 }
 
+export class ComicMarkAsRead implements Action {
+  readonly type = ComicActionTypes.MarkAsRead;
+
+  constructor(public payload: { comic: Comic; read: boolean }) {}
+}
+
+export class ComicMarkedAsRead implements Action {
+  readonly type = ComicActionTypes.MarkedAsRead;
+
+  constructor(public payload: { lastRead: number }) {}
+}
+
+export class ComicMarkAsReadFailed implements Action {
+  readonly type = ComicActionTypes.MarkAsReadFailed;
+
+  constructor() {}
+}
+
 export type ComicActions =
   | ComicGetScanTypes
   | ComicGotScanTypes
@@ -262,4 +283,7 @@ export type ComicActions =
   | ComicDeleteFailed
   | ComicRestore
   | ComicRestored
-  | ComicRestoreFailed;
+  | ComicRestoreFailed
+  | ComicMarkAsRead
+  | ComicMarkedAsRead
+  | ComicMarkAsReadFailed;

--- a/comixed-frontend/src/app/comics/adaptors/comic.adaptor.ts
+++ b/comixed-frontend/src/app/comics/adaptors/comic.adaptor.ts
@@ -32,6 +32,7 @@ import {
   ComicGetFormats,
   ComicGetIssue,
   ComicGetScanTypes,
+  ComicMarkAsRead,
   ComicRestore,
   ComicSave,
   ComicSavePage,
@@ -60,6 +61,7 @@ export class ComicAdaptor {
   private _comic$ = new BehaviorSubject<Comic>(null);
   private _deletingComic$ = new BehaviorSubject<boolean>(false);
   private _restoringComic$ = new BehaviorSubject<boolean>(false);
+  private _markingAsRead$ = new BehaviorSubject<boolean>(false);
 
   constructor(private logger: LoggerService, private store: Store<AppState>) {
     this.store
@@ -102,6 +104,9 @@ export class ComicAdaptor {
         }
         if (!_.isEqual(state.comic, this._comic$.getValue())) {
           this._comic$.next(state.comic);
+        }
+        if (state.settingReadState !== this._markingAsRead$.getValue()) {
+          this._markingAsRead$.next(state.settingReadState);
         }
       });
   }
@@ -210,5 +215,19 @@ export class ComicAdaptor {
 
   get restoringComic$(): Observable<boolean> {
     return this._restoringComic$.asObservable();
+  }
+
+  markAsRead(comic: Comic): void {
+    this.logger.debug('marking comic as read:', comic);
+    this.store.dispatch(new ComicMarkAsRead({ comic: comic, read: true }));
+  }
+
+  get markingAsRead$(): Observable<boolean> {
+    return this._markingAsRead$.asObservable();
+  }
+
+  markAsUnread(comic: Comic): void {
+    this.logger.debug('marking comic as unread:', comic);
+    this.store.dispatch(new ComicMarkAsRead({ comic: comic, read: false }));
   }
 }

--- a/comixed-frontend/src/app/comics/comics.constants.ts
+++ b/comixed-frontend/src/app/comics/comics.constants.ts
@@ -28,6 +28,8 @@ export const DELETE_COMIC_URL = `${API_ROOT_URL}/comics/\${id}`;
 export const RESTORE_COMIC_URL = `${API_ROOT_URL}/comics/\${id}/restore`;
 export const DOWNLOAD_COMIC_URL = `${API_ROOT_URL}/comics/\${id}/download`;
 export const GET_COMIC_COVER_URL = `${API_ROOT_URL}/comics/\${id}/cover/content`;
+export const MARK_COMIC_AS_READ_URL = `${API_ROOT_URL}/comics/\${id}/read`;
+export const MARK_COMIC_AS_UNREAD_URL = `${API_ROOT_URL}/comics/\${id}/read`;
 
 export const MISSING_COMIC_IMAGE_URL = '/assets/img/missing-comic-file.png';
 

--- a/comixed-frontend/src/app/comics/components/comic-overview/comic-overview.component.html
+++ b/comixed-frontend/src/app/comics/components/comic-overview/comic-overview.component.html
@@ -179,9 +179,19 @@
       <div class='ui-g-12'>
         <strong>{{"comic-overview.label.last-read-date"|translate}}</strong>
       </div>
-      <div class='ui-g-12'>
-        <span *ngIf='!comic.lastReadDate'>{{'comic-overview.text.never-read'|translate}}</span>
-        <span *ngIf='comic.lastReadDate'>{{comic.lastReadDate|date:'medium'}}</span>
+      <div *ngIf='!comic.lastRead'
+           class='ui-g-12'>
+        <span class='fa fa-fw fa-square'
+              (click)='markAsRead(true)'
+              [pTooltip]='"comic-overview.tooltip.toggle-read"|translate:{marked:false}'></span>
+        {{'comic-overview.text.never-read'|translate}}
+      </div>
+      <div *ngIf='!!comic.lastRead'
+           class='ui-g-12'>
+        <span class='fa fa-fw fas fa-check-square'
+              (click)='markAsRead(false)'
+              [pTooltip]='"comic-overview.tooltip.toggle-read"|translate:{marked:true}'></span>
+        {{comic.lastRead|date:'medium'}}
       </div>
       <div class='ui-g-12'>
         <strong>{{"comic-overview.label.page-count"|translate}}</strong>

--- a/comixed-frontend/src/app/comics/components/comic-overview/comic-overview.component.ts
+++ b/comixed-frontend/src/app/comics/components/comic-overview/comic-overview.component.ts
@@ -197,4 +197,16 @@ export class ComicOverviewComponent implements OnInit, OnDestroy {
     this.logger.debug(`${show ? 'showing' : 'hiding'} file entries dialog`);
     this.showFileEntriesDialog = show;
   }
+
+  markAsRead(read: boolean): void {
+    this.logger.debug(
+      `toggling read start ${read ? 'on' : 'off'} for comic:`,
+      this.comic
+    );
+    if (read) {
+      this.comicAdaptor.markAsRead(this.comic);
+    } else {
+      this.comicAdaptor.markAsUnread(this.comic);
+    }
+  }
 }

--- a/comixed-frontend/src/app/comics/components/comic-story/comic-story.component.spec.ts
+++ b/comixed-frontend/src/app/comics/components/comic-story/comic-story.component.spec.ts
@@ -30,6 +30,7 @@ import { MessageService } from 'primeng/api';
 import { StoreModule } from '@ngrx/store';
 import { COMIC_FEATURE_KEY, reducer } from 'app/comics/reducers/comic.reducer';
 import { ComicEffects } from 'app/comics/effects/comic.effects';
+import { LoggerModule } from '@angular-ru/logger';
 
 describe('ComicStoryComponent', () => {
   let component: ComicStoryComponent;
@@ -41,6 +42,7 @@ describe('ComicStoryComponent', () => {
         HttpClientTestingModule,
         RouterTestingModule,
         TranslateModule.forRoot(),
+        LoggerModule.forRoot(),
         StoreModule.forRoot({}),
         StoreModule.forFeature(COMIC_FEATURE_KEY, reducer),
         EffectsModule.forRoot([]),

--- a/comixed-frontend/src/app/comics/models/comic.ts
+++ b/comixed-frontend/src/app/comics/models/comic.ts
@@ -65,5 +65,5 @@ export interface Comic {
   pages?: Page[];
   duplicateCount?: number;
   readingLists: ReadingList[];
-  lastReadDate?: number;
+  lastRead?: number;
 }

--- a/comixed-frontend/src/app/comics/reducers/comic.reducer.spec.ts
+++ b/comixed-frontend/src/app/comics/reducers/comic.reducer.spec.ts
@@ -34,6 +34,9 @@ import {
   ComicGotIssue,
   ComicGotPageTypes,
   ComicGotScanTypes,
+  ComicMarkAsRead,
+  ComicMarkAsReadFailed,
+  ComicMarkedAsRead,
   ComicMetadataCleared,
   ComicPageHashBlockingSet,
   ComicPageSaved,
@@ -66,9 +69,11 @@ import {
   SCAN_TYPE_5
 } from 'app/comics/models/scan-type.fixtures';
 import { ComicState, initialState, reducer } from './comic.reducer';
+import { COMIC_1_LAST_READ_DATE } from 'app/library/models/last-read-date.fixtures';
 
 describe('Comic Reducer', () => {
   const COMIC = COMIC_1;
+  const LAST_READ_DATE = COMIC_1_LAST_READ_DATE;
 
   let state: ComicState;
 
@@ -155,6 +160,10 @@ describe('Comic Reducer', () => {
 
     it('clears the scraping comic flag', () => {
       expect(state.scrapingComic).toBeFalsy();
+    });
+
+    it('clears the setting read state flag', () => {
+      expect(state.settingReadState).toBeFalsy();
     });
   });
 
@@ -632,6 +641,74 @@ describe('Comic Reducer', () => {
 
     it('clears the restoring flag', () => {
       expect(state.restoringComic).toBeFalsy();
+    });
+  });
+
+  describe('setting the read state', () => {
+    beforeEach(() => {
+      state = reducer(
+        { ...state, settingReadState: false },
+        new ComicMarkAsRead({ comic: COMIC, read: true })
+      );
+    });
+
+    it('sets the marking as read flag', () => {
+      expect(state.settingReadState).toBeTruthy();
+    });
+  });
+
+  describe('when the comic is marked as read', () => {
+    beforeEach(() => {
+      state = reducer(
+        {
+          ...state,
+          settingReadState: true,
+          comic: { ...COMIC, lastRead: null }
+        },
+        new ComicMarkedAsRead({ lastRead: LAST_READ_DATE.lastRead })
+      );
+    });
+
+    it('clears the marking as read flag', () => {
+      expect(state.settingReadState).toBeFalsy();
+    });
+
+    it('sets the last read date', () => {
+      expect(state.comic.lastRead).toEqual(LAST_READ_DATE.lastRead);
+    });
+  });
+
+  describe('when the last read date is cleared', () => {
+    beforeEach(() => {
+      state = reducer(
+        {
+          ...state,
+          settingReadState: true,
+          comic: { ...COMIC, lastRead: LAST_READ_DATE.lastRead }
+        },
+        new ComicMarkedAsRead({ lastRead: null })
+      );
+    });
+
+    it('clears the marking as read flag', () => {
+      expect(state.settingReadState).toBeFalsy();
+    });
+
+    it('clears the last read date', () => {
+      expect(state.comic.lastRead).toBeNull();
+    });
+  });
+
+  describe('failure to set the read state', () => {
+    beforeEach(() => {
+      state = reducer(
+        { ...state, settingReadState: true },
+        new ComicMarkAsReadFailed()
+      );
+    });
+
+    it('clears the marking as read flag', () => {
+      expect(state.settingReadState).toBeFalsy();
     });
   });
 });

--- a/comixed-frontend/src/app/comics/reducers/comic.reducer.ts
+++ b/comixed-frontend/src/app/comics/reducers/comic.reducer.ts
@@ -41,6 +41,7 @@ export interface ComicState {
   deletingComic: boolean;
   restoringComic: boolean;
   scrapingComic: boolean;
+  settingReadState: boolean;
 }
 
 export const initialState: ComicState = {
@@ -62,7 +63,8 @@ export const initialState: ComicState = {
   clearingMetadata: false,
   deletingComic: false,
   restoringComic: false,
-  scrapingComic: false
+  scrapingComic: false,
+  settingReadState: false
 };
 
 export function reducer(
@@ -174,6 +176,19 @@ export function reducer(
 
     case ComicActionTypes.RestoreComicFailed:
       return { ...state, restoringComic: false };
+
+    case ComicActionTypes.MarkAsRead:
+      return { ...state, settingReadState: true };
+
+    case ComicActionTypes.MarkedAsRead:
+      return {
+        ...state,
+        settingReadState: false,
+        comic: { ...state.comic, lastRead: action.payload.lastRead }
+      };
+
+    case ComicActionTypes.MarkAsReadFailed:
+      return { ...state, settingReadState: false };
 
     default:
       return state;

--- a/comixed-frontend/src/app/comics/services/comic.service.spec.ts
+++ b/comixed-frontend/src/app/comics/services/comic.service.spec.ts
@@ -30,6 +30,7 @@ import {
   GET_FORMATS_URL,
   GET_PAGE_TYPES_URL,
   GET_SCAN_TYPES_URL,
+  MARK_COMIC_AS_READ_URL,
   RESTORE_COMIC_URL,
   SAVE_COMIC_URL
 } from 'app/comics/comics.constants';
@@ -47,17 +48,20 @@ import {
 } from 'app/comics/models/scan-type.fixtures';
 
 import { ComicService } from './comic.service';
+import { COMIC_1_LAST_READ_DATE } from 'app/library/models/last-read-date.fixtures';
+import { LoggerModule } from '@angular-ru/logger';
 
 describe('ComicService', () => {
   const COMIC = COMIC_1;
   const SKIP_CACHE = false;
+  const LAST_READ_DATE = COMIC_1_LAST_READ_DATE;
 
   let service: ComicService;
   let httpMock: HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      imports: [HttpClientTestingModule, LoggerModule.forRoot()],
       providers: [ComicService]
     });
 
@@ -169,5 +173,29 @@ describe('ComicService', () => {
     expect(req.request.method).toEqual('PUT');
     expect(req.request.body).toEqual({});
     req.flush(COMIC);
+  });
+
+  it('can mark a comic as read', () => {
+    service
+      .markAsRead(COMIC, true)
+      .subscribe(response => expect(response).toEqual(LAST_READ_DATE));
+
+    const req = httpMock.expectOne(
+      interpolate(MARK_COMIC_AS_READ_URL, { id: COMIC.id })
+    );
+    expect(req.request.method).toEqual('PUT');
+    req.flush(LAST_READ_DATE);
+  });
+
+  it('can unmark a comic as read', () => {
+    service
+      .markAsRead(COMIC, false)
+      .subscribe(response => expect(response).toBeNull());
+
+    const req = httpMock.expectOne(
+      interpolate(MARK_COMIC_AS_READ_URL, { id: COMIC.id })
+    );
+    expect(req.request.method).toEqual('DELETE');
+    req.flush(null);
   });
 });

--- a/comixed-frontend/src/app/comics/services/comic.service.ts
+++ b/comixed-frontend/src/app/comics/services/comic.service.ts
@@ -27,16 +27,19 @@ import {
   GET_FORMATS_URL,
   GET_PAGE_TYPES_URL,
   GET_SCAN_TYPES_URL,
+  MARK_COMIC_AS_READ_URL,
+  MARK_COMIC_AS_UNREAD_URL,
   RESTORE_COMIC_URL,
   SAVE_COMIC_URL
 } from 'app/comics/comics.constants';
 import { Observable } from 'rxjs';
+import { LoggerService } from '@angular-ru/logger';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ComicService {
-  constructor(private http: HttpClient) {}
+  constructor(private logger: LoggerService, private http: HttpClient) {}
 
   getScanTypes(): Observable<any> {
     return this.http.get(interpolate(GET_SCAN_TYPES_URL));
@@ -68,5 +71,20 @@ export class ComicService {
 
   restoreComic(comic: Comic): Observable<any> {
     return this.http.put(interpolate(RESTORE_COMIC_URL, { id: comic.id }), {});
+  }
+
+  markAsRead(comic: Comic, mark: boolean): Observable<any> {
+    if (mark) {
+      this.logger.debug('http [PUT]: Marking comic as read');
+      return this.http.put(
+        interpolate(MARK_COMIC_AS_READ_URL, { id: comic.id }),
+        {}
+      );
+    } else {
+      this.logger.debug('http [DELETE]: Unmarking comic as read');
+      return this.http.delete(
+        interpolate(MARK_COMIC_AS_UNREAD_URL, { id: comic.id })
+      );
+    }
   }
 }

--- a/comixed-frontend/src/app/library/adaptors/library.adaptor.ts
+++ b/comixed-frontend/src/app/library/adaptors/library.adaptor.ts
@@ -175,9 +175,7 @@ export class LibraryAdaptor {
             const lastReadDate = state.lastReadDates.find(
               entry => entry.comicId === comic.id
             );
-            comic.lastReadDate = !!lastReadDate
-              ? lastReadDate.lastReadDate
-              : null;
+            comic.lastRead = !!lastReadDate ? lastReadDate.lastRead : null;
           });
           this._comic$.next(state.comics);
         }

--- a/comixed-frontend/src/app/library/models/last-read-date.fixtures.ts
+++ b/comixed-frontend/src/app/library/models/last-read-date.fixtures.ts
@@ -21,6 +21,6 @@ import { LastReadDate } from 'app/library/models/last-read-date';
 
 export const COMIC_1_LAST_READ_DATE: LastReadDate = {
   comicId: COMIC_1.id,
-  lastReadDate: 65535,
+  lastRead: 65535,
   lastUpdated: 65536
 };

--- a/comixed-frontend/src/app/library/models/last-read-date.ts
+++ b/comixed-frontend/src/app/library/models/last-read-date.ts
@@ -18,6 +18,6 @@
 
 export interface LastReadDate {
   comicId: number;
-  lastReadDate: number;
+  lastRead: number;
   lastUpdated: number;
 }

--- a/comixed-frontend/src/assets/i18n/en/comics.json
+++ b/comixed-frontend/src/assets/i18n/en/comics.json
@@ -144,7 +144,8 @@
       "delete-comic": "Mark comic for deletion.",
       "undelete-comic": "Do not mark comic for deletion.",
       "save-changes": "Save changes.",
-      "undo-changes": "Undo changes."
+      "undo-changes": "Undo changes.",
+      "toggle-read": "{marked, select, true{Clear} other{Set}} the last read date."
     }
   },
   "comic-story": {

--- a/comixed-frontend/src/assets/i18n/en/comics.json
+++ b/comixed-frontend/src/assets/i18n/en/comics.json
@@ -75,6 +75,11 @@
       "error": {
         "detail": "Failed to scrape comic."
       }
+    },
+    "mark-as-read": {
+      "error": {
+        "detail": "Failed to change the last read date."
+      }
     }
   },
   "comic-overview": {

--- a/comixed-frontend/src/assets/i18n/es/comics.json
+++ b/comixed-frontend/src/assets/i18n/es/comics.json
@@ -144,7 +144,8 @@
       "delete-comic": "Mark comic for deletion.",
       "undelete-comic": "Do not mark comic for deletion.",
       "save-changes": "Save changes.",
-      "undo-changes": "Undo changes."
+      "undo-changes": "Undo changes.",
+      "toggle-read": "{marked, select, true{Clear} other{Set}} the last read date."
     }
   },
   "comic-story": {

--- a/comixed-frontend/src/assets/i18n/es/comics.json
+++ b/comixed-frontend/src/assets/i18n/es/comics.json
@@ -75,6 +75,11 @@
       "error": {
         "detail": "Failed to scrape comic."
       }
+    },
+    "mark-as-read": {
+      "error": {
+        "detail": "Failed to change the last read date."
+      }
     }
   },
   "comic-overview": {

--- a/comixed-frontend/src/assets/i18n/fr/comics.json
+++ b/comixed-frontend/src/assets/i18n/fr/comics.json
@@ -144,7 +144,8 @@
       "delete-comic": "Mark comic for deletion.",
       "undelete-comic": "Do not mark comic for deletion.",
       "save-changes": "Save changes.",
-      "undo-changes": "Undo changes."
+      "undo-changes": "Undo changes.",
+      "toggle-read": "{marked, select, true{Clear} other{Set}} the last read date."
     }
   },
   "comic-story": {

--- a/comixed-frontend/src/assets/i18n/fr/comics.json
+++ b/comixed-frontend/src/assets/i18n/fr/comics.json
@@ -75,6 +75,11 @@
       "error": {
         "detail": "Failed to scrape comic."
       }
+    },
+    "mark-as-read": {
+      "error": {
+        "detail": "Failed to change the last read date."
+      }
     }
   },
   "comic-overview": {

--- a/comixed-library/src/main/java/org/comixed/model/comic/Comic.java
+++ b/comixed-library/src/main/java/org/comixed/model/comic/Comic.java
@@ -230,11 +230,7 @@ public class Comic {
   @JsonView({View.ComicList.class, View.LibraryUpdate.class})
   private List<String> locations = new ArrayList<>();
 
-  @OneToMany(
-      mappedBy = "comic",
-      cascade = CascadeType.ALL,
-      fetch = FetchType.EAGER,
-      orphanRemoval = true)
+  @OneToMany(mappedBy = "comic", cascade = CascadeType.ALL, orphanRemoval = true)
   @JsonProperty("credits")
   @JsonView({View.ComicList.class, View.LibraryUpdate.class})
   private Set<Credit> credits = new HashSet<>();
@@ -1136,5 +1132,9 @@ public class Comic {
   @Override
   public int hashCode() {
     return 17 * Objects.hash(filename);
+  }
+
+  public Date getDateLastRead() {
+    return this.lastReadDates.isEmpty() ? null : this.lastReadDates.iterator().next().getLastRead();
   }
 }

--- a/comixed-library/src/main/java/org/comixed/model/comic/Comic.java
+++ b/comixed-library/src/main/java/org/comixed/model/comic/Comic.java
@@ -293,6 +293,10 @@ public class Comic {
   @JsonIgnore
   private List<LastReadDate> lastReadDates = new ArrayList<>();
 
+  @Transient
+  @JsonView(View.ComicDetails.class)
+  private Date lastRead;
+
   public Date getDateLastUpdated() {
     return dateLastUpdated;
   }
@@ -1136,5 +1140,9 @@ public class Comic {
 
   public Date getDateLastRead() {
     return this.lastReadDates.isEmpty() ? null : this.lastReadDates.iterator().next().getLastRead();
+  }
+
+  public void setLastRead(Date lastRead) {
+    this.lastRead = lastRead;
   }
 }

--- a/comixed-library/src/main/java/org/comixed/model/user/LastReadDate.java
+++ b/comixed-library/src/main/java/org/comixed/model/user/LastReadDate.java
@@ -35,15 +35,15 @@ public class LastReadDate {
   private Long id;
 
   @ManyToOne
-  @JoinColumn(name = "comic_id")
+  @JoinColumn(name = "comic_id", insertable = true, updatable = false, nullable = false)
   @JsonProperty("comic")
   private Comic comic;
 
   @ManyToOne
-  @JoinColumn(name = "user_id")
+  @JoinColumn(name = "user_id", insertable = true, updatable = false, nullable = false)
   private ComiXedUser user;
 
-  @Column(name = "last_read", nullable = false, updatable = false)
+  @Column(name = "last_read", insertable = true, updatable = false, nullable = false)
   @JsonProperty("lastRead")
   @JsonFormat(shape = JsonFormat.Shape.NUMBER)
   @JsonView({View.UserDetails.class, View.LibraryUpdate.class})
@@ -54,6 +54,10 @@ public class LastReadDate {
   @JsonFormat(shape = JsonFormat.Shape.NUMBER)
   @JsonView({View.UserDetails.class, View.LibraryUpdate.class})
   private Date lastUpdated = new Date();
+
+  public void setComic(Comic comic) {
+    this.comic = comic;
+  }
 
   public Comic getComic() {
     return this.comic;
@@ -76,6 +80,10 @@ public class LastReadDate {
 
   public void setLastRead(Date lastRead) {
     this.lastRead = lastRead;
+  }
+
+  public void setUser(ComiXedUser user) {
+    this.user = user;
   }
 
   public ComiXedUser getUser() {

--- a/comixed-library/src/main/java/org/comixed/repositories/library/LastReadDatesRepository.java
+++ b/comixed-library/src/main/java/org/comixed/repositories/library/LastReadDatesRepository.java
@@ -20,6 +20,8 @@ package org.comixed.repositories.library;
 
 import java.util.Date;
 import java.util.List;
+import org.comixed.model.comic.Comic;
+import org.comixed.model.user.ComiXedUser;
 import org.comixed.model.user.LastReadDate;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -43,4 +45,14 @@ public interface LastReadDatesRepository extends CrudRepository<LastReadDate, Lo
       "SELECT d FROM LastReadDate d WHERE d.user.id = :userId AND d.lastUpdated >= :updatedSince")
   List<LastReadDate> findAllForUser(
       @Param("userId") Long userId, @Param("updatedSince") Date updatedSince);
+
+  /**
+   * Returns the last ready entry for the specific comic by the specified user.
+   *
+   * @param comic the comic
+   * @param user the user
+   * @return the last read date entry
+   */
+  @Query("SELECT d FROM LastReadDate d WHERE d.user = :user AND d.comic = :comic")
+  LastReadDate getForComicAndUser(@Param("comic") Comic comic, @Param("user") ComiXedUser user);
 }

--- a/comixed-library/src/test/java/org/comixed/repositories/comic/ComicRepositoryTest.java
+++ b/comixed-library/src/test/java/org/comixed/repositories/comic/ComicRepositoryTest.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang.time.DateUtils;
 import org.comixed.model.comic.Comic;
 import org.comixed.model.comic.ComicFormat;
 import org.comixed.model.comic.ScanType;
+import org.comixed.repositories.ComiXedUserRepository;
 import org.comixed.repositories.RepositoryContext;
 import org.junit.Before;
 import org.junit.Test;
@@ -74,11 +75,13 @@ public class ComicRepositoryTest {
   private static final String TEST_ISSUE_WITH_NO_PREV = "249";
   private static final String TEST_ISSUE_WITH_PREV = "513";
   private static final Long TEST_COMIC_ID_WITH_DUPLICATES = 1020L;
+  private static final String TEST_USER_EMAIL_NO_READ_COMIC = "comixedreader2@localhost";
 
   @Autowired private ComicRepository repository;
   @Autowired private PageTypeRepository pageTypeRepository;
   @Autowired private ScanTypeRepository scanTypeRepository;
   @Autowired private ComicFormatRepository comicFormatRepository;
+  @Autowired private ComiXedUserRepository userRepository;
 
   private Comic comic;
 

--- a/comixed-library/src/test/resources/application.properties
+++ b/comixed-library/src/test/resources/application.properties
@@ -5,7 +5,7 @@ spring.main.banner-mode=off
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.naming-strategy=org.hibernate.cfg.ImprovedNamingStrategy
 spring.jpa.hibernate.use-new-id-generator-mappings=false
-spring.jpa.show-sql=false
+spring.jpa.show-sql=true
 spring.jpa.generate-ddl=false
 spring.jpa.hibernate.ddl-auto=create
 

--- a/comixed-library/src/test/resources/test-database.xml
+++ b/comixed-library/src/test/resources/test-database.xml
@@ -404,6 +404,11 @@
          password_hash="12345"
          first_login_date="2018-01-01 12:00:00"
          last_login_date="2018-12-18 17:57:00"/>
+  <users id="2000"
+         email="comixedreader2@localhost"
+         password_hash="54321"
+         first_login_date="2018-01-01 12:00:00"
+         last_login_date="2018-12-18 17:57:00"/>
   <user_last_read_dates id="1"
                         user_id="1000"
                         comic_id="1000"

--- a/comixed-rest-api/src/main/java/org/comixed/controller/comic/ComicController.java
+++ b/comixed-rest-api/src/main/java/org/comixed/controller/comic/ComicController.java
@@ -378,4 +378,28 @@ public class ComicController {
 
     return this.comicService.restoreComic(id);
   }
+
+  @PutMapping(
+      value = "/{id}/read",
+      produces = MediaType.APPLICATION_JSON_VALUE,
+      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @JsonView(View.UserDetails.class)
+  public LastReadDate markAsRead(Principal principal, @PathVariable("id") Long id)
+      throws ComicException {
+    String email = principal.getName();
+    if (email == null) throw new ComicException("not authenticated");
+    this.log.info("Marking comic as read for {}: id={}", email, id);
+
+    return this.comicService.markAsRead(email, id);
+  }
+
+  @DeleteMapping(value = "/{id}/read", produces = MediaType.APPLICATION_JSON_VALUE)
+  public boolean markAsUnread(Principal principal, @PathVariable("id") Long id)
+      throws ComicException {
+    String email = principal.getName();
+    if (email == null) throw new ComicException("not authenticated");
+    this.log.info("Marking comic as unread for {}: id={}", email, id);
+
+    return this.comicService.markAsUnread(email, id);
+  }
 }

--- a/comixed-rest-api/src/main/java/org/comixed/controller/comic/ComicController.java
+++ b/comixed-rest-api/src/main/java/org/comixed/controller/comic/ComicController.java
@@ -151,10 +151,11 @@ public class ComicController {
 
   @GetMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
   @JsonView(ComicDetails.class)
-  public Comic getComic(@PathVariable("id") long id) throws ComicException {
-    this.log.info("Getting comic: id={}", id);
+  public Comic getComic(Principal principal, @PathVariable("id") long id) throws ComicException {
+    String email = principal.getName();
+    this.log.info("Getting comic for user: id={} user={}", id, email);
 
-    final Comic result = this.comicService.getComic(id);
+    final Comic result = this.comicService.getComic(id, email);
 
     if (result == null) {
       this.log.error("No such comic");

--- a/comixed-rest-api/src/test/java/org/comixed/controller/comic/ComicControllerTest.java
+++ b/comixed-rest-api/src/test/java/org/comixed/controller/comic/ComicControllerTest.java
@@ -391,23 +391,27 @@ public class ComicControllerTest {
 
   @Test
   public void testGetComicForNonexistentComic() throws ComicException {
-    Mockito.when(comicService.getComic(Mockito.anyLong())).thenReturn(null);
+    Mockito.when(principal.getName()).thenReturn(TEST_EMAIL_ADDRESS);
+    Mockito.when(comicService.getComic(Mockito.anyLong(), Mockito.anyString())).thenReturn(null);
 
-    assertNull(controller.getComic(TEST_COMIC_ID));
+    Comic result = controller.getComic(principal, TEST_COMIC_ID);
 
-    Mockito.verify(comicService, Mockito.times(1)).getComic(TEST_COMIC_ID);
+    assertNull(result);
+
+    Mockito.verify(comicService, Mockito.times(1)).getComic(TEST_COMIC_ID, TEST_EMAIL_ADDRESS);
   }
 
   @Test
   public void testGetComic() throws ComicException {
-    Mockito.when(comicService.getComic(Mockito.anyLong())).thenReturn(comic);
+    Mockito.when(principal.getName()).thenReturn(TEST_EMAIL_ADDRESS);
+    Mockito.when(comicService.getComic(Mockito.anyLong(), Mockito.anyString())).thenReturn(comic);
 
-    Comic result = controller.getComic(TEST_COMIC_ID);
+    Comic result = controller.getComic(principal, TEST_COMIC_ID);
 
     assertNotNull(result);
     assertSame(comic, result);
 
-    Mockito.verify(comicService, Mockito.times(1)).getComic(TEST_COMIC_ID);
+    Mockito.verify(comicService, Mockito.times(1)).getComic(TEST_COMIC_ID, TEST_EMAIL_ADDRESS);
   }
 
   @Test

--- a/comixed-services/src/main/java/org/comixed/service/comic/ComicService.java
+++ b/comixed-services/src/main/java/org/comixed/service/comic/ComicService.java
@@ -342,4 +342,22 @@ public class ComicService {
     this.log.debug("Returning success");
     return true;
   }
+
+  public Comic getComic(long comicId, String email) throws ComicException {
+    Comic result = this.getComic(comicId);
+    ComiXedUser user = this.userRepository.findByEmail(email);
+
+    if (user == null) {
+      throw new ComicException("could not load last read date for non-existent user: " + email);
+    }
+
+    this.log.debug("Loading last read date for comic: user id={}", user.getId());
+    LastReadDate lastRead = this.lastReadDatesRepository.getForComicAndUser(result, user);
+    if (lastRead != null) {
+      this.log.debug("Last read on {}", lastRead.getLastRead());
+      result.setLastRead(lastRead.getLastRead());
+    }
+
+    return result;
+  }
 }


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Added the REST APIs and frontend changes to handle setting and clearing the last read date for individual comics.