### PR TITLE
Users can move their entire library to a new directory

### DIFF
--- a/comixed-frontend/src/app/library/actions/library.actions.ts
+++ b/comixed-frontend/src/app/library/actions/library.actions.ts
@@ -35,9 +35,9 @@ export enum LibraryActionTypes {
   ConvertComics = '[LIBRARY] Convert comics to a new archive type',
   ComicsConverting = '[LIBRARY] Comics converting to a new archive type',
   ConvertComicsFailed = '[LIBRARY] Failed to convert comics',
-  Consolidate = '[LIBRARY] Consolidate the library',
-  Consolidated = '[LIBRARY] Library is consolidated',
-  ConsolidateFailed = '[LIBRARY] Failed to consolidate library',
+  MoveComics = '[LIBRARY] Move the library',
+  ComicsMoved = '[LIBRARY] Library was moved',
+  MoveComicsFailed = '[LIBRARY] Moving the library failed',
   ClearImageCache = '[LIBRARY] Clear the image cache',
   ImageCacheCleared = '[LIBRARY] Image cache cleared',
   ClearImageCacheFailed = '[LIBRARY] Failed to clear the image cache'
@@ -145,20 +145,26 @@ export class LibraryConvertComicsFailed implements Action {
   constructor() {}
 }
 
-export class LibraryConsolidate implements Action {
-  readonly type = LibraryActionTypes.Consolidate;
+export class LibraryMoveComics implements Action {
+  readonly type = LibraryActionTypes.MoveComics;
 
-  constructor(public payload: { deletePhysicalFiles: boolean }) {}
+  constructor(
+    public payload: {
+      deletePhysicalFiles: boolean;
+      directory: string;
+      renamingRule: string;
+    }
+  ) {}
 }
 
-export class LibraryConsolidated implements Action {
-  readonly type = LibraryActionTypes.Consolidated;
+export class LibraryComicsMoved implements Action {
+  readonly type = LibraryActionTypes.ComicsMoved;
 
-  constructor(public payload: { deletedComics: Comic[] }) {}
+  constructor() {}
 }
 
-export class LibraryConsolidateFailed implements Action {
-  readonly type = LibraryActionTypes.ConsolidateFailed;
+export class LibraryMoveComicsFailed implements Action {
+  readonly type = LibraryActionTypes.MoveComicsFailed;
 
   constructor() {}
 }
@@ -195,9 +201,9 @@ export type LibraryActions =
   | LibraryConvertComics
   | LibraryComicsConverting
   | LibraryConvertComicsFailed
-  | LibraryConsolidate
-  | LibraryConsolidated
-  | LibraryConsolidateFailed
+  | LibraryMoveComics
+  | LibraryComicsMoved
+  | LibraryMoveComicsFailed
   | LibraryClearImageCache
   | LibraryImageCacheCleared
   | LibraryClearImageCacheFailed;

--- a/comixed-frontend/src/app/library/adaptors/library.adaptor.spec.ts
+++ b/comixed-frontend/src/app/library/adaptors/library.adaptor.spec.ts
@@ -47,13 +47,13 @@ import {
   LibraryClearImageCache,
   LibraryClearImageCacheFailed,
   LibraryComicsConverting,
-  LibraryConsolidate,
-  LibraryConsolidated,
-  LibraryConsolidateFailed,
+  LibraryComicsMoved,
   LibraryConvertComics,
   LibraryConvertComicsFailed,
   LibraryGetUpdates,
   LibraryImageCacheCleared,
+  LibraryMoveComics,
+  LibraryMoveComicsFailed,
   LibraryUpdatesReceived
 } from '../actions/library.actions';
 import { LibraryAdaptor } from './library.adaptor';
@@ -76,6 +76,9 @@ describe('LibraryAdaptor', () => {
   const ARCHIVE_TYPE = 'CBZ';
   const RENAME_PAGES = true;
   const READING_LISTS = [READING_LIST_1, READING_LIST_2];
+  const DIRECTORY = '/Users/comixedreader/Documents/comics';
+  const RENAMING_RULE =
+    '$PUBLISHER/$SERIES/$VOLUME/$SERIES v$VOLUME #$ISSUE [$COVERDATE]';
 
   let adaptor: LibraryAdaptor;
   let store: Store<AppState>;
@@ -312,12 +315,16 @@ describe('LibraryAdaptor', () => {
 
   describe('consolidating the library', () => {
     beforeEach(() => {
-      adaptor.consolidate(true);
+      adaptor.consolidate(true, DIRECTORY, RENAMING_RULE);
     });
 
     it('fires an action', () => {
       expect(store.dispatch).toHaveBeenCalledWith(
-        new LibraryConsolidate({ deletePhysicalFiles: true })
+        new LibraryMoveComics({
+          deletePhysicalFiles: true,
+          directory: DIRECTORY,
+          renamingRule: RENAMING_RULE
+        })
       );
     });
 
@@ -343,9 +350,7 @@ describe('LibraryAdaptor', () => {
             readingLists: []
           })
         );
-        store.dispatch(
-          new LibraryConsolidated({ deletedComics: DELETED_COMICS })
-        );
+        store.dispatch(new LibraryComicsMoved());
       });
 
       it('provides updates on consolidating', () => {
@@ -353,19 +358,11 @@ describe('LibraryAdaptor', () => {
           expect(response).toBeFalsy()
         );
       });
-
-      it('provides updates on comics', () => {
-        DELETED_COMICS.forEach(comic => {
-          adaptor.comic$.subscribe(comics =>
-            expect(comics).not.toContain(comic)
-          );
-        });
-      });
     });
 
     describe('failure', () => {
       beforeEach(() => {
-        store.dispatch(new LibraryConsolidateFailed());
+        store.dispatch(new LibraryMoveComicsFailed());
       });
 
       it('provides updates on consolidating', () => {

--- a/comixed-frontend/src/app/library/adaptors/library.adaptor.ts
+++ b/comixed-frontend/src/app/library/adaptors/library.adaptor.ts
@@ -31,10 +31,10 @@ import { extractField } from 'app/library/library.functions';
 import { LastReadDate } from 'app/library/models/last-read-date';
 import {
   LibraryClearImageCache,
-  LibraryConsolidate,
   LibraryConvertComics,
   LibraryDeleteMultipleComics,
   LibraryGetUpdates,
+  LibraryMoveComics,
   LibraryReset,
   LibraryStartRescan
 } from 'app/library/actions/library.actions';
@@ -300,12 +300,20 @@ export class LibraryAdaptor {
     return this._converting$.asObservable();
   }
 
-  consolidate(deletePhysicalFiles: boolean): void {
+  consolidate(
+    deletePhysicalFiles: boolean,
+    targetDirectory: string,
+    renamingRule: string
+  ): void {
     this.logger.debug(
       `firing action to consolidate library: deletePhysicalFiles=${deletePhysicalFiles}`
     );
     this.store.dispatch(
-      new LibraryConsolidate({ deletePhysicalFiles: deletePhysicalFiles })
+      new LibraryMoveComics({
+        deletePhysicalFiles: deletePhysicalFiles,
+        directory: targetDirectory,
+        renamingRule: renamingRule
+      })
     );
   }
 

--- a/comixed-frontend/src/app/library/components/consolidate-library/consolidate-library.component.html
+++ b/comixed-frontend/src/app/library/components/consolidate-library/consolidate-library.component.html
@@ -1,20 +1,40 @@
-<div class='ui-g'>
-  <form [formGroup]='consolidationForm'>
-    <div class='ui-g-12'>
-      <p-checkbox id='delete-physical-files'
-                  [binary]='true'
-                  formControlName='deletePhysicalFiles'></p-checkbox>
-      <label for='delete-physical-files'>{{'consolidate-library.label.delete-physical-files'|translate}}</label>
+<div class="ui-g">
+  <form [formGroup]="consolidationForm">
+    <div class="ui-g-12">
+      <p-checkbox id="delete-physical-files"
+                  [binary]="true"
+                  formControlName="deletePhysicalFiles"></p-checkbox>
+      <label for="delete-physical-files">{{"consolidate-library.label.delete-physical-files"|translate}}</label>
     </div>
-    <div class='ui-g-12'>
-      <p>{{'consolidate-library.text.paragraph-1'|translate}}</p>
+    <div class="ui-g-12">
+      <label for="cx-target-directory"
+             class="cx-input-label">{{"consolidate-library.label.target-directory"|translate}}</label>
     </div>
-    <div class='ui-g-12 cx-container-centered-text'>
+    <div class="ui-g-12">
+      <input pInputText
+             id="cx-target-directory"
+             class="cx-input-field"
+             formControlName="targetDirectory">
+    </div>
+    <div class="ui-g-12">
+      <label for="cx-renaming-rule"
+             class="cx-input-label">{{"consolidate-library.label.renaming-rule"|translate}}</label>
+    </div>
+    <div class="ui-g-12">
+      <input pInputText
+             id="cx-renaming-rule"
+             class="cx-input-field"
+             formControlName="renamingRule">
+    </div>
+    <div class="ui-g-12">
+      <p>{{"consolidate-library.text.paragraph-1"|translate}}</p>
+    </div>
+    <div class="ui-g-12 cx-container-centered-text">
       <button pButton
-              type='button'
-              class='cx-action-button'
-              [label]='"consolidate-library.button.start"|translate'
-              (click)='consolidateLibrary()'></button>
+              type="button"
+              class="cx-action-button"
+              [label]="'consolidate-library.button.start'|translate"
+              (click)="consolidateLibrary()"></button>
     </div>
   </form>
 </div>

--- a/comixed-frontend/src/app/library/components/consolidate-library/consolidate-library.component.spec.ts
+++ b/comixed-frontend/src/app/library/components/consolidate-library/consolidate-library.component.spec.ts
@@ -38,10 +38,18 @@ import { Confirmation, ConfirmationService, MessageService } from 'primeng/api';
 import { ComicsModule } from 'app/comics/comics.module';
 import { AuthUserLoaded } from 'app/user/actions/authentication.actions';
 import { AuthenticationAdaptor, USER_ADMIN } from 'app/user';
-import { CONSOLIDATE_DELETE_PHYSICAL_FILES } from 'app/user/models/preferences.constants';
+import {
+  MOVE_COMICS_DELETE_PHYSICAL_FILE,
+  MOVE_COMICS_RENAMING_RULE,
+  MOVE_COMICS_TARGET_DIRECTORY
+} from 'app/user/models/preferences.constants';
 import { RouterTestingModule } from '@angular/router/testing';
 
 describe('ConsolidateLibraryComponent', () => {
+  const DIRECTORY = '/Users/comixedreader/Documents/comics';
+  const RENAMING_RULE =
+    '$PUBLISHER/$SERIES/$VOLUME/$SERIES v$VOLUME #$ISSUE [$COVERDATE]';
+
   let component: ConsolidateLibraryComponent;
   let fixture: ComponentFixture<ConsolidateLibraryComponent>;
   let confirmationService: ConfirmationService;
@@ -91,7 +99,7 @@ describe('ConsolidateLibraryComponent', () => {
           user: {
             ...USER_ADMIN,
             preferences: [
-              { name: CONSOLIDATE_DELETE_PHYSICAL_FILES, value: '1' }
+              { name: MOVE_COMICS_DELETE_PHYSICAL_FILE, value: '1' }
             ]
           }
         })
@@ -107,7 +115,7 @@ describe('ConsolidateLibraryComponent', () => {
           user: {
             ...USER_ADMIN,
             preferences: [
-              { name: CONSOLIDATE_DELETE_PHYSICAL_FILES, value: '0' }
+              { name: MOVE_COMICS_DELETE_PHYSICAL_FILE, value: '0' }
             ]
           }
         })
@@ -132,6 +140,12 @@ describe('ConsolidateLibraryComponent', () => {
         component.consolidationForm.controls['deletePhysicalFiles'].setValue(
           true
         );
+        component.consolidationForm.controls['targetDirectory'].setValue(
+          DIRECTORY
+        );
+        component.consolidationForm.controls['renamingRule'].setValue(
+          RENAMING_RULE
+        );
         component.consolidateLibrary();
       });
 
@@ -140,13 +154,31 @@ describe('ConsolidateLibraryComponent', () => {
       });
 
       it('calls the library adaptor', () => {
-        expect(libraryAdaptor.consolidate).toHaveBeenCalledWith(true);
+        expect(libraryAdaptor.consolidate).toHaveBeenCalledWith(
+          true,
+          DIRECTORY,
+          RENAMING_RULE
+        );
       });
 
       it('saves the delete physical files flag as a preference', () => {
         expect(authenticationAdaptor.setPreference).toHaveBeenCalledWith(
-          CONSOLIDATE_DELETE_PHYSICAL_FILES,
+          MOVE_COMICS_DELETE_PHYSICAL_FILE,
           '1'
+        );
+      });
+
+      it('saves the delete physical files flag as a preference', () => {
+        expect(authenticationAdaptor.setPreference).toHaveBeenCalledWith(
+          MOVE_COMICS_TARGET_DIRECTORY,
+          DIRECTORY
+        );
+      });
+
+      it('saves the delete physical files flag as a preference', () => {
+        expect(authenticationAdaptor.setPreference).toHaveBeenCalledWith(
+          MOVE_COMICS_RENAMING_RULE,
+          RENAMING_RULE
         );
       });
     });
@@ -156,6 +188,12 @@ describe('ConsolidateLibraryComponent', () => {
         component.consolidationForm.controls['deletePhysicalFiles'].setValue(
           false
         );
+        component.consolidationForm.controls['targetDirectory'].setValue(
+          DIRECTORY
+        );
+        component.consolidationForm.controls['renamingRule'].setValue(
+          RENAMING_RULE
+        );
         component.consolidateLibrary();
       });
 
@@ -164,13 +202,31 @@ describe('ConsolidateLibraryComponent', () => {
       });
 
       it('calls the library adaptor', () => {
-        expect(libraryAdaptor.consolidate).toHaveBeenCalledWith(false);
+        expect(libraryAdaptor.consolidate).toHaveBeenCalledWith(
+          false,
+          DIRECTORY,
+          RENAMING_RULE
+        );
       });
 
       it('saves the delete physical files flag as a preference', () => {
         expect(authenticationAdaptor.setPreference).toHaveBeenCalledWith(
-          CONSOLIDATE_DELETE_PHYSICAL_FILES,
+          MOVE_COMICS_DELETE_PHYSICAL_FILE,
           '0'
+        );
+      });
+
+      it('saves the delete physical files flag as a preference', () => {
+        expect(authenticationAdaptor.setPreference).toHaveBeenCalledWith(
+          MOVE_COMICS_TARGET_DIRECTORY,
+          DIRECTORY
+        );
+      });
+
+      it('saves the delete physical files flag as a preference', () => {
+        expect(authenticationAdaptor.setPreference).toHaveBeenCalledWith(
+          MOVE_COMICS_RENAMING_RULE,
+          RENAMING_RULE
         );
       });
     });

--- a/comixed-frontend/src/app/library/effects/library.effects.spec.ts
+++ b/comixed-frontend/src/app/library/effects/library.effects.spec.ts
@@ -25,9 +25,7 @@ import {
   LibraryClearImageCache,
   LibraryClearImageCacheFailed,
   LibraryComicsConverting,
-  LibraryConsolidate,
-  LibraryConsolidated,
-  LibraryConsolidateFailed,
+  LibraryComicsMoved,
   LibraryConvertComics,
   LibraryConvertComicsFailed,
   LibraryDeleteMultipleComics,
@@ -35,6 +33,8 @@ import {
   LibraryGetUpdates,
   LibraryGetUpdatesFailed,
   LibraryImageCacheCleared,
+  LibraryMoveComics,
+  LibraryMoveComicsFailed,
   LibraryMultipleComicsDeleted,
   LibraryRescanStarted,
   LibraryStartRescan,
@@ -61,6 +61,9 @@ describe('LibraryEffects', () => {
   const LAST_READ_DATES = [COMIC_1_LAST_READ_DATE];
   const COUNT = 25;
   const ASCENDING = false;
+  const DIRECTORY = '/Users/comixedreader/Documents/comics';
+  const RENAMING_RULE =
+    '$PUBLISHER/$SERIES/$VOLUME/$SERIES v$VOLUME #$ISSUE [$COVERDATE]';
 
   let actions$: Observable<any>;
   let effects: LibraryEffects;
@@ -347,8 +350,12 @@ describe('LibraryEffects', () => {
   describe('consolidating the library', () => {
     it('fires an action on success', () => {
       const serviceResponse = COMICS;
-      const action = new LibraryConsolidate({ deletePhysicalFiles: true });
-      const outcome = new LibraryConsolidated({ deletedComics: COMICS });
+      const action = new LibraryMoveComics({
+        deletePhysicalFiles: true,
+        directory: DIRECTORY,
+        renamingRule: RENAMING_RULE
+      });
+      const outcome = new LibraryComicsMoved();
 
       actions$ = hot('-a', { a: action });
       libraryService.consolidate.and.returnValue(of(serviceResponse));
@@ -362,8 +369,12 @@ describe('LibraryEffects', () => {
 
     it('fires an action on service failure', () => {
       const serviceResponse = new HttpErrorResponse({});
-      const action = new LibraryConsolidate({ deletePhysicalFiles: true });
-      const outcome = new LibraryConsolidateFailed();
+      const action = new LibraryMoveComics({
+        deletePhysicalFiles: true,
+        directory: DIRECTORY,
+        renamingRule: RENAMING_RULE
+      });
+      const outcome = new LibraryMoveComicsFailed();
 
       actions$ = hot('-a', { a: action });
       libraryService.consolidate.and.returnValue(throwError(serviceResponse));
@@ -376,8 +387,12 @@ describe('LibraryEffects', () => {
     });
 
     it('fires an action on general failure', () => {
-      const action = new LibraryConsolidate({ deletePhysicalFiles: true });
-      const outcome = new LibraryConsolidateFailed();
+      const action = new LibraryMoveComics({
+        deletePhysicalFiles: true,
+        directory: DIRECTORY,
+        renamingRule: RENAMING_RULE
+      });
+      const outcome = new LibraryMoveComicsFailed();
 
       actions$ = hot('-a', { a: action });
       libraryService.consolidate.and.throwError('expected');

--- a/comixed-frontend/src/app/library/library.constants.ts
+++ b/comixed-frontend/src/app/library/library.constants.ts
@@ -28,7 +28,7 @@ export const SET_DELETED_STATE_URL = `${API_ROOT_URL}/pages/hashes/deleted`;
 export const START_RESCAN_URL = `${COMIXED_API_ROOT}/comics/rescan`;
 export const DELETE_MULTIPLE_COMICS_URL = `${COMIXED_API_ROOT}/comics/multiple/delete`;
 export const CONVERT_COMICS_URL = `${COMIXED_API_ROOT}/library/convert`;
-export const CONSOLIDATE_LIBRARY_URL = `${COMIXED_API_ROOT}/library/consolidate`;
+export const CONSOLIDATE_LIBRARY_URL = `${COMIXED_API_ROOT}/library/move`;
 export const CLEAR_IMAGE_CACHE_URL = `${COMIXED_API_ROOT}/library/cache/images`;
 
 export const GET_COLLECTION_ENTRIES_URL = `${API_ROOT_URL}/collections/\${type}`;

--- a/comixed-frontend/src/app/library/models/net/consolidate-library-request.ts
+++ b/comixed-frontend/src/app/library/models/net/consolidate-library-request.ts
@@ -18,4 +18,6 @@
 
 export interface ConsolidateLibraryRequest {
   deletePhysicalFiles: boolean;
+  targetDirectory: string;
+  renamingRule: string;
 }

--- a/comixed-frontend/src/app/library/reducers/library.reducer.spec.ts
+++ b/comixed-frontend/src/app/library/reducers/library.reducer.spec.ts
@@ -27,9 +27,7 @@ import {
   LibraryClearImageCache,
   LibraryClearImageCacheFailed,
   LibraryComicsConverting,
-  LibraryConsolidate,
-  LibraryConsolidated,
-  LibraryConsolidateFailed,
+  LibraryComicsMoved,
   LibraryConvertComics,
   LibraryConvertComicsFailed,
   LibraryDeleteMultipleComics,
@@ -37,6 +35,8 @@ import {
   LibraryGetUpdates,
   LibraryGetUpdatesFailed,
   LibraryImageCacheCleared,
+  LibraryMoveComics,
+  LibraryMoveComicsFailed,
   LibraryMultipleComicsDeleted,
   LibraryRescanStarted,
   LibraryReset,
@@ -63,6 +63,9 @@ describe('Library Reducer', () => {
   const ASCENDING = true;
   const COMIC_COUNT = 2372;
   const LATEST_UPDATED_DATE = new Date();
+  const DIRECTORY = '/Users/comixedreader/Documents/comics';
+  const RENAMING_RULE =
+    '$PUBLISHER/$SERIES/$VOLUME/$SERIES v$VOLUME #$ISSUE [$COVERDATE]';
 
   let state: LibraryState;
 
@@ -368,7 +371,11 @@ describe('Library Reducer', () => {
     beforeEach(() => {
       state = reducer(
         { ...state, consolidating: false },
-        new LibraryConsolidate({ deletePhysicalFiles: true })
+        new LibraryMoveComics({
+          deletePhysicalFiles: true,
+          directory: DIRECTORY,
+          renamingRule: RENAMING_RULE
+        })
       );
     });
 
@@ -378,8 +385,6 @@ describe('Library Reducer', () => {
   });
 
   describe('when the library is consolidated', () => {
-    const DELETED_COMICS = [COMICS[2]];
-
     beforeEach(() => {
       state = reducer(
         {
@@ -387,18 +392,12 @@ describe('Library Reducer', () => {
           consolidating: true,
           comics: COMICS
         },
-        new LibraryConsolidated({ deletedComics: DELETED_COMICS })
+        new LibraryComicsMoved()
       );
     });
 
     it('clears the consolidating library flag', () => {
       expect(state.consolidating).toBeFalsy();
-    });
-
-    it('removes the deleted comics from the state', () => {
-      DELETED_COMICS.forEach(comic =>
-        expect(state.comics).not.toContain(comic)
-      );
     });
   });
 
@@ -406,7 +405,7 @@ describe('Library Reducer', () => {
     beforeEach(() => {
       state = reducer(
         { ...state, consolidating: true },
-        new LibraryConsolidateFailed()
+        new LibraryMoveComicsFailed()
       );
     });
 

--- a/comixed-frontend/src/app/library/reducers/library.reducer.ts
+++ b/comixed-frontend/src/app/library/reducers/library.reducer.ts
@@ -17,11 +17,7 @@
  */
 
 import { LibraryActions, LibraryActionTypes } from '../actions/library.actions';
-import {
-  deleteComics,
-  mergeComics,
-  mergeReadingLists
-} from 'app/library/library.functions';
+import { mergeComics, mergeReadingLists } from 'app/library/library.functions';
 import { Comic } from 'app/comics';
 import { LastReadDate } from 'app/library/models/last-read-date';
 import { ReadingList } from 'app/comics/models/reading-list';
@@ -129,15 +125,14 @@ export function reducer(
     case LibraryActionTypes.ConvertComicsFailed:
       return { ...state, convertingComics: false };
 
-    case LibraryActionTypes.Consolidate:
+    case LibraryActionTypes.MoveComics:
       return { ...state, consolidating: true };
 
-    case LibraryActionTypes.Consolidated: {
-      const comics = deleteComics(state.comics, action.payload.deletedComics);
-      return { ...state, consolidating: false, comics: comics };
+    case LibraryActionTypes.ComicsMoved: {
+      return { ...state, consolidating: false };
     }
 
-    case LibraryActionTypes.ConsolidateFailed:
+    case LibraryActionTypes.MoveComicsFailed:
       return { ...state, consolidating: false };
 
     case LibraryActionTypes.ClearImageCache:

--- a/comixed-frontend/src/app/library/services/library.service.spec.ts
+++ b/comixed-frontend/src/app/library/services/library.service.spec.ts
@@ -58,6 +58,9 @@ describe('LibraryService', () => {
   const LAST_READ_DATES = [COMIC_1_LAST_READ_DATE];
   const COMIC_COUNT = 2372;
   const LATEST_UPDATED_DATE = new Date();
+  const DIRECTORY = '/Users/comixedreader/Documents/comics';
+  const RENAMING_RULE =
+    '$PUBLISHER/$SERIES/$VOLUME/$SERIES v$VOLUME #$ISSUE [$COVERDATE]';
 
   let service: LibraryService;
   let httpMock: HttpTestingController;
@@ -158,13 +161,15 @@ describe('LibraryService', () => {
 
   it('can consolidate the library', () => {
     service
-      .consolidate(true)
+      .consolidate(true, DIRECTORY, RENAMING_RULE)
       .subscribe(response => expect(response).toEqual(COMICS));
 
     const req = httpMock.expectOne(interpolate(CONSOLIDATE_LIBRARY_URL));
     expect(req.request.method).toEqual('POST');
     expect(req.request.body).toEqual({
-      deletePhysicalFiles: true
+      deletePhysicalFiles: true,
+      targetDirectory: DIRECTORY,
+      renamingRule: RENAMING_RULE
     } as ConsolidateLibraryRequest);
     req.flush(COMICS);
   });

--- a/comixed-frontend/src/app/library/services/library.service.ts
+++ b/comixed-frontend/src/app/library/services/library.service.ts
@@ -90,12 +90,19 @@ export class LibraryService {
     } as ConvertComicsRequest);
   }
 
-  consolidate(deletePhysicalFiles: boolean): Observable<any> {
-    this.logger.debug(
-      `[POST] http request consolidate library: deletePhysicalFiles=${deletePhysicalFiles}`
-    );
+  consolidate(
+    deletePhysicalFiles: boolean,
+    targetDirectory: string,
+    renamingRule: string
+  ): Observable<any> {
+    this.logger.debug('[POST] http request consolidate library:');
+    this.logger.debug(`  deletePhysicalFiles=${deletePhysicalFiles}`);
+    this.logger.debug(`  targetDirectory=${targetDirectory}`);
+    this.logger.debug(`  renamingRule=${renamingRule}`);
     return this.http.post(interpolate(CONSOLIDATE_LIBRARY_URL), {
-      deletePhysicalFiles: deletePhysicalFiles
+      deletePhysicalFiles: deletePhysicalFiles,
+      targetDirectory: targetDirectory,
+      renamingRule: renamingRule
     } as ConsolidateLibraryRequest);
   }
 

--- a/comixed-frontend/src/app/user/effects/authentication.effects.ts
+++ b/comixed-frontend/src/app/user/effects/authentication.effects.ts
@@ -28,7 +28,7 @@ import { LoggerService } from '@angular-ru/logger';
 import { MessageService } from 'primeng/api';
 import { Observable, of } from 'rxjs';
 
-import { catchError, map, switchMap, tap } from 'rxjs/operators';
+import { catchError, map, mergeMap, switchMap, tap } from 'rxjs/operators';
 import * as AuthenticationActions from '../actions/authentication.actions';
 import {
   AuthCheckState,
@@ -176,7 +176,7 @@ export class AuthenticationEffects {
     tap(action =>
       this.logger.debug('effect: setting user preference:', action)
     ),
-    switchMap(action =>
+    mergeMap(action =>
       this.authenticationService.setPreference(action.name, action.value).pipe(
         tap(response =>
           this.logger.debug('setting user preference response:', response)

--- a/comixed-frontend/src/app/user/models/preferences.constants.ts
+++ b/comixed-frontend/src/app/user/models/preferences.constants.ts
@@ -20,8 +20,11 @@ export const LIBRARY_SORT = 'library.sort-by';
 export const LIBRARY_ROWS = 'library.rows';
 export const LIBRARY_COVER_SIZE = 'library.cover-size';
 export const LIBRARY_CURRENT_TAB = 'library.current-tab';
-export const CONSOLIDATE_DELETE_PHYSICAL_FILES =
+export const MOVE_COMICS_DELETE_PHYSICAL_FILE =
   'library.consolidate.delete-physical-file';
+export const MOVE_COMICS_TARGET_DIRECTORY =
+  'library.consolidate.target-directory';
+export const MOVE_COMICS_RENAMING_RULE = 'library.consolidate.renaming-rule';
 
 export const IMPORT_SORT = 'import.sort-by';
 export const IMPORT_ROWS = 'import.rows';

--- a/comixed-frontend/src/assets/i18n/en/library.json
+++ b/comixed-frontend/src/assets/i18n/en/library.json
@@ -407,7 +407,9 @@
   },
   "consolidate-library": {
     "label": {
-      "delete-physical-files": "Delete The Physical Comic Files."
+      "delete-physical-files": "Delete The Physical Comic Files.",
+      "target-directory": "Target directory",
+      "renaming-rule": "The renaming rule"
     },
     "button": {
       "start": "Start Consolidation"

--- a/comixed-frontend/src/assets/i18n/es/library.json
+++ b/comixed-frontend/src/assets/i18n/es/library.json
@@ -407,7 +407,9 @@
   },
   "consolidate-library": {
     "label": {
-      "delete-physical-files": "Borrar los archivos físicos de cómics."
+      "delete-physical-files": "Borrar los archivos físicos de cómics.",
+      "target-directory": "Target directory",
+      "renaming-rule": "The renaming rule"
     },
     "button": {
       "start": "Comenzar la consolidación"

--- a/comixed-frontend/src/assets/i18n/fr/library.json
+++ b/comixed-frontend/src/assets/i18n/fr/library.json
@@ -407,7 +407,9 @@
   },
   "consolidate-library": {
     "label": {
-      "delete-physical-files": "Delete The Physical Comic Files."
+      "delete-physical-files": "Delete The Physical Comic Files.",
+      "target-directory": "Target directory",
+      "renaming-rule": "The renaming rule"
     },
     "button": {
       "start": "Start Consolidation"

--- a/comixed-frontend/src/assets/i18n/pt/library.json
+++ b/comixed-frontend/src/assets/i18n/pt/library.json
@@ -407,7 +407,9 @@
   },
   "consolidate-library": {
     "label": {
-      "delete-physical-files": "Delete The Physical Comic Files."
+      "delete-physical-files": "Delete The Physical Comic Files.",
+      "target-directory": "Target directory",
+      "renaming-rule": "The renaming rule"
     },
     "button": {
       "start": "Start Consolidation"

--- a/comixed-library/src/main/java/org/comixed/repositories/comic/ComicRepository.java
+++ b/comixed-library/src/main/java/org/comixed/repositories/comic/ComicRepository.java
@@ -21,6 +21,7 @@ package org.comixed.repositories.comic;
 import java.util.Date;
 import java.util.List;
 import org.comixed.model.comic.Comic;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -103,4 +104,7 @@ public interface ComicRepository extends JpaRepository<Comic, Long> {
 
   @Query("SELECT c FROM Comic c WHERE c.dateDeleted IS NOT NULL")
   List<Comic> findAllMarkedForDeletion();
+
+  @Query("SELECT c FROM Comic c")
+  List<Comic> findComicsToMove(PageRequest page);
 }

--- a/comixed-rest-api/src/main/java/org/comixed/controller/library/LibraryController.java
+++ b/comixed-rest-api/src/main/java/org/comixed/controller/library/LibraryController.java
@@ -166,4 +166,20 @@ public class LibraryController {
 
     return new ClearImageCacheResponse(true);
   }
+
+  @PostMapping(
+      value = "/library/move",
+      produces = MediaType.APPLICATION_JSON_VALUE,
+      consumes = MediaType.APPLICATION_JSON_VALUE)
+  public MoveComicsResponse moveComics(@RequestBody() MoveComicsRequest request) {
+    String targetDirectory = request.getTargetDirectory();
+    String renamingRule = request.getRenamingRule();
+    Boolean deletePhysicalFiles = request.getDeletePhysicalFiles();
+
+    log.info("Moving comics: targetDirectory={}", targetDirectory);
+    log.info("             : renamingRule={}", renamingRule);
+    this.libraryService.moveComics(deletePhysicalFiles, targetDirectory, renamingRule);
+
+    return new MoveComicsResponse(true);
+  }
 }

--- a/comixed-rest-api/src/main/java/org/comixed/net/MoveComicsRequest.java
+++ b/comixed-rest-api/src/main/java/org/comixed/net/MoveComicsRequest.java
@@ -1,0 +1,51 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixed.net;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MoveComicsRequest {
+  @JsonProperty("deletePhysicalFiles")
+  private Boolean deletePhysicalFiles;
+
+  @JsonProperty("targetDirectory")
+  private String targetDirectory;
+
+  @JsonProperty("renamingRule")
+  private String renamingRule;
+
+  public MoveComicsRequest(
+      Boolean deletePhysicalFiles, String targetDirectory, String renamingRule) {
+    this.deletePhysicalFiles = deletePhysicalFiles;
+    this.targetDirectory = targetDirectory;
+    this.renamingRule = renamingRule;
+  }
+
+  public Boolean getDeletePhysicalFiles() {
+    return deletePhysicalFiles;
+  }
+
+  public String getTargetDirectory() {
+    return targetDirectory;
+  }
+
+  public String getRenamingRule() {
+    return renamingRule;
+  }
+}

--- a/comixed-rest-api/src/main/java/org/comixed/net/MoveComicsResponse.java
+++ b/comixed-rest-api/src/main/java/org/comixed/net/MoveComicsResponse.java
@@ -16,19 +16,19 @@
  * along with this program. If not, see <http://www.gnu.org/licenses>
  */
 
-package org.comixed.model.tasks;
+package org.comixed.net;
 
-/**
- * <code>TaskType</code> defines the list of supported tasks that can be performed.
- *
- * @author Darryl L. Pierce
- */
-public enum TaskType {
-  ADD_COMIC,
-  PROCESS_COMIC,
-  RESCAN_COMIC,
-  DELETE_COMIC,
-  DELETE_COMICS,
-  CONVERT_COMIC,
-  MOVE_COMIC;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MoveComicsResponse {
+  @JsonProperty("success")
+  private boolean success;
+
+  public MoveComicsResponse(boolean success) {
+    this.success = success;
+  }
+
+  public boolean isSuccess() {
+    return this.success;
+  }
 }

--- a/comixed-rest-api/src/test/java/org/comixed/controller/library/LibraryControllerTest.java
+++ b/comixed-rest-api/src/test/java/org/comixed/controller/library/LibraryControllerTest.java
@@ -57,6 +57,8 @@ public class LibraryControllerTest {
   private static final boolean TEST_RENAME_PAGES = RANDOM.nextBoolean();
   private static final Boolean TEST_DELETE_PHYSICAL_FILES = RANDOM.nextBoolean();
   private static final int TEST_CACHE_ENTRIES_CLEARED = RANDOM.nextInt();
+  private static final String TEST_RENAMING_RULE = "PUBLISHER/SERIES/VOLUME/SERIES vVOLUME #ISSUE";
+  private static final String TEST_DESTINATION_DIRECTORY = "/home/comixedreader/Documents/comics";
 
   @InjectMocks private LibraryController libraryController;
   @Mock private LibraryService libraryService;
@@ -254,5 +256,23 @@ public class LibraryControllerTest {
     assertFalse(result.isSuccess());
 
     Mockito.verify(libraryService, Mockito.times(1)).clearImageCache();
+  }
+
+  @Test
+  public void testMoveLibrary() {
+    Mockito.doNothing()
+        .when(libraryService)
+        .moveComics(Mockito.anyBoolean(), Mockito.anyString(), Mockito.anyString());
+
+    MoveComicsResponse result =
+        libraryController.moveComics(
+            new MoveComicsRequest(
+                TEST_DELETE_PHYSICAL_FILES, TEST_DESTINATION_DIRECTORY, TEST_RENAMING_RULE));
+
+    assertNotNull(result);
+    assertTrue(result.isSuccess());
+
+    Mockito.verify(libraryService, Mockito.times(1))
+        .moveComics(TEST_DELETE_PHYSICAL_FILES, TEST_DESTINATION_DIRECTORY, TEST_RENAMING_RULE);
   }
 }

--- a/comixed-services/src/main/java/org/comixed/service/library/LibraryService.java
+++ b/comixed-services/src/main/java/org/comixed/service/library/LibraryService.java
@@ -36,6 +36,7 @@ import org.comixed.service.task.TaskService;
 import org.comixed.service.user.ComiXedUserException;
 import org.comixed.service.user.UserService;
 import org.comixed.task.model.ConvertComicsWorkerTask;
+import org.comixed.task.model.MoveComicsWorkerTask;
 import org.comixed.task.runner.Worker;
 import org.comixed.utils.Utils;
 import org.springframework.beans.factory.ObjectFactory;
@@ -56,6 +57,7 @@ public class LibraryService {
   @Autowired private Worker worker;
   @Autowired private Utils utils;
   @Autowired private PageCacheService pageCacheService;
+  @Autowired private ObjectFactory<MoveComicsWorkerTask> moveComicsTaskObjectFactory;
 
   public List<Comic> getComicsUpdatedSince(
       String email, Date latestUpdatedDate, int maximumComics, long lastComicId) {
@@ -163,5 +165,23 @@ public class LibraryService {
     } catch (IOException error) {
       throw new LibraryException("failed to clean image cache directory", error);
     }
+  }
+
+  /**
+   * Moves all comics in the library, renaming them using the specified naming rule.
+   *
+   * @param deletePhysicalFiles
+   * @param directory the root directory
+   * @param renamingRule the name rule
+   */
+  public void moveComics(Boolean deletePhysicalFiles, String directory, String renamingRule) {
+    log.debug("Creating move comics task");
+    MoveComicsWorkerTask task = this.moveComicsTaskObjectFactory.getObject();
+    log.debug("Setting directory: {}", directory);
+    task.setDirectory(directory);
+    log.debug("Setting renaming rule: {}", renamingRule);
+    task.setRenamingRule(renamingRule);
+    log.debug("Enqueuing task");
+    this.worker.addTasksToQueue(task);
   }
 }

--- a/comixed-tasks/src/main/java/org/comixed/task/encoders/MoveComicTaskEncoder.java
+++ b/comixed-tasks/src/main/java/org/comixed/task/encoders/MoveComicTaskEncoder.java
@@ -1,0 +1,109 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixed.task.encoders;
+
+import lombok.extern.log4j.Log4j2;
+import org.comixed.model.comic.Comic;
+import org.comixed.model.tasks.Task;
+import org.comixed.model.tasks.TaskType;
+import org.comixed.repositories.tasks.TaskRepository;
+import org.comixed.task.model.MoveComicWorkerTask;
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+/**
+ * <code>MoveComicTaskEncoder</code> encodes instances of {@link MoveComicWorkerTask}.
+ *
+ * @author Darryl L. Pierce
+ */
+@Component
+@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+@Log4j2
+public class MoveComicTaskEncoder extends AbstractTaskEncoder<MoveComicWorkerTask> {
+  public static final String DIRECTORY = "destination-directory";
+  public static final String RENAMING_RULE = "renaming-rule";
+
+  @Autowired private ObjectFactory<MoveComicWorkerTask> moveComicWorkerTaskObjectFactory;
+  @Autowired private TaskRepository taskRepository;
+
+  private Comic comic;
+  private String directory;
+  private String renamingRule;
+
+  @Override
+  public Task encode() {
+    log.debug(
+        "encoding move comic task: id={} directory={} rename rule={}",
+        this.comic.getId(),
+        this.directory,
+        this.renamingRule);
+
+    Task result = new Task();
+    result.setTaskType(TaskType.MOVE_COMIC);
+    result.setComic(this.comic);
+    result.setProperty(DIRECTORY, this.directory);
+    result.setProperty(RENAMING_RULE, this.renamingRule);
+
+    return result;
+  }
+
+  @Override
+  public MoveComicWorkerTask decode(Task task) {
+    this.taskRepository.delete(task);
+
+    log.debug("Decoding move comic task: id={}", task.getId());
+
+    MoveComicWorkerTask result = this.moveComicWorkerTaskObjectFactory.getObject();
+    result.setComic(task.getComic());
+    result.setDirectory(task.getProperty(DIRECTORY));
+    result.setRenamingRule(task.getProperty(RENAMING_RULE));
+
+    return result;
+  }
+
+  /**
+   * Sets the comic to be moved.
+   *
+   * @param comic the comic
+   */
+  public void setComic(Comic comic) {
+    this.comic = comic;
+  }
+
+  /**
+   * Sets the root directory into which the comic is to be moved.
+   *
+   * @param directory the directory
+   */
+  public void setDirectory(String directory) {
+    this.directory = directory;
+  }
+
+  /**
+   * Sets the renaming rule to be applied.
+   *
+   * @param renamingRule the renaming rule
+   */
+  public void setRenamingRule(String renamingRule) {
+    this.renamingRule = renamingRule;
+  }
+}

--- a/comixed-tasks/src/main/java/org/comixed/task/model/MoveComicsWorkerTask.java
+++ b/comixed-tasks/src/main/java/org/comixed/task/model/MoveComicsWorkerTask.java
@@ -1,0 +1,98 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixed.task.model;
+
+import java.util.List;
+import lombok.extern.log4j.Log4j2;
+import org.comixed.model.comic.Comic;
+import org.comixed.repositories.comic.ComicRepository;
+import org.comixed.repositories.tasks.TaskRepository;
+import org.comixed.task.encoders.MoveComicTaskEncoder;
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+
+/**
+ * <code>MoveComicsWorkerTask</code> handles encoding instances of {@link MoveComicTask} to move
+ * individual comics.
+ *
+ * @author Darryl L. Pierce
+ */
+@Component
+@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+@Log4j2
+public class MoveComicsWorkerTask extends AbstractWorkerTask {
+  private static final int MAX_COMIC_PAGE = 50;
+
+  @Autowired private ObjectFactory<MoveComicTaskEncoder> moveComicWorkerTaskEncoderObjectFactory;
+
+  @Autowired private TaskRepository taskRepository;
+  @Autowired private ComicRepository comicRepository;
+
+  private String directory;
+  private String renamingRule;
+
+  @Override
+  protected String createDescription() {
+    return "Moving comics";
+  }
+
+  @Override
+  public void startTask() throws WorkerTaskException {
+    boolean done = false;
+    int page = 0;
+    while (!done) {
+      log.debug("Preparing to page {} of {} comics", page, MAX_COMIC_PAGE);
+      List<Comic> comics =
+          this.comicRepository.findComicsToMove(PageRequest.of(page, MAX_COMIC_PAGE + 1));
+      for (int index = 0; index < comics.size(); index++) {
+        MoveComicTaskEncoder encoder = this.moveComicWorkerTaskEncoderObjectFactory.getObject();
+
+        encoder.setComic(comics.get(index));
+        encoder.setDirectory(this.directory);
+        encoder.setRenamingRule(this.renamingRule);
+        log.debug("Saving move comic task");
+        this.taskRepository.save(encoder.encode());
+      }
+      // we're done when we've processed fewer comics than the page size
+      done = comics.size() < (MAX_COMIC_PAGE + 1);
+    }
+  }
+
+  /**
+   * Sets the directory into which the comics will be moved.
+   *
+   * @param directory the directory
+   */
+  public void setDirectory(String directory) {
+    this.directory = directory;
+  }
+
+  /**
+   * Sets the renaming rule to be used.
+   *
+   * @param renamingRule the renaming rule
+   */
+  public void setRenamingRule(String renamingRule) {
+    this.renamingRule = renamingRule;
+  }
+}

--- a/comixed-tasks/src/main/resources/task-adaptors.properties
+++ b/comixed-tasks/src/main/resources/task-adaptors.properties
@@ -8,3 +8,5 @@ task.adaptors[3].type=DeleteComic
 task.adaptors[3].name=deleteComicTaskEncoder
 task.adaptors[4].type=ConvertComic
 task.adaptors[4].name=convertComicTaskEncoder
+task.adaptors[5].type=MoveComic
+task.adaptors[5].name=moveComicTaskEncoder

--- a/comixed-tasks/src/test/java/org/comixed/task/encoders/MoveComicTaskEncoderTest.java
+++ b/comixed-tasks/src/test/java/org/comixed/task/encoders/MoveComicTaskEncoderTest.java
@@ -1,0 +1,80 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixed.task.encoders;
+
+import static junit.framework.TestCase.*;
+
+import org.comixed.model.comic.Comic;
+import org.comixed.model.tasks.Task;
+import org.comixed.repositories.tasks.TaskRepository;
+import org.comixed.task.model.MoveComicWorkerTask;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.beans.factory.ObjectFactory;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MoveComicTaskEncoderTest {
+  private static final String TEST_DIRECTORY = "/Users/comixedreader/Documents/comics";
+  private static final String TEST_RENAMING_RULE =
+      "$PUBLISHER/$SERIES/$VOLUME/$SERIES v$VOLUME #$ISSUE ($COVERDATE)";
+
+  @InjectMocks private MoveComicTaskEncoder moveComicTaskEncoder;
+  @Mock private TaskRepository taskRepository;
+  @Mock private ObjectFactory<MoveComicWorkerTask> moveComicWorkerTaskObjectFactory;
+  @Mock private MoveComicWorkerTask moveComicWorkerTask;
+  @Mock Comic comic;
+
+  @Test
+  public void testEncode() {
+    moveComicTaskEncoder.setComic(comic);
+    moveComicTaskEncoder.setDirectory(TEST_DIRECTORY);
+    moveComicTaskEncoder.setRenamingRule(TEST_RENAMING_RULE);
+
+    Task result = moveComicTaskEncoder.encode();
+
+    assertNotNull(result);
+    assertSame(comic, result.getComic());
+    assertEquals(TEST_DIRECTORY, result.getProperty(MoveComicTaskEncoder.DIRECTORY));
+    assertEquals(TEST_RENAMING_RULE, result.getProperty(MoveComicTaskEncoder.RENAMING_RULE));
+  }
+
+  @Test
+  public void testDecode() {
+    Mockito.when(moveComicWorkerTaskObjectFactory.getObject()).thenReturn(moveComicWorkerTask);
+
+    Task task = new Task();
+    task.setComic(comic);
+    task.setProperty(MoveComicTaskEncoder.DIRECTORY, TEST_DIRECTORY);
+    task.setProperty(MoveComicTaskEncoder.RENAMING_RULE, TEST_RENAMING_RULE);
+
+    MoveComicWorkerTask result = moveComicTaskEncoder.decode(task);
+
+    assertNotNull(result);
+    assertSame(moveComicWorkerTask, result);
+
+    Mockito.verify(taskRepository, Mockito.times(1)).delete(task);
+    Mockito.verify(moveComicWorkerTask, Mockito.times(1)).setComic(comic);
+    Mockito.verify(moveComicWorkerTask, Mockito.times(1)).setDirectory(TEST_DIRECTORY);
+    Mockito.verify(moveComicWorkerTask, Mockito.times(1)).setRenamingRule(TEST_RENAMING_RULE);
+  }
+}

--- a/comixed-tasks/src/test/java/org/comixed/task/model/MoveComicsWorkerTaskTest.java
+++ b/comixed-tasks/src/test/java/org/comixed/task/model/MoveComicsWorkerTaskTest.java
@@ -1,0 +1,78 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixed.task.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.comixed.model.comic.Comic;
+import org.comixed.model.tasks.Task;
+import org.comixed.repositories.comic.ComicRepository;
+import org.comixed.repositories.tasks.TaskRepository;
+import org.comixed.task.encoders.MoveComicTaskEncoder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.data.domain.PageRequest;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MoveComicsWorkerTaskTest {
+  private static final String TEST_DIRECTORY = "/users/comixedreader/Documents/comics";
+  private static final String TEST_RENAMING_RULE =
+      "$PUBLISHER/$SERIES/$VOLUME/$SERIES v$VOLUME #$ISSUE ($COVERDATE)";
+
+  @InjectMocks private MoveComicsWorkerTask moveComicsWorkerTask;
+  @Mock private ComicRepository comicRepository;
+  @Mock private ObjectFactory<MoveComicTaskEncoder> moveComicWorkerTaskEncoderObjectFactory;
+  @Mock private MoveComicTaskEncoder moveComicTaskEncoder;
+  @Mock private MoveComicWorkerTask moveComicWorkerTask;
+  @Mock private Task task;
+  @Mock private TaskRepository taskRepository;
+  @Mock private Comic comic;
+
+  private List<Comic> comicList = new ArrayList<>();
+
+  @Test
+  public void testStartTask() throws WorkerTaskException {
+    Mockito.when(moveComicWorkerTaskEncoderObjectFactory.getObject())
+        .thenReturn(moveComicTaskEncoder);
+    Mockito.when(comicRepository.findComicsToMove(Mockito.any(PageRequest.class)))
+        .thenReturn(comicList);
+    Mockito.when(moveComicTaskEncoder.encode()).thenReturn(task);
+    Mockito.when(taskRepository.save(Mockito.any(Task.class))).thenReturn(task);
+
+    for (int index = 0; index < 25; index++) comicList.add(comic);
+    moveComicsWorkerTask.setDirectory(TEST_DIRECTORY);
+    moveComicsWorkerTask.setRenamingRule(TEST_RENAMING_RULE);
+
+    moveComicsWorkerTask.startTask();
+
+    Mockito.verify(moveComicWorkerTaskEncoderObjectFactory, Mockito.times(comicList.size()))
+        .getObject();
+    Mockito.verify(moveComicTaskEncoder, Mockito.times(comicList.size())).setComic(comic);
+    Mockito.verify(moveComicTaskEncoder, Mockito.times(comicList.size()))
+        .setDirectory(TEST_DIRECTORY);
+    Mockito.verify(moveComicTaskEncoder, Mockito.times(comicList.size()))
+        .setRenamingRule(TEST_RENAMING_RULE);
+    Mockito.verify(taskRepository, Mockito.times(comicList.size())).save(task);
+  }
+}

--- a/comixed-tasks/src/test/resources/application.properties
+++ b/comixed-tasks/src/test/resources/application.properties
@@ -20,7 +20,7 @@ spring.jackson.deserialization.fail-on-unknown-properties=false
 
 # Logging
 logging.level.root=OFF
-logging.level.org.comixed=INFO
+logging.level.org.comixed=DEBUG
 
 # Comic entry loaders
 comic.entry.loaders[0].type=jpeg


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Added a new REST API for starting the moving process. Added a worker task to create individual move tasks for each comic in the library. Updated the frontend to take as input the new root directory and renaming rules, but the latter is not currently used (that's going to be in #378), so the comics are moved to a directory and filename of $ROOT/PUBLISHER/SERIES/VOLUME/SERIES vVOLUME #ISSUE.cb?