### PR TITLE
Users can set a maximum number of comics to fetch during import

### DIFF
--- a/comixed-frontend/src/app/comic-import/actions/comic-import.actions.ts
+++ b/comixed-frontend/src/app/comic-import/actions/comic-import.actions.ts
@@ -41,7 +41,7 @@ export class ComicImportSetDirectory implements Action {
 export class ComicImportGetFiles implements Action {
   readonly type = ComicImportActionTypes.GetFiles;
 
-  constructor(public payload: { directory: string }) {}
+  constructor(public payload: { directory: string; maximum: number }) {}
 }
 
 export class ComicImportFilesReceived implements Action {

--- a/comixed-frontend/src/app/comic-import/adaptors/comic-import.adaptor.spec.ts
+++ b/comixed-frontend/src/app/comic-import/adaptors/comic-import.adaptor.spec.ts
@@ -52,6 +52,7 @@ describe('ComicImportAdaptor', () => {
   const DIRECTORY = '/Users/comixedreader/Library';
   const COMIC_FILES = [COMIC_FILE_1, COMIC_FILE_3];
   const COMIC_FILE = COMIC_FILE_2;
+  const MAXIMUM = 13;
 
   let adaptor: ComicImportAdaptor;
   let store: Store<AppState>;
@@ -99,12 +100,12 @@ describe('ComicImportAdaptor', () => {
 
   describe('getting comic files', () => {
     beforeEach(() => {
-      adaptor.getComicFiles(DIRECTORY);
+      adaptor.getComicFiles(DIRECTORY, MAXIMUM);
     });
 
     it('fires an action', () => {
       expect(store.dispatch).toHaveBeenCalledWith(
-        new ComicImportGetFiles({ directory: DIRECTORY })
+        new ComicImportGetFiles({ directory: DIRECTORY, maximum: MAXIMUM })
       );
     });
 

--- a/comixed-frontend/src/app/comic-import/adaptors/comic-import.adaptor.ts
+++ b/comixed-frontend/src/app/comic-import/adaptors/comic-import.adaptor.ts
@@ -82,8 +82,10 @@ export class ComicImportAdaptor {
     return this._directory$.asObservable();
   }
 
-  getComicFiles(directory: string) {
-    this.store.dispatch(new ComicImportGetFiles({ directory: directory }));
+  getComicFiles(directory: string, maximum: number) {
+    this.store.dispatch(
+      new ComicImportGetFiles({ directory: directory, maximum: maximum })
+    );
   }
 
   get fetchingComicFile$(): Observable<boolean> {

--- a/comixed-frontend/src/app/comic-import/comic-import.constants.ts
+++ b/comixed-frontend/src/app/comic-import/comic-import.constants.ts
@@ -20,3 +20,6 @@ import { API_ROOT_URL } from 'app/app.functions';
 
 export const GET_COMIC_FILES_URL = `${API_ROOT_URL}/files/contents`;
 export const START_IMPORT_URL = `${API_ROOT_URL}/files/import`;
+
+export const COMIC_IMPORT_DIRECTORY = 'import-directory';
+export const COMIC_IMPORT_MAXIMUM = 'import-maximum-results';

--- a/comixed-frontend/src/app/comic-import/components/comic-file-list-toolbar/comic-file-list-toolbar.component.html
+++ b/comixed-frontend/src/app/comic-import/components/comic-file-list-toolbar/comic-file-list-toolbar.component.html
@@ -1,75 +1,78 @@
-<p-toolbar id='importing-toolbar'>
-    <div class='ui-inputgroup'>
-        <input id='directory-input'
-               pInputText
-               [(ngModel)]='directory'
-               [disabled]='busy'
-               [placeholder]='"import-toolbar.text.directory-placeholder"|translate'
-               [style.width]='"100%"'
-               type='text'/>
-        <button (click)='findComics()'
-                [disabled]='busy||!directory||!directory.length'
-                [label]='"import-toolbar.button.find"|translate'
-                icon='fa fa-fw fa-search'
-                id='find-comics'
-                pButton
-                type='button'></button>
-    </div>
+<p-toolbar id="importing-toolbar">
+  <div class="ui-inputgroup">
+    <input id="directory-input"
+           pInputText
+           [(ngModel)]="directory"
+           [disabled]="busy"
+           [placeholder]="'import-toolbar.text.directory-placeholder'|translate"
+           [style.width]="'100%'"
+           type="text"/>
+    <button (click)="findComics()"
+            [disabled]="busy||!directory||!directory.length"
+            [label]="'import-toolbar.button.find'|translate"
+            icon="fa fa-fw fa-search"
+            id="find-comics"
+            pButton
+            type="button"></button>
+  </div>
 </p-toolbar>
 <p-toolbar>
-    <div class='ui-toolbar-group-left'>
-        <button pButton
-                [icon]='gridLayout?"fa fa-fw fa-th":"fa fa-fw fa-list"'
-                (click)='setGridLayout(!gridLayout)'
-                [pTooltip]='"import-toolbar.tooltip."+(gridLayout?"grid":"list")+"-layout"|translate'></button>
-        <p-dropdown (onChange)='setSortField($event.value)'
-                    [(ngModel)]='sortField'
-                    [options]='sortFieldOptions'
-                    styleClass='cx-layout-dropdown'></p-dropdown>
-        <p-dropdown (onChange)='setComicsShown($event.value)'
-                    [(ngModel)]='rows'
-                    [options]='rowOptions'
-                    styleClass='cx-layout-dropdown'></p-dropdown>
-        <p-checkbox (onChange)='useSameHeight($event)'
-                    [(ngModel)]='sameHeight'
-                    [label]='"library-contents.options.cover-size.same-height"|translate'
-                    binary='true'></p-checkbox>
-        <p-slider (onChange)='setCoverSize($event.value)'
-                  (onSlideEnd)='saveCoverSize($event.value)'
-                  [(ngModel)]='coverSize'
-                  [max]='400'
-                  [min]='100'></p-slider>
-        {{"library-contents.label.cover-size"|translate: {cover_size: coverSize} }}
-    </div>
-    <div class='ui-toolbar-group-right'>
-        <button pButton
-                type='button'
-                (click)='toggleBlockedPages()'
-                [icon]='deleteBlockedPages?"fa fa-fw fas fa-ban":"fa fa-fw far fa-stop-circle"'
-                [pTooltip]='"import-toolbar.tooltip."+(deleteBlockedPages?"delete-blocked-pages":"allow-blocked-pages")|translate'
-                class='cx-toolbar-button'
-                [class.ui-button-danger]='deleteBlockedPages'
-                [class.ui-button-success]='!deleteBlockedPages'></button>
-        <button (click)='selectAllComicFiles()'
-                [disabled]='!comicFiles.length||selectedComicFiles.length === comicFiles.length'
-                icon='fa fa-fw fa-plus'
-                [pTooltip]='"toolbar.tooltip.select-all"|translate'
-                class='ui-button-secondary cx-toolbar-button'
-                id='select-all-comics'
-                pButton
-                type='button'></button>
-        <button (click)='deselectAllComicFiles()'
-                [disabled]='selectedComicFiles.length === 0'
-                icon='fa fa-fw fa-minus'
-                [pTooltip]='"toolbar.tooltip.deselect-all"|translate'
-                class='ui-button-danger cx-toolbar-button'
-                id='deselect-all-comics'
-                pButton
-                type='button'></button>
-        <p-splitButton [model]='importOptions'
-                       [disabled]='selectedComicFiles.length === 0'
-                       icon='fa fa-fw fa-play'
-                       [pTooltip]='"import-toolbar.tooltip.start-import"|translate'
-                       class='cx-toolbar-button'></p-splitButton>
-    </div>
+  <div class="ui-toolbar-group-left">
+    <button pButton
+            [icon]="gridLayout?'fa fa-fw fa-th':'fa fa-fw fa-list'"
+            (click)="setGridLayout(!gridLayout)"
+            [pTooltip]="'import-toolbar.tooltip.'+(gridLayout?'grid':'list')+'-layout'|translate"></button>
+    <p-dropdown (onChange)="setSortField($event.value)"
+                [(ngModel)]="sortField"
+                [options]="sortFieldOptions"
+                styleClass="cx-layout-dropdown"></p-dropdown>
+    <p-dropdown (onChange)="setComicsShown($event.value)"
+                [(ngModel)]="rows"
+                [options]="rowOptions"
+                styleClass="cx-layout-dropdown"></p-dropdown>
+    <p-dropdown (onChange)="setMaximum($event.value)"
+                [options]='maximumOptions'
+                [(ngModel)]='maximum'></p-dropdown>
+    <p-checkbox (onChange)="useSameHeight($event)"
+                [(ngModel)]="sameHeight"
+                [label]="'library-contents.options.cover-size.same-height'|translate"
+                binary="true"></p-checkbox>
+    <p-slider (onChange)="setCoverSize($event.value)"
+              (onSlideEnd)="saveCoverSize($event.value)"
+              [(ngModel)]="coverSize"
+              [max]="400"
+              [min]="100"></p-slider>
+    {{'library-contents.label.cover-size'|translate: {cover_size: coverSize} }}
+  </div>
+  <div class="ui-toolbar-group-right">
+    <button pButton
+            type="button"
+            (click)="toggleBlockedPages()"
+            [icon]="deleteBlockedPages?'fa fa-fw fas fa-ban':'fa fa-fw far fa-stop-circle'"
+            [pTooltip]="'import-toolbar.tooltip.'+(deleteBlockedPages?'delete-blocked-pages':'allow-blocked-pages')|translate"
+            class="cx-toolbar-button"
+            [class.ui-button-danger]="deleteBlockedPages"
+            [class.ui-button-success]="!deleteBlockedPages"></button>
+    <button (click)="selectAllComicFiles()"
+            [disabled]="!comicFiles.length||selectedComicFiles.length === comicFiles.length"
+            icon="fa fa-fw fa-plus"
+            [pTooltip]="'toolbar.tooltip.select-all'|translate"
+            class="ui-button-secondary cx-toolbar-button"
+            id="select-all-comics"
+            pButton
+            type="button"></button>
+    <button (click)="deselectAllComicFiles()"
+            [disabled]="selectedComicFiles.length === 0"
+            icon="fa fa-fw fa-minus"
+            [pTooltip]="'toolbar.tooltip.deselect-all'|translate"
+            class="ui-button-danger cx-toolbar-button"
+            id="deselect-all-comics"
+            pButton
+            type="button"></button>
+    <p-splitButton [model]="importOptions"
+                   [disabled]="selectedComicFiles.length === 0"
+                   icon="fa fa-fw fa-play"
+                   [pTooltip]="'import-toolbar.tooltip.start-import'|translate"
+                   class="cx-toolbar-button"></p-splitButton>
+  </div>
 </p-toolbar>

--- a/comixed-frontend/src/app/comic-import/components/comic-file-list-toolbar/comic-file-list-toolbar.component.spec.ts
+++ b/comixed-frontend/src/app/comic-import/components/comic-file-list-toolbar/comic-file-list-toolbar.component.spec.ts
@@ -53,12 +53,14 @@ import {
   ToolbarModule
 } from 'primeng/primeng';
 import { ComicFileListToolbarComponent } from './comic-file-list-toolbar.component';
+import { COMIC_IMPORT_MAXIMUM } from 'app/comic-import/comic-import.constants';
 
 const DIRECTORY_TO_SEARCH = '/Users/comixed/library';
 
 describe('ComicFileListToolbarComponent', () => {
   const DIRECTORY = '/home/comixed/Documents/comics';
   const COMIC_FILES = [COMIC_FILE_1, COMIC_FILE_2, COMIC_FILE_3, COMIC_FILE_4];
+  const MAXIMUM = 31;
 
   let component: ComicFileListToolbarComponent;
   let fixture: ComponentFixture<ComicFileListToolbarComponent>;
@@ -66,6 +68,7 @@ describe('ComicFileListToolbarComponent', () => {
   let translateService: TranslateService;
   let confirmationService: ConfirmationService;
   let libraryDisplayAdaptor: LibraryDisplayAdaptor;
+  let authenticationAdaptor: AuthenticationAdaptor;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -105,6 +108,8 @@ describe('ComicFileListToolbarComponent', () => {
     translateService = TestBed.get(TranslateService);
     confirmationService = TestBed.get(ConfirmationService);
     libraryDisplayAdaptor = TestBed.get(LibraryDisplayAdaptor);
+    authenticationAdaptor = TestBed.get(AuthenticationAdaptor);
+    spyOn(authenticationAdaptor, 'setPreference');
 
     fixture.detectChanges();
   }));
@@ -138,11 +143,15 @@ describe('ComicFileListToolbarComponent', () => {
     beforeEach(() => {
       spyOn(comicImportAdaptor, 'getComicFiles');
       component.directory = DIRECTORY;
+      component.maximum = MAXIMUM;
       component.findComics();
     });
 
     it('invokes the adaptor', () => {
-      expect(comicImportAdaptor.getComicFiles).toHaveBeenCalledWith(DIRECTORY);
+      expect(comicImportAdaptor.getComicFiles).toHaveBeenCalledWith(
+        DIRECTORY,
+        MAXIMUM
+      );
     });
   });
 
@@ -299,6 +308,19 @@ describe('ComicFileListToolbarComponent', () => {
           component.deleteBlockedPages
         );
       });
+    });
+  });
+
+  describe('setting the maximum comics value', () => {
+    beforeEach(() => {
+      component.setMaximum(MAXIMUM);
+    });
+
+    it('saves the user preference', () => {
+      expect(authenticationAdaptor.setPreference).toHaveBeenCalledWith(
+        COMIC_IMPORT_MAXIMUM,
+        `${MAXIMUM}`
+      );
     });
   });
 });

--- a/comixed-frontend/src/app/comic-import/components/comic-file-list-toolbar/comic-file-list-toolbar.component.ts
+++ b/comixed-frontend/src/app/comic-import/components/comic-file-list-toolbar/comic-file-list-toolbar.component.ts
@@ -31,6 +31,11 @@ import { LibraryDisplayAdaptor } from 'app/library';
 import { ComicFile } from 'app/comic-import/models/comic-file';
 import { ComicImportAdaptor } from 'app/comic-import/adaptors/comic-import.adaptor';
 import { Subscription } from 'rxjs';
+import {
+  COMIC_IMPORT_DIRECTORY,
+  COMIC_IMPORT_MAXIMUM
+} from 'app/comic-import/comic-import.constants';
+import { LoggerService } from '@angular-ru/logger';
 
 @Component({
   selector: 'app-comic-file-list-toolbar',
@@ -65,8 +70,11 @@ export class ComicFileListToolbarComponent implements OnInit, OnDestroy {
   coverSizeSubscription: Subscription;
   coverSize: number;
   deleteBlockedPages = false;
+  maximumOptions: SelectItem[] = [];
+  maximum = 0;
 
   constructor(
+    private logger: LoggerService,
     private authenticationAdaptor: AuthenticationAdaptor,
     private libraryDisplayAdaptor: LibraryDisplayAdaptor,
     private comicImportAdaptor: ComicImportAdaptor,
@@ -80,9 +88,13 @@ export class ComicFileListToolbarComponent implements OnInit, OnDestroy {
         this.loadTranslations();
       }
     );
-    this.loadSortFieldOptions();
-    this.loadRowsOptions();
-    this.loadImportOptions();
+    this.loadTranslations();
+    this.authenticationAdaptor.user$.subscribe(user => {
+      this.maximum = parseInt(
+        this.authenticationAdaptor.getPreference(COMIC_IMPORT_MAXIMUM) || '0',
+        10
+      );
+    });
     this.layoutSubscription = this.libraryDisplayAdaptor.layout$.subscribe(
       layout => (this.gridLayout = layout === 'grid')
     );
@@ -111,10 +123,10 @@ export class ComicFileListToolbarComponent implements OnInit, OnDestroy {
 
   findComics(): void {
     this.authenticationAdaptor.setPreference(
-      'import.directory',
+      COMIC_IMPORT_DIRECTORY,
       this.directory
     );
-    this.comicImportAdaptor.getComicFiles(this.directory);
+    this.comicImportAdaptor.getComicFiles(this.directory, this.maximum);
   }
 
   selectAllComicFiles(): void {
@@ -216,6 +228,7 @@ export class ComicFileListToolbarComponent implements OnInit, OnDestroy {
     this.loadSortFieldOptions();
     this.loadRowsOptions();
     this.loadImportOptions();
+    this.loadMaximumOptions();
   }
 
   startImport(withMetadata: boolean): void {
@@ -242,5 +255,39 @@ export class ComicFileListToolbarComponent implements OnInit, OnDestroy {
     const layout = useGridLayout ? 'grid' : 'list';
     this.libraryDisplayAdaptor.setLayout(layout);
     this.dataView.changeLayout(layout);
+  }
+
+  private loadMaximumOptions() {
+    this.maximumOptions = [
+      {
+        label: this.translateService.instant(
+          'comic-file-list-toolbar.options.maximum.unlimited'
+        ),
+        value: 0
+      },
+      {
+        label: this.translateService.instant(
+          'comic-file-list-toolbar.options.maximum.50-comics'
+        ),
+        value: 50
+      },
+      {
+        label: this.translateService.instant(
+          'comic-file-list-toolbar.options.maximum.100-comics'
+        ),
+        value: 100
+      },
+      {
+        label: this.translateService.instant(
+          'comic-file-list-toolbar.options.maximum.1000-comics'
+        ),
+        value: 1000
+      }
+    ];
+  }
+
+  setMaximum(value: number): void {
+    this.logger.debug(`setting maximum import values: ${value}`);
+    this.authenticationAdaptor.setPreference(COMIC_IMPORT_MAXIMUM, `${value}`);
   }
 }

--- a/comixed-frontend/src/app/comic-import/effects/comic-import.effects.spec.ts
+++ b/comixed-frontend/src/app/comic-import/effects/comic-import.effects.spec.ts
@@ -38,11 +38,13 @@ import { MessageService } from 'primeng/api';
 import { Observable, of, throwError } from 'rxjs';
 
 import { ComicImportEffects } from './comic-import.effects';
+import { LoggerModule } from '@angular-ru/logger';
 import objectContaining = jasmine.objectContaining;
 
 describe('ComicImportEffects', () => {
   const DIRECTORY = '/Users/comixedreader/Library';
   const COMIC_FILES = [COMIC_FILE_1, COMIC_FILE_3];
+  const MAXIMUM = 23;
 
   let actions$: Observable<any>;
   let effects: ComicImportEffects;
@@ -51,7 +53,7 @@ describe('ComicImportEffects', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot()],
+      imports: [TranslateModule.forRoot(), LoggerModule.forRoot()],
       providers: [
         ComicImportEffects,
         provideMockActions(() => actions$),
@@ -79,7 +81,10 @@ describe('ComicImportEffects', () => {
   describe('getting comic files', () => {
     it('fires an action on success', () => {
       const serviceResponse = COMIC_FILES;
-      const action = new ComicImportGetFiles({ directory: DIRECTORY });
+      const action = new ComicImportGetFiles({
+        directory: DIRECTORY,
+        maximum: MAXIMUM
+      });
       const outcome = new ComicImportFilesReceived({ comicFiles: COMIC_FILES });
 
       actions$ = hot('-a', { a: action });
@@ -94,7 +99,10 @@ describe('ComicImportEffects', () => {
 
     it('fires an action on service failure', () => {
       const serviceResponse = new HttpErrorResponse({});
-      const action = new ComicImportGetFiles({ directory: DIRECTORY });
+      const action = new ComicImportGetFiles({
+        directory: DIRECTORY,
+        maximum: MAXIMUM
+      });
       const outcome = new ComicImportGetFilesFailed();
 
       actions$ = hot('-a', { a: action });
@@ -108,7 +116,10 @@ describe('ComicImportEffects', () => {
     });
 
     it('fires an action on general failure', () => {
-      const action = new ComicImportGetFiles({ directory: DIRECTORY });
+      const action = new ComicImportGetFiles({
+        directory: DIRECTORY,
+        maximum: MAXIMUM
+      });
       const outcome = new ComicImportGetFilesFailed();
 
       actions$ = hot('-a', { a: action });

--- a/comixed-frontend/src/app/comic-import/models/net/get-comic-files-request.ts
+++ b/comixed-frontend/src/app/comic-import/models/net/get-comic-files-request.ts
@@ -18,4 +18,5 @@
 
 export interface GetComicFilesRequest {
   directory: string;
+  maximum: number;
 }

--- a/comixed-frontend/src/app/comic-import/pages/import-page/import-page.component.html
+++ b/comixed-frontend/src/app/comic-import/pages/import-page/import-page.component.html
@@ -1,19 +1,19 @@
-<h2 *ngIf='!comicFiles.length && !importing'>{{'import-page.title-no-comics'|translate}}</h2>
-<h2 *ngIf='comicFiles.length && !importing'>{{'import-page.title-with-comics'|translate:{
+<h2 *ngIf="!comicFiles.length && !importing">{{"import-page.title-no-comics"|translate}}</h2>
+<h2 *ngIf="comicFiles.length && !importing">{{"import-page.title-with-comics"|translate:{
     comicCount: comicFiles.length,
     selectedCount: selectedComicFiles.length
 } }}</h2>
-<div *ngIf='importing'
-     id='import-busy-indicator-container'>
-    <h2>{{'import-page.importing-title'|translate:{count: importCount} }}</h2>
+<div *ngIf="importing"
+     id="import-busy-indicator-container">
+  <h2>{{"import-page.importing-title"|translate:{count: importCount} }}</h2>
 </div>
-<p-progressBar *ngIf='importing||fetchingFiles'
-               mode='indeterminate'></p-progressBar>
-<div *ngIf='!importing'
-     id='comic-file-list-container'>
-    <app-comic-file-list [busy]='fetchingFiles'
-                         [comicFiles]="comicFiles"
-                         [directory]='user | user_preference: "import.directory"'
-                         [selectedComicFiles]="selectedComicFiles"
-                         id='comic-file-list'></app-comic-file-list>
+<p-progressBar *ngIf="importing||fetchingFiles"
+               mode="indeterminate"></p-progressBar>
+<div *ngIf="!importing"
+     id="comic-file-list-container">
+  <app-comic-file-list id="comic-file-list"
+                       [busy]="fetchingFiles"
+                       [comicFiles]='comicFiles'
+                       [directory]="user | user_preference: 'import.directory'"
+                       [selectedComicFiles]='selectedComicFiles'></app-comic-file-list>
 </div>

--- a/comixed-frontend/src/app/comic-import/pages/import-page/import-page.component.ts
+++ b/comixed-frontend/src/app/comic-import/pages/import-page/import-page.component.ts
@@ -188,11 +188,6 @@ export class ImportPageComponent implements OnInit, OnDestroy {
     );
   }
 
-  retrieveFiles(directory: string): void {
-    this.authenticationAdaptor.setPreference(IMPORT_LAST_DIRECTORY, directory);
-    this.comicImportAdaptor.getComicFiles(directory);
-  }
-
   toggleSelectAll(select: boolean): void {
     if (select) {
       this.selectComicFiles(this.comicFiles);

--- a/comixed-frontend/src/app/comic-import/reducers/comic-import.reducer.spec.ts
+++ b/comixed-frontend/src/app/comic-import/reducers/comic-import.reducer.spec.ts
@@ -42,6 +42,7 @@ import {
 describe('ComicImport Reducer', () => {
   const DIRECTORY = '/Users/comixedreader/Library';
   const COMIC_FILES = [COMIC_FILE_1, COMIC_FILE_3];
+  const MAXIMUM = 17;
 
   let state: ComicImportState;
 
@@ -92,7 +93,7 @@ describe('ComicImport Reducer', () => {
     beforeEach(() => {
       state = reducer(
         { ...state, fetchingFiles: false },
-        new ComicImportGetFiles({ directory: DIRECTORY })
+        new ComicImportGetFiles({ directory: DIRECTORY, maximum: MAXIMUM })
       );
     });
 

--- a/comixed-frontend/src/app/comic-import/services/comic-import.service.spec.ts
+++ b/comixed-frontend/src/app/comic-import/services/comic-import.service.spec.ts
@@ -40,6 +40,7 @@ import { LoggerModule } from '@angular-ru/logger';
 describe('ComicImportService', () => {
   const DIRECTORY = '/Users/comixedreader/Library';
   const COMIC_FILES = [COMIC_FILE_1, COMIC_FILE_3];
+  const MAXIMUM = 29;
 
   let service: ComicImportService;
   let httpMock: HttpTestingController;
@@ -60,13 +61,14 @@ describe('ComicImportService', () => {
 
   it('can get comic files under a root directory', () => {
     service
-      .getFiles(DIRECTORY)
+      .getFiles(DIRECTORY, MAXIMUM)
       .subscribe(response => expect(response).toEqual(COMIC_FILES));
 
     const req = httpMock.expectOne(interpolate(GET_COMIC_FILES_URL));
     expect(req.request.method).toEqual('POST');
     expect(req.request.body).toEqual({
-      directory: DIRECTORY
+      directory: DIRECTORY,
+      maximum: MAXIMUM
     } as GetComicFilesRequest);
     req.flush(COMIC_FILES);
   });

--- a/comixed-frontend/src/app/comic-import/services/comic-import.service.ts
+++ b/comixed-frontend/src/app/comic-import/services/comic-import.service.ts
@@ -34,9 +34,10 @@ import { StartImportRequest } from 'app/comic-import/models/net/start-import-req
 export class ComicImportService {
   constructor(private http: HttpClient) {}
 
-  getFiles(directory: string): Observable<any> {
+  getFiles(directory: string, maximum: number): Observable<any> {
     return this.http.post(interpolate(GET_COMIC_FILES_URL), {
-      directory: directory
+      directory: directory,
+      maximum: maximum
     } as GetComicFilesRequest);
   }
 

--- a/comixed-frontend/src/assets/i18n/en/comic-import.json
+++ b/comixed-frontend/src/assets/i18n/en/comic-import.json
@@ -26,6 +26,12 @@
       "import": {
         "with-metadata": "With Metadata",
         "without-metadata": "Without Metadata"
+      },
+      "maximum": {
+        "unlimited": "All Comics",
+        "50-comics": "50 Comics",
+        "100-comics": "100 Comics",
+        "1000-comics": "1000 Comics"
       }
     },
     "start-import": {

--- a/comixed-frontend/src/assets/i18n/es/comic-import.json
+++ b/comixed-frontend/src/assets/i18n/es/comic-import.json
@@ -26,6 +26,12 @@
       "import": {
         "with-metadata": "Con metadatos",
         "without-metadata": "Sin metadatos"
+      },
+      "maximum": {
+        "unlimited": "All Comics",
+        "50-comics": "50 Comics",
+        "100-comics": "100 Comics",
+        "1000-comics": "1000 Comics"
       }
     },
     "start-import": {

--- a/comixed-frontend/src/assets/i18n/fr/comic-import.json
+++ b/comixed-frontend/src/assets/i18n/fr/comic-import.json
@@ -26,6 +26,12 @@
       "import": {
         "with-metadata": "With Metadata",
         "without-metadata": "Without Metadata"
+      },
+      "maximum": {
+        "unlimited": "All Comics",
+        "50-comics": "50 Comics",
+        "100-comics": "100 Comics",
+        "1000-comics": "1000 Comics"
       }
     },
     "start-import": {

--- a/comixed-frontend/src/assets/i18n/pt/comic-import.json
+++ b/comixed-frontend/src/assets/i18n/pt/comic-import.json
@@ -26,6 +26,12 @@
       "import": {
         "with-metadata": "With Metadata",
         "without-metadata": "Without Metadata"
+      },
+      "maximum": {
+        "unlimited": "All Comics",
+        "50-comics": "50 Comics",
+        "100-comics": "100 Comics",
+        "1000-comics": "1000 Comics"
       }
     },
     "start-import": {

--- a/comixed-rest-api/src/main/java/org/comixed/controller/file/FileController.java
+++ b/comixed-rest-api/src/main/java/org/comixed/controller/file/FileController.java
@@ -62,9 +62,15 @@ public class FileController {
   @Secured("ROLE_ADMIN")
   public List<FileDetails> getAllComicsUnder(@RequestBody() final GetAllComicsUnderRequest request)
       throws IOException, JSONException {
-    log.info("Getting all comic files: root={}", request.getDirectory());
+    String directory = request.getDirectory();
+    Integer maximum = request.getMaximum();
 
-    final List<FileDetails> result = this.fileService.getAllComicsUnder(request.getDirectory());
+    log.info(
+        "Getting all comic files: root={} maximum={}",
+        directory,
+        maximum > 0 ? maximum : "UNLIMITED");
+
+    final List<FileDetails> result = this.fileService.getAllComicsUnder(directory, maximum);
 
     log.info("Returning {} file{}", result.size(), result.size() != 1 ? "s" : "");
 

--- a/comixed-rest-api/src/main/java/org/comixed/net/GetAllComicsUnderRequest.java
+++ b/comixed-rest-api/src/main/java/org/comixed/net/GetAllComicsUnderRequest.java
@@ -20,21 +20,41 @@ package org.comixed.net;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * <code>GetAllComicsUnderRequest</code> represents the request body during comic file imports.
+ *
+ * @author Darryl L. Pierce
+ */
 public class GetAllComicsUnderRequest {
   @JsonProperty("directory")
   private String directory;
 
+  @JsonProperty("maximum")
+  private Integer maximum;
+
   public GetAllComicsUnderRequest() {}
 
-  public GetAllComicsUnderRequest(final String directory) {
+  public GetAllComicsUnderRequest(final String directory, final Integer maximum) {
     this.directory = directory;
+    this.maximum = maximum;
   }
 
+  /**
+   * The root directory to be searched.
+   *
+   * @return the directory
+   */
   public String getDirectory() {
     return directory;
   }
 
-  public void setDirectory(final String directory) {
-    this.directory = directory;
+  /**
+   * The maximum number of comics to find. If the value is zero then then all comics found are
+   * returned.
+   *
+   * @return the maximum
+   */
+  public Integer getMaximum() {
+    return maximum;
   }
 }

--- a/comixed-rest-api/src/test/java/org/comixed/controller/file/FileControllerTest.java
+++ b/comixed-rest-api/src/test/java/org/comixed/controller/file/FileControllerTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
+import java.util.Random;
 import org.comixed.adaptors.archive.ArchiveAdaptorException;
 import org.comixed.handlers.ComicFileHandlerException;
 import org.comixed.model.file.FileDetails;
@@ -43,14 +44,15 @@ import org.springframework.boot.test.context.SpringBootTest;
 @RunWith(MockitoJUnitRunner.class)
 @SpringBootTest
 public class FileControllerTest {
-  private static final String COVER_IMAGE_FILENAME = "coverimage.png";
+  private static final Random RANDOM = new Random();
   private static final String COMIC_ARCHIVE = "testcomic.cbz";
   private static final byte[] IMAGE_CONTENT = new byte[65535];
-  private static final String TEST_FILE = "src/test/resources/example.cbz";
   private static final String TEST_DIRECTORY = "src/test";
   private static final String[] TEST_FILENAMES =
       new String[] {"First.cbz", "Second.cbz", "Third.cbr", "Fourth.cb7"};
   private static final int TEST_IMPORT_STATUS = 129;
+  private static final Integer TEST_LIMIT = RANDOM.nextInt();
+  private static final Integer TEST_NO_LIMIT = -1;
 
   @InjectMocks private FileController controller;
   @Mock private FileService fileService;
@@ -69,16 +71,31 @@ public class FileControllerTest {
   }
 
   @Test
-  public void testGetAllComicsUnder() throws IOException, JSONException {
-    Mockito.when(fileService.getAllComicsUnder(Mockito.anyString())).thenReturn(fileDetailsList);
+  public void testGetAllComicsUnderNoLimit() throws IOException, JSONException {
+    Mockito.when(fileService.getAllComicsUnder(Mockito.anyString(), Mockito.anyInt()))
+        .thenReturn(fileDetailsList);
 
     final List<FileDetails> result =
-        controller.getAllComicsUnder(new GetAllComicsUnderRequest(TEST_DIRECTORY));
+        controller.getAllComicsUnder(new GetAllComicsUnderRequest(TEST_DIRECTORY, TEST_NO_LIMIT));
 
     assertNotNull(result);
     assertSame(fileDetailsList, result);
 
-    Mockito.verify(fileService, Mockito.times(1)).getAllComicsUnder(TEST_DIRECTORY);
+    Mockito.verify(fileService, Mockito.times(1)).getAllComicsUnder(TEST_DIRECTORY, TEST_NO_LIMIT);
+  }
+
+  @Test
+  public void testGetAllComicsUnder() throws IOException, JSONException {
+    Mockito.when(fileService.getAllComicsUnder(Mockito.anyString(), Mockito.anyInt()))
+        .thenReturn(fileDetailsList);
+
+    final List<FileDetails> result =
+        controller.getAllComicsUnder(new GetAllComicsUnderRequest(TEST_DIRECTORY, TEST_LIMIT));
+
+    assertNotNull(result);
+    assertSame(fileDetailsList, result);
+
+    Mockito.verify(fileService, Mockito.times(1)).getAllComicsUnder(TEST_DIRECTORY, TEST_LIMIT);
   }
 
   @Test

--- a/comixed-services/src/test/java/org/comixed/service/file/FileServiceTest.java
+++ b/comixed-services/src/test/java/org/comixed/service/file/FileServiceTest.java
@@ -57,6 +57,8 @@ public class FileServiceTest {
       TEST_ROOT_DIRECTORY + "/" + TEST_ARCHIVE_FILENAME;
   private static final String[] TEST_FILENAMES =
       new String[] {"First.cbz", "Second.cbz", "Third.cbr", "Fourth.cb7"};
+  private static final Integer TEST_LIMIT = 2;
+  private static final Integer TEST_NO_LIMIT = -1;
 
   @InjectMocks private FileService service;
   @Mock private ComicFileHandler comicFileHandler;
@@ -114,7 +116,7 @@ public class FileServiceTest {
   @Test
   public void testGetAllComicsUnderInvalidDirectory() throws IOException {
     final List<FileDetails> result =
-        service.getAllComicsUnder(TEST_ROOT_DIRECTORY + "/nonexistent");
+        service.getAllComicsUnder(TEST_ROOT_DIRECTORY + "/nonexistent", TEST_LIMIT);
 
     assertNotNull(result);
     assertTrue(result.isEmpty());
@@ -122,7 +124,7 @@ public class FileServiceTest {
 
   @Test
   public void testGetAllComicsUnderWithFileSupplied() throws IOException {
-    final List<FileDetails> result = service.getAllComicsUnder(TEST_COMIC_ARCHIVE);
+    final List<FileDetails> result = service.getAllComicsUnder(TEST_COMIC_ARCHIVE, TEST_LIMIT);
 
     assertNotNull(result);
     assertTrue(result.isEmpty());
@@ -132,7 +134,7 @@ public class FileServiceTest {
   public void testGetAllComicsAlreadyImported() throws IOException {
     Mockito.when(comicRepository.findByFilename(Mockito.anyString())).thenReturn(comic);
 
-    final List<FileDetails> result = service.getAllComicsUnder(TEST_ROOT_DIRECTORY);
+    final List<FileDetails> result = service.getAllComicsUnder(TEST_ROOT_DIRECTORY, TEST_LIMIT);
 
     assertNotNull(result);
     assertTrue(result.isEmpty());
@@ -142,12 +144,21 @@ public class FileServiceTest {
   }
 
   @Test
-  public void testGetAllComicsUnder() throws IOException {
-    final List<FileDetails> result = service.getAllComicsUnder(TEST_ROOT_DIRECTORY);
+  public void testGetAllComicsUnderWithLimit() throws IOException {
+    final List<FileDetails> result = service.getAllComicsUnder(TEST_ROOT_DIRECTORY, TEST_LIMIT);
 
     assertNotNull(result);
     assertFalse(result.isEmpty());
-    assertEquals(1, result.size());
+    assertEquals(TEST_LIMIT.intValue(), result.size());
+  }
+
+  @Test
+  public void testGetAllComicsUnder() throws IOException {
+    final List<FileDetails> result = service.getAllComicsUnder(TEST_ROOT_DIRECTORY, TEST_NO_LIMIT);
+
+    assertNotNull(result);
+    assertFalse(result.isEmpty());
+    assertEquals(3, result.size());
   }
 
   @Test


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Added a request parameter to set the maximum number of comic files to return. Added a dropdown to the frontend to let the user set a persistent maximum value, and to submit it during import.