### PR TITLE
Fix the query for getting the next and previous comic in a series

### DIFF
--- a/comixed-library/src/main/java/org/comixed/repositories/comic/ComicRepository.java
+++ b/comixed-library/src/main/java/org/comixed/repositories/comic/ComicRepository.java
@@ -89,18 +89,20 @@ public interface ComicRepository extends JpaRepository<Comic, Long> {
   Comic getById(@Param("id") long id);
 
   @Query(
-      "SELECT c FROM Comic c WHERE c.series = :series AND c.volume = :volume AND c.issueNumber <> :issueNumber AND c.coverDate <= (SELECT DISTINCT d.coverDate FROM Comic d WHERE d.series = :series AND d.volume = :volume AND d.issueNumber = :issueNumber) ORDER BY c.coverDate,c.issueNumber DESC")
+      "SELECT c FROM Comic c WHERE c.series = :series AND c.volume = :volume AND c.issueNumber <> :issueNumber AND c.coverDate <= :coverDate ORDER BY c.coverDate,c.issueNumber DESC")
   List<Comic> findIssuesBeforeComic(
-      @Param("series") String series,
-      @Param("volume") String volume,
-      @Param("issueNumber") String issueNumber);
+      @Param("series") final String series,
+      @Param("volume") final String volume,
+      @Param("issueNumber") final String issueNumber,
+      @Param("coverDate") final Date coverDate);
 
   @Query(
-      "SELECT c FROM Comic c WHERE c.series = :series AND c.volume = :volume AND c.issueNumber <> :issueNumber AND c.coverDate >= (SELECT DISTINCT d.coverDate FROM Comic d WHERE d.series = :series AND d.volume = :volume AND d.issueNumber = :issueNumber) ORDER BY c.coverDate,c.issueNumber ASC")
+      "SELECT c FROM Comic c WHERE c.series = :series AND c.volume = :volume AND c.issueNumber <> :issueNumber AND c.coverDate >= :coverDate ORDER BY c.coverDate,c.issueNumber ASC")
   List<Comic> findIssuesAfterComic(
       @Param("series") String series,
       @Param("volume") String volume,
-      @Param("issueNumber") String issueNumber);
+      @Param("issueNumber") String issueNumber,
+      @Param("coverDate") Date coverDate);
 
   @Query("SELECT c FROM Comic c WHERE c.dateDeleted IS NOT NULL")
   List<Comic> findAllMarkedForDeletion();

--- a/comixed-library/src/test/java/org/comixed/repositories/comic/ComicRepositoryTest.java
+++ b/comixed-library/src/test/java/org/comixed/repositories/comic/ComicRepositoryTest.java
@@ -76,6 +76,10 @@ public class ComicRepositoryTest {
   private static final String TEST_ISSUE_WITH_PREV = "513";
   private static final Long TEST_COMIC_ID_WITH_DUPLICATES = 1020L;
   private static final String TEST_USER_EMAIL_NO_READ_COMIC = "comixedreader2@localhost";
+  private static final Date TEST_COVER_DATE_NO_NEXT = new Date(1490932800000L);
+  private static final Date TEST_COVER_DATE_WITH_NEXT = new Date(1485838800000L);
+  private static final Date TEST_COVER_DATE_NO_PREV = new Date(1425099600000L);
+  private static final Date TEST_COVER_DATE_WITH_PREV = new Date(1488258000000L);
 
   @Autowired private ComicRepository repository;
   @Autowired private PageTypeRepository pageTypeRepository;
@@ -486,7 +490,8 @@ public class ComicRepositoryTest {
   @Test
   public void testGetIssuesAfterComicWithNone() {
     final List<Comic> result =
-        this.repository.findIssuesAfterComic(TEST_SERIES, TEST_VOLUME, TEST_ISSUE_WITH_NO_NEXT);
+        this.repository.findIssuesAfterComic(
+            TEST_SERIES, TEST_VOLUME, TEST_ISSUE_WITH_NO_NEXT, TEST_COVER_DATE_NO_NEXT);
 
     assertTrue(result.isEmpty());
   }
@@ -494,7 +499,8 @@ public class ComicRepositoryTest {
   @Test
   public void testGetIssuesAfterComic() {
     final List<Comic> result =
-        this.repository.findIssuesAfterComic(TEST_SERIES, TEST_VOLUME, TEST_ISSUE_WITH_NEXT);
+        this.repository.findIssuesAfterComic(
+            TEST_SERIES, TEST_VOLUME, TEST_ISSUE_WITH_NEXT, TEST_COVER_DATE_WITH_NEXT);
 
     assertFalse(result.isEmpty());
     for (int index = 0; index < result.size(); index++) {
@@ -505,7 +511,8 @@ public class ComicRepositoryTest {
   @Test
   public void testGetIssuesBeforeComicNone() {
     final List<Comic> result =
-        this.repository.findIssuesBeforeComic(TEST_SERIES, TEST_VOLUME, TEST_ISSUE_WITH_NO_PREV);
+        this.repository.findIssuesBeforeComic(
+            TEST_SERIES, TEST_VOLUME, TEST_ISSUE_WITH_NO_PREV, TEST_COVER_DATE_NO_PREV);
 
     assertTrue(result.isEmpty());
   }
@@ -513,7 +520,8 @@ public class ComicRepositoryTest {
   @Test
   public void testGetIssuesBeforeComic() {
     final List<Comic> result =
-        this.repository.findIssuesBeforeComic(TEST_SERIES, TEST_VOLUME, TEST_ISSUE_WITH_PREV);
+        this.repository.findIssuesBeforeComic(
+            TEST_SERIES, TEST_VOLUME, TEST_ISSUE_WITH_PREV, TEST_COVER_DATE_WITH_PREV);
 
     assertFalse(result.isEmpty());
     for (int index = 0; index < result.size(); index++) {

--- a/comixed-services/src/main/java/org/comixed/service/comic/ComicService.java
+++ b/comixed-services/src/main/java/org/comixed/service/comic/ComicService.java
@@ -239,7 +239,7 @@ public class ComicService {
     final Comic result = comicRecord.get();
     final List<Comic> next =
         this.comicRepository.findIssuesAfterComic(
-            result.getSeries(), result.getVolume(), result.getIssueNumber());
+            result.getSeries(), result.getVolume(), result.getIssueNumber(), result.getCoverDate());
     if (!next.isEmpty()) {
       int index = 0;
       Comic nextComic = null;
@@ -266,7 +266,7 @@ public class ComicService {
     }
     final List<Comic> prev =
         this.comicRepository.findIssuesBeforeComic(
-            result.getSeries(), result.getVolume(), result.getIssueNumber());
+            result.getSeries(), result.getVolume(), result.getIssueNumber(), result.getCoverDate());
     if (!prev.isEmpty()) {
       int index = prev.size() - 1;
       Comic prevComic = null;

--- a/comixed-services/src/test/java/org/comixed/service/comic/ComicServiceTest.java
+++ b/comixed-services/src/test/java/org/comixed/service/comic/ComicServiceTest.java
@@ -72,6 +72,7 @@ public class ComicServiceTest {
   private static final String TEST_SORTABLE_NAME = "Sortable Name";
   private static final ScanType TEST_SCAN_TYPE = new ScanType();
   private static final ComicFormat TEST_COMIC_FORMAT = new ComicFormat();
+  private static final Date TEST_COVER_DATE = new Date();
 
   @InjectMocks private ComicService comicService;
   @Mock private ComicRepository comicRepository;
@@ -111,6 +112,7 @@ public class ComicServiceTest {
     currentComic.setIssueNumber(TEST_CURRENT_ISSUE_NUMBER);
     currentComic.setId(TEST_CURRENT_COMIC_ID);
     currentComic.setCoverDate(new Date(System.currentTimeMillis()));
+    currentComic.setCoverDate(TEST_COVER_DATE);
     nextComic.setIssueNumber(TEST_NEXT_ISSUE_NUMBER);
     nextComic.setId(TEST_NEXT_COMIC_ID);
     nextComic.setCoverDate(new Date(System.currentTimeMillis() + 24 * 60 * 60 * 1000));
@@ -262,11 +264,17 @@ public class ComicServiceTest {
 
     Mockito.when(
             comicRepository.findIssuesBeforeComic(
-                Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+                Mockito.anyString(),
+                Mockito.anyString(),
+                Mockito.anyString(),
+                Mockito.any(Date.class)))
         .thenReturn(previousComics);
     Mockito.when(
             comicRepository.findIssuesAfterComic(
-                Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
+                Mockito.anyString(),
+                Mockito.anyString(),
+                Mockito.anyString(),
+                Mockito.any(Date.class)))
         .thenReturn(nextComics);
 
     final Comic result = comicService.getComic(TEST_COMIC_ID);
@@ -278,9 +286,10 @@ public class ComicServiceTest {
 
     Mockito.verify(comicRepository, Mockito.times(1)).findById(TEST_COMIC_ID);
     Mockito.verify(comicRepository, Mockito.times(1))
-        .findIssuesBeforeComic(TEST_SERIES, TEST_VOLUME, TEST_CURRENT_ISSUE_NUMBER);
+        .findIssuesBeforeComic(
+            TEST_SERIES, TEST_VOLUME, TEST_CURRENT_ISSUE_NUMBER, TEST_COVER_DATE);
     Mockito.verify(comicRepository, Mockito.times(1))
-        .findIssuesAfterComic(TEST_SERIES, TEST_VOLUME, TEST_CURRENT_ISSUE_NUMBER);
+        .findIssuesAfterComic(TEST_SERIES, TEST_VOLUME, TEST_CURRENT_ISSUE_NUMBER, TEST_COVER_DATE);
   }
 
   @Test


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Changed the queries to take an explicit date rather than trying to subselect for it.