### PR TITLE
Reading lists not being returned with library updates

### DIFF
--- a/comixed-frontend/src/app/library/adaptors/library.adaptor.ts
+++ b/comixed-frontend/src/app/library/adaptors/library.adaptor.ts
@@ -132,26 +132,30 @@ export class LibraryAdaptor {
           this._stories$.next(
             extractField(state.comics, CollectionType.STORIES)
           );
-          const readingLists = extractField(
-            state.comics,
-            CollectionType.READING_LISTS
+        }
+
+        // rebuild the reading lists
+        const readingLists = extractField(
+          state.comics,
+          CollectionType.READING_LISTS
+        );
+        // merge in any reading lists that have no comics
+        state.readingLists.forEach(readingList => {
+          const existing = readingLists.find(
+            entry => entry.name === readingList.name
           );
-          // merge in any reading lists that have no comics
-          state.readingLists.forEach(readingList => {
-            const existing = readingLists.find(
-              entry => entry.name === readingList.name
-            );
-            if (!existing) {
-              this.logger.debug('pushing reading list:', readingList);
-              readingLists.push({
-                name: readingList.name,
-                comics: [],
-                count: 0,
-                last_comic_added: 0,
-                type: CollectionType.READING_LISTS
-              } as ComicCollectionEntry);
-            }
-          });
+          if (!existing) {
+            this.logger.debug('pushing reading list:', readingList);
+            readingLists.push({
+              name: readingList.name,
+              comics: [],
+              count: 0,
+              last_comic_added: 0,
+              type: CollectionType.READING_LISTS
+            } as ComicCollectionEntry);
+          }
+        });
+        if (!_.isEqual(this._readingLists$.getValue(), readingLists)) {
           this._readingLists$.next(readingLists);
         }
         if (!_.isEqual(this._lists$.getValue(), state.readingLists)) {

--- a/comixed-library/src/main/java/org/comixed/model/library/ReadingList.java
+++ b/comixed-library/src/main/java/org/comixed/model/library/ReadingList.java
@@ -41,17 +41,17 @@ public class ReadingList {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @JsonProperty("id")
-  @JsonView({View.ComicList.class, View.ReadingList.class})
+  @JsonView({View.ComicList.class, View.ReadingList.class, View.LibraryUpdate.class})
   private Long id;
 
   @Column(name = "name", length = 128)
   @JsonProperty("name")
-  @JsonView({View.ComicList.class, View.ReadingList.class})
+  @JsonView({View.ComicList.class, View.ReadingList.class, View.LibraryUpdate.class})
   private String name;
 
   @Column(name = "summary", length = 256, nullable = true)
   @JsonProperty("summary")
-  @JsonView({View.ComicList.class, View.ReadingList.class})
+  @JsonView({View.ComicList.class, View.ReadingList.class, View.LibraryUpdate.class})
   private String summary;
 
   @JsonProperty("owner")


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
The ReadingList Java model's annotations didn't include the LibrayUpdate view, and the LibraryAdaptor was only updating the reading list state when the comics changed.