### PR TITLE
Remove empty reading list selection entry

### DIFF
--- a/comixed-frontend/src/app/library/components/add-comics-to-list-reading-list/add-comics-to-reading-list.component.ts
+++ b/comixed-frontend/src/app/library/components/add-comics-to-list-reading-list/add-comics-to-reading-list.component.ts
@@ -60,14 +60,12 @@ export class AddComicsToReadingListComponent implements OnInit, OnDestroy {
     );
     this.readingListsSubscription = this.libraryAdaptor.lists$.subscribe(
       readingLists => {
-        this.readingListOptions = [{ label: '' } as SelectItem].concat(
-          readingLists.map(readingList => {
-            return {
-              label: readingList.name,
-              value: readingList
-            } as SelectItem;
-          })
-        );
+        this.readingListOptions = readingLists.map(readingList => {
+          return {
+            label: readingList.name,
+            value: readingList
+          } as SelectItem;
+        });
       }
     );
     this.selectedComicsSubscription = this.selectionAdaptor.comicSelection$.subscribe(


### PR DESCRIPTION
Removed the empty first entry that was intended to be a "select an option..." entry.

## Status
**READ**

## Migrations
NO

## Description
Remove the empty entry.