### PR TITLE
Add page for viewing task audit log entries

### DIFF
--- a/comixed-frontend/src/app/backend-status/actions/task-audit-log.actions.ts
+++ b/comixed-frontend/src/app/backend-status/actions/task-audit-log.actions.ts
@@ -1,0 +1,53 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { Action } from '@ngrx/store';
+import { TaskAuditLogEntry } from 'app/backend-status/models/task-audit-log-entry';
+
+export enum TaskAuditLogActionTypes {
+  GetEntries = '[TASK AUDIT LOG] Get task audit log entries',
+  ReceivedEntries = '[TASK AUDIT LOG] Task audit log entries received',
+  GetEntriesFailed = '[TASK AUDIT LOG] Failed to get task audit log entries'
+}
+
+export class GetTaskAuditLogEntries implements Action {
+  readonly type = TaskAuditLogActionTypes.GetEntries;
+
+  constructor(
+    public payload: {
+      cutoff: number;
+    }
+  ) {}
+}
+
+export class ReceivedTaskAuditLogEntries implements Action {
+  readonly type = TaskAuditLogActionTypes.ReceivedEntries;
+
+  constructor(public payload: { entries: TaskAuditLogEntry[] }) {}
+}
+
+export class GetTaskAuditLogEntriesFailed implements Action {
+  readonly type = TaskAuditLogActionTypes.GetEntriesFailed;
+
+  constructor() {}
+}
+
+export type TaskAuditLogActions =
+  | GetTaskAuditLogEntries
+  | ReceivedTaskAuditLogEntries
+  | GetTaskAuditLogEntriesFailed;

--- a/comixed-frontend/src/app/backend-status/adaptors/task-audit-log.adaptor.spec.ts
+++ b/comixed-frontend/src/app/backend-status/adaptors/task-audit-log.adaptor.spec.ts
@@ -1,0 +1,134 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { TaskAuditLogAdaptor } from './task-audit-log.adaptor';
+import {
+  TASK_AUDIT_LOG_ENTRY_1,
+  TASK_AUDIT_LOG_ENTRY_2,
+  TASK_AUDIT_LOG_ENTRY_3,
+  TASK_AUDIT_LOG_ENTRY_4,
+  TASK_AUDIT_LOG_ENTRY_5
+} from 'app/backend-status/models/task-audit-log-entry.fixtures';
+import { TestBed } from '@angular/core/testing';
+import { Store, StoreModule } from '@ngrx/store';
+import { AppState } from 'app/backend-status';
+import {
+  GetTaskAuditLogEntries,
+  GetTaskAuditLogEntriesFailed,
+  ReceivedTaskAuditLogEntries
+} from 'app/backend-status/actions/task-audit-log.actions';
+import { LoggerModule } from '@angular-ru/logger';
+import {
+  reducer,
+  TASK_AUDIT_LOG_FEATURE_KEY
+} from 'app/backend-status/reducers/task-audit-log.reducer';
+import { EffectsModule } from '@ngrx/effects';
+import { TaskAuditLogEffects } from 'app/backend-status/effects/task-audit-log.effects';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { MessageService } from 'primeng/api';
+import { TranslateModule } from '@ngx-translate/core';
+
+describe('TaskAuditLogAdaptor', () => {
+  const LAST_ENTRY_DATE = new Date().getTime();
+  const LOG_ENTRIES = [
+    TASK_AUDIT_LOG_ENTRY_1,
+    TASK_AUDIT_LOG_ENTRY_2,
+    TASK_AUDIT_LOG_ENTRY_3,
+    TASK_AUDIT_LOG_ENTRY_4,
+    TASK_AUDIT_LOG_ENTRY_5
+  ];
+
+  let taskAuditLogAdaptor: TaskAuditLogAdaptor;
+  let store: Store<AppState>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        LoggerModule.forRoot(),
+        TranslateModule.forRoot(),
+        StoreModule.forRoot({}),
+        StoreModule.forFeature(TASK_AUDIT_LOG_FEATURE_KEY, reducer),
+        EffectsModule.forRoot([]),
+        EffectsModule.forFeature([TaskAuditLogEffects])
+      ],
+      providers: [TaskAuditLogAdaptor, MessageService]
+    });
+
+    taskAuditLogAdaptor = TestBed.get(TaskAuditLogAdaptor);
+    store = TestBed.get(Store);
+    spyOn(store, 'dispatch').and.callThrough();
+  });
+
+  it('should create an instance', () => {
+    expect(taskAuditLogAdaptor).toBeTruthy();
+  });
+
+  describe('getting the list of task audit log entries', () => {
+    let lastEntryDate: number;
+
+    beforeEach(() => {
+      lastEntryDate = taskAuditLogAdaptor.lastEntryDate;
+      taskAuditLogAdaptor.getEntries();
+    });
+
+    it('fires an action', () => {
+      expect(store.dispatch).toHaveBeenCalledWith(
+        new GetTaskAuditLogEntries({ cutoff: lastEntryDate })
+      );
+    });
+
+    it('provides updates on fetching', () => {
+      taskAuditLogAdaptor.fetchingEntries$.subscribe(response =>
+        expect(response).toBeTruthy()
+      );
+    });
+
+    describe('success', () => {
+      beforeEach(() => {
+        store.dispatch(
+          new ReceivedTaskAuditLogEntries({ entries: LOG_ENTRIES })
+        );
+      });
+
+      it('provides updates on fetching', () => {
+        taskAuditLogAdaptor.fetchingEntries$.subscribe(response =>
+          expect(response).toBeFalsy()
+        );
+      });
+
+      it('provides updates on the log entries', () => {
+        taskAuditLogAdaptor.entries$.subscribe(response =>
+          expect(response).toEqual(LOG_ENTRIES)
+        );
+      });
+    });
+
+    describe('failure', () => {
+      beforeEach(() => {
+        store.dispatch(new GetTaskAuditLogEntriesFailed());
+      });
+
+      it('provides updates on fetching', () => {
+        taskAuditLogAdaptor.fetchingEntries$.subscribe(response =>
+          expect(response).toBeFalsy()
+        );
+      });
+    });
+  });
+});

--- a/comixed-frontend/src/app/backend-status/adaptors/task-audit-log.adaptor.ts
+++ b/comixed-frontend/src/app/backend-status/adaptors/task-audit-log.adaptor.ts
@@ -1,0 +1,77 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import {Injectable} from '@angular/core';
+import {LoggerService} from '@angular-ru/logger';
+import {Store} from '@ngrx/store';
+import {AppState} from 'app/backend-status';
+import {BehaviorSubject, Observable} from 'rxjs';
+import {TaskAuditLogEntry} from 'app/backend-status/models/task-audit-log-entry';
+import {GetTaskAuditLogEntries} from 'app/backend-status/actions/task-audit-log.actions';
+import {TASK_AUDIT_LOG_FEATURE_KEY, TaskAuditLogState} from 'app/backend-status/reducers/task-audit-log.reducer';
+import {filter} from 'rxjs/operators';
+import * as _ from 'lodash';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class TaskAuditLogAdaptor {
+    private _lastEntryDate$ = new BehaviorSubject<number>(0);
+    private _fetchingEntries$ = new BehaviorSubject<boolean>(false);
+    private _entries$ = new BehaviorSubject<TaskAuditLogEntry[]>([]);
+
+    constructor(private logger: LoggerService, private store: Store<AppState>) {
+        this.store
+            .select(TASK_AUDIT_LOG_FEATURE_KEY)
+            .pipe(filter(state => !!state))
+            .subscribe((state: TaskAuditLogState) => {
+                this.logger.debug('task audit log state changed:', state);
+                if (!_.isEqual(this._lastEntryDate$.getValue(), state.lastEntryDate)) {
+                    this._lastEntryDate$.next(state.lastEntryDate);
+                }
+                if (this._fetchingEntries$.getValue() !== state.fetchingEntries) {
+                    this._fetchingEntries$.next(state.fetchingEntries);
+                }
+                if (!_.isEqual(this._entries$.getValue(), state.entries)) {
+                    this._entries$.next(state.entries);
+                }
+            });
+    }
+
+    getEntries(): void {
+        this.logger.debug(
+            'getting task audit log entries:',
+            this._lastEntryDate$.getValue()
+        );
+        this.store.dispatch(
+            new GetTaskAuditLogEntries({cutoff: this._lastEntryDate$.getValue()})
+        );
+    }
+
+    get lastEntryDate(): number {
+        return this._lastEntryDate$.getValue();
+    }
+
+    get fetchingEntries$(): Observable<boolean> {
+        return this._fetchingEntries$.asObservable();
+    }
+
+    get entries$(): Observable<TaskAuditLogEntry[]> {
+        return this._entries$.asObservable();
+    }
+}

--- a/comixed-frontend/src/app/backend-status/backend-status-routing.module.ts
+++ b/comixed-frontend/src/app/backend-status/backend-status-routing.module.ts
@@ -19,11 +19,18 @@
 import { RouterModule, Routes } from '@angular/router';
 import { BuildDetailsPageComponent } from 'app/backend-status/pages/build-details-page/build-details-page.component';
 import { NgModule } from '@angular/core';
+import { TaskAuditLogPageComponent } from 'app/backend-status/pages/task-audit-log-page/task-audit-log-page.component';
+import { AdminGuard } from 'app/user';
 
 const routes: Routes = [
   {
     path: 'build/details',
     component: BuildDetailsPageComponent
+  },
+  {
+    path: 'admin/tasks/logs',
+    component: TaskAuditLogPageComponent,
+    canActivate: [AdminGuard]
   }
 ];
 

--- a/comixed-frontend/src/app/backend-status/backend-status.constants.ts
+++ b/comixed-frontend/src/app/backend-status/backend-status.constants.ts
@@ -1,0 +1,21 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { API_ROOT_URL } from 'app/app.functions';
+
+export const GET_TASK_LOG_ENTRIES_URL = `${API_ROOT_URL}/tasks/entries/\${timestamp}`;

--- a/comixed-frontend/src/app/backend-status/backend-status.fixtures.ts
+++ b/comixed-frontend/src/app/backend-status/backend-status.fixtures.ts
@@ -1,0 +1,28 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+export {
+  BUILD_DETAILS
+} from 'app/backend-status/models/build-details.fixtures';
+export {
+  TASK_AUDIT_LOG_ENTRY_1,
+  TASK_AUDIT_LOG_ENTRY_2,
+  TASK_AUDIT_LOG_ENTRY_3,
+  TASK_AUDIT_LOG_ENTRY_4,
+  TASK_AUDIT_LOG_ENTRY_5
+} from 'app/backend-status/models/task-audit-log-entry.fixtures';

--- a/comixed-frontend/src/app/backend-status/backend-status.module.ts
+++ b/comixed-frontend/src/app/backend-status/backend-status.module.ts
@@ -24,9 +24,13 @@ import { BackendStatusRoutingModule } from 'app/backend-status/backend-status-ro
 import { BuildDetailsAdaptor } from 'app/backend-status/adaptors/build-details.adaptor';
 import { StoreModule } from '@ngrx/store';
 import * as fromBuildDetails from './reducers/build-details.reducer';
+import * as fromTaskAuditLog from './reducers/task-audit-log.reducer';
 import { EffectsModule } from '@ngrx/effects';
 import { BuildDetailsEffects } from 'app/backend-status/effects/build-details.effects';
 import { TranslateModule } from '@ngx-translate/core';
+import { TaskAuditLogEffects } from 'app/backend-status/effects/task-audit-log.effects';
+import { TaskAuditLogPageComponent } from './pages/task-audit-log-page/task-audit-log-page.component';
+import { TaskAuditLogAdaptor } from 'app/backend-status/adaptors/task-audit-log.adaptor';
 
 @NgModule({
   declarations: [BuildDetailsPageComponent],
@@ -38,9 +42,13 @@ import { TranslateModule } from '@ngx-translate/core';
       fromBuildDetails.BUILD_DETAILS_FEATURE_KEY,
       fromBuildDetails.reducer
     ),
-    EffectsModule.forFeature([BuildDetailsEffects])
+    StoreModule.forFeature(
+      fromTaskAuditLog.TASK_AUDIT_LOG_FEATURE_KEY,
+      fromTaskAuditLog.reducer
+    ),
+    EffectsModule.forFeature([BuildDetailsEffects, TaskAuditLogEffects])
   ],
   exports: [CommonModule],
-  providers: [BuildDetailsService, BuildDetailsAdaptor]
+  providers: [BuildDetailsService, BuildDetailsAdaptor, TaskAuditLogAdaptor]
 })
 export class BackendStatusModule {}

--- a/comixed-frontend/src/app/backend-status/backend-status.module.ts
+++ b/comixed-frontend/src/app/backend-status/backend-status.module.ts
@@ -31,9 +31,10 @@ import { TranslateModule } from '@ngx-translate/core';
 import { TaskAuditLogEffects } from 'app/backend-status/effects/task-audit-log.effects';
 import { TaskAuditLogPageComponent } from './pages/task-audit-log-page/task-audit-log-page.component';
 import { TaskAuditLogAdaptor } from 'app/backend-status/adaptors/task-audit-log.adaptor';
+import { TableModule } from 'primeng/table';
 
 @NgModule({
-  declarations: [BuildDetailsPageComponent],
+  declarations: [BuildDetailsPageComponent, TaskAuditLogPageComponent],
   imports: [
     CommonModule,
     BackendStatusRoutingModule,
@@ -46,7 +47,8 @@ import { TaskAuditLogAdaptor } from 'app/backend-status/adaptors/task-audit-log.
       fromTaskAuditLog.TASK_AUDIT_LOG_FEATURE_KEY,
       fromTaskAuditLog.reducer
     ),
-    EffectsModule.forFeature([BuildDetailsEffects, TaskAuditLogEffects])
+    EffectsModule.forFeature([BuildDetailsEffects, TaskAuditLogEffects]),
+    TableModule
   ],
   exports: [CommonModule],
   providers: [BuildDetailsService, BuildDetailsAdaptor, TaskAuditLogAdaptor]

--- a/comixed-frontend/src/app/backend-status/effects/task-audit-log.effects.spec.ts
+++ b/comixed-frontend/src/app/backend-status/effects/task-audit-log.effects.spec.ts
@@ -1,0 +1,136 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {provideMockActions} from '@ngrx/effects/testing';
+import {Observable, of, throwError} from 'rxjs';
+
+import {TaskAuditLogEffects} from './task-audit-log.effects';
+import {TaskAuditLogService} from 'app/backend-status/services/task-audit-log.service';
+import {
+    TASK_AUDIT_LOG_ENTRY_1,
+    TASK_AUDIT_LOG_ENTRY_2,
+    TASK_AUDIT_LOG_ENTRY_3,
+    TASK_AUDIT_LOG_ENTRY_4,
+    TASK_AUDIT_LOG_ENTRY_5
+} from 'app/backend-status/backend-status.fixtures';
+import {
+    GetTaskAuditLogEntries,
+    GetTaskAuditLogEntriesFailed,
+    ReceivedTaskAuditLogEntries
+} from 'app/backend-status/actions/task-audit-log.actions';
+import {hot} from 'jasmine-marbles';
+import {HttpErrorResponse} from '@angular/common/http';
+import {MessageService} from 'primeng/api';
+import {LoggerModule} from '@angular-ru/logger';
+import {TranslateModule} from '@ngx-translate/core';
+import objectContaining = jasmine.objectContaining;
+
+describe('TaskAuditLogEffects', () => {
+    const LOG_ENTRIES = [
+        TASK_AUDIT_LOG_ENTRY_1,
+        TASK_AUDIT_LOG_ENTRY_2,
+        TASK_AUDIT_LOG_ENTRY_3,
+        TASK_AUDIT_LOG_ENTRY_4,
+        TASK_AUDIT_LOG_ENTRY_5
+    ];
+
+    let actions$: Observable<any>;
+    let effects: TaskAuditLogEffects;
+    let taskAuditLogService: jasmine.SpyObj<TaskAuditLogService>;
+    let messageService: MessageService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [LoggerModule.forRoot(), TranslateModule.forRoot()],
+            providers: [
+                TaskAuditLogEffects,
+                provideMockActions(() => actions$),
+                {
+                    provide: TaskAuditLogService,
+                    useValue: {
+                        getLogEntries: jasmine.createSpy(
+                            'TaskAuditLogService.getLogEntries()'
+                        )
+                    }
+                },
+                MessageService
+            ]
+        });
+
+        effects = TestBed.get<TaskAuditLogEffects>(TaskAuditLogEffects);
+        taskAuditLogService = TestBed.get(TaskAuditLogService);
+        messageService = TestBed.get(MessageService);
+        spyOn(messageService, 'add');
+    });
+
+    it('should be created', () => {
+        expect(effects).toBeTruthy();
+    });
+
+    describe('getting the list of log entries', () => {
+        it('fires an action on success', () => {
+            const serviceResponse = LOG_ENTRIES;
+            const action = new GetTaskAuditLogEntries({
+                cutoff: new Date().getTime()
+            });
+            const outcome = new ReceivedTaskAuditLogEntries({entries: LOG_ENTRIES});
+
+            actions$ = hot('-a', {a: action});
+            taskAuditLogService.getLogEntries.and.returnValue(of(serviceResponse));
+
+            const expected = hot('-b', {b: outcome});
+            expect(effects.getLogEntries$).toBeObservable(expected);
+        });
+
+        it('fires an action on service failure', () => {
+            const serviceResponse = new HttpErrorResponse({});
+            const action = new GetTaskAuditLogEntries({
+                cutoff: new Date().getTime()
+            });
+            const outcome = new GetTaskAuditLogEntriesFailed();
+
+            actions$ = hot('-a', {a: action});
+            taskAuditLogService.getLogEntries.and.returnValue(
+                throwError(serviceResponse)
+            );
+
+            const expected = hot('-b', {b: outcome});
+            expect(effects.getLogEntries$).toBeObservable(expected);
+            expect(messageService.add).toHaveBeenCalledWith(
+                objectContaining({severity: 'error'})
+            );
+        });
+
+        it('fires an action on general failure', () => {
+            const action = new GetTaskAuditLogEntries({
+                cutoff: new Date().getTime()
+            });
+            const outcome = new GetTaskAuditLogEntriesFailed();
+
+            actions$ = hot('-a', {a: action});
+            taskAuditLogService.getLogEntries.and.throwError('expected');
+
+            const expected = hot('-(b|)', {b: outcome});
+            expect(effects.getLogEntries$).toBeObservable(expected);
+            expect(messageService.add).toHaveBeenCalledWith(
+                objectContaining({severity: 'error'})
+            );
+        });
+    });
+});

--- a/comixed-frontend/src/app/backend-status/effects/task-audit-log.effects.ts
+++ b/comixed-frontend/src/app/backend-status/effects/task-audit-log.effects.ts
@@ -1,0 +1,89 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { Injectable } from '@angular/core';
+import { Actions, Effect, ofType } from '@ngrx/effects';
+import {
+  GetTaskAuditLogEntriesFailed,
+  ReceivedTaskAuditLogEntries,
+  TaskAuditLogActions,
+  TaskAuditLogActionTypes
+} from '../actions/task-audit-log.actions';
+import { Action } from '@ngrx/store';
+import { Observable, of } from 'rxjs';
+import { catchError, map, switchMap, tap } from 'rxjs/operators';
+import { LoggerService } from '@angular-ru/logger';
+import { TaskAuditLogService } from 'app/backend-status/services/task-audit-log.service';
+import { TaskAuditLogEntry } from 'app/backend-status/models/task-audit-log-entry';
+import { MessageService } from 'primeng/api';
+import { TranslateService } from '@ngx-translate/core';
+
+@Injectable()
+export class TaskAuditLogEffects {
+  constructor(
+    private actions$: Actions<TaskAuditLogActions>,
+    private logger: LoggerService,
+    private taskAuditLogService: TaskAuditLogService,
+    private messageService: MessageService,
+    private translateService: TranslateService
+  ) {}
+
+  @Effect()
+  getLogEntries$: Observable<Action> = this.actions$.pipe(
+    ofType(TaskAuditLogActionTypes.GetEntries),
+    map(action => action.payload),
+    tap(action =>
+      this.logger.debug('effect: getting task audit log entries:', action)
+    ),
+    switchMap(action =>
+      this.taskAuditLogService.getLogEntries(action.cutoff).pipe(
+        tap(response => this.logger.debug('received response:', response)),
+        map(
+          (response: TaskAuditLogEntry[]) =>
+            new ReceivedTaskAuditLogEntries({ entries: response })
+        ),
+        catchError(error => {
+          this.logger.error(
+            'service failure getting task audit log entries:',
+            error
+          );
+          this.messageService.add({
+            severity: 'error',
+            detail: this.translateService.instant(
+              'task-audit-log-effects.get-log-entries.error.detail'
+            )
+          });
+          return of(new GetTaskAuditLogEntriesFailed());
+        })
+      )
+    ),
+    catchError(error => {
+      this.logger.error(
+        'general failure getting task audit log entries:',
+        error
+      );
+      this.messageService.add({
+        severity: 'error',
+        detail: this.translateService.instant(
+          'general-message.error.general-service-failure'
+        )
+      });
+      return of(new GetTaskAuditLogEntriesFailed());
+    })
+  );
+}

--- a/comixed-frontend/src/app/backend-status/index.ts
+++ b/comixed-frontend/src/app/backend-status/index.ts
@@ -18,11 +18,13 @@
 
 import * as fromRouter from '@ngrx/router-store';
 import * as fromBuildDetails from './reducers/build-details.reducer';
+import { BuildDetailsState } from './reducers/build-details.reducer';
+import * as fromTaskAuditLog from './reducers/task-audit-log.reducer';
 
 import { Params } from '@angular/router';
-import { BuildDetailsState } from './reducers/build-details.reducer';
 import { ActionReducerMap, MetaReducer } from '@ngrx/store';
 import { environment } from '../../environments/environment';
+import { TaskAuditLogState } from 'app/backend-status/reducers/task-audit-log.reducer';
 
 interface RouterStateUrl {
   url: string;
@@ -33,13 +35,15 @@ interface RouterStateUrl {
 export interface AppState {
   router: fromRouter.RouterReducerState<RouterStateUrl>;
   build_details: BuildDetailsState;
+  task_audit_log_state: TaskAuditLogState;
 }
 
 export type State = AppState;
 
 export const reducers: ActionReducerMap<AppState> = {
   router: fromRouter.routerReducer,
-  build_details: fromBuildDetails.reducer
+  build_details: fromBuildDetails.reducer,
+  task_audit_log_state: fromTaskAuditLog.reducer
 };
 
 export const metaReducers: MetaReducer<AppState>[] = !environment.production

--- a/comixed-frontend/src/app/backend-status/models/task-audit-log-entry.fixtures.ts
+++ b/comixed-frontend/src/app/backend-status/models/task-audit-log-entry.fixtures.ts
@@ -1,0 +1,54 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { TaskAuditLogEntry } from 'app/backend-status/models/task-audit-log-entry';
+
+export const TASK_AUDIT_LOG_ENTRY_1: TaskAuditLogEntry = {
+  startTime: new Date().getTime(),
+  endTime: new Date().getTime(),
+  successful: true,
+  description: 'The first task'
+};
+
+export const TASK_AUDIT_LOG_ENTRY_2: TaskAuditLogEntry = {
+  startTime: new Date().getTime(),
+  endTime: new Date().getTime(),
+  successful: true,
+  description: 'The second task'
+};
+
+export const TASK_AUDIT_LOG_ENTRY_3: TaskAuditLogEntry = {
+  startTime: new Date().getTime(),
+  endTime: new Date().getTime(),
+  successful: true,
+  description: 'The third task'
+};
+
+export const TASK_AUDIT_LOG_ENTRY_4: TaskAuditLogEntry = {
+  startTime: new Date().getTime(),
+  endTime: new Date().getTime(),
+  successful: true,
+  description: 'The fourth task'
+};
+
+export const TASK_AUDIT_LOG_ENTRY_5: TaskAuditLogEntry = {
+  startTime: new Date().getTime(),
+  endTime: new Date().getTime(),
+  successful: true,
+  description: 'The fifth task'
+};

--- a/comixed-frontend/src/app/backend-status/models/task-audit-log-entry.ts
+++ b/comixed-frontend/src/app/backend-status/models/task-audit-log-entry.ts
@@ -1,0 +1,24 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+export interface TaskAuditLogEntry {
+  startTime: number;
+  endTime: number;
+  successful: boolean;
+  description: string;
+}

--- a/comixed-frontend/src/app/backend-status/pages/task-audit-log-page/task-audit-log-page.component.html
+++ b/comixed-frontend/src/app/backend-status/pages/task-audit-log-page/task-audit-log-page.component.html
@@ -1,0 +1,29 @@
+<h2>{{"task-audit-log-page.title"|translate}}</h2>
+<p-table [value]="entries"
+         [rows]="rows"
+         [paginator]="true"
+         paginatorPosition="both">
+  <ng-template pTemplate="colgroup">
+    <col class="cx-table-column-medium"/>
+    <col class="cx-table-column-medium"/>
+    <col class="cx-table-column-medium"/>
+    <col/>
+  </ng-template>
+  <ng-template pTemplate="header">
+    <tr>
+      <th id="task-start-time">{{"task-audit-log-page.table.header.start-time"|translate}}</th>
+      <th id="task-end-time">{{"task-audit-log-page.table.header.end-time"|translate}}</th>
+      <th id="task-successful">{{"task-audit-log-page.table.header.successful"|translate}}</th>
+      <th id="task-description">{{"task-audit-log-page.table.header.description"|translate}}</th>
+    </tr>
+  </ng-template>
+  <ng-template pTemplate="body"
+               let-entry>
+    <tr>
+      <td class="cx-table-column-align-center">{{entry.startTime|date:'medium'}}</td>
+      <td class="cx-table-column-align-center">{{entry.endTime|date:'medium'}}</td>
+      <td class="cx-table-column-align-center">{{entry.successful}}</td>
+      <td class="cx-no-wrap-text">{{entry.description}}</td>
+    </tr>
+  </ng-template>
+</p-table>

--- a/comixed-frontend/src/app/backend-status/pages/task-audit-log-page/task-audit-log-page.component.spec.ts
+++ b/comixed-frontend/src/app/backend-status/pages/task-audit-log-page/task-audit-log-page.component.spec.ts
@@ -1,0 +1,68 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TaskAuditLogPageComponent } from './task-audit-log-page.component';
+import { TableModule } from 'primeng/table';
+import { TranslateModule } from '@ngx-translate/core';
+import { LoggerModule } from '@angular-ru/logger';
+import { StoreModule } from '@ngrx/store';
+import {
+  reducer,
+  TASK_AUDIT_LOG_FEATURE_KEY
+} from 'app/backend-status/reducers/task-audit-log.reducer';
+import { EffectsModule } from '@ngrx/effects';
+import { TaskAuditLogEffects } from 'app/backend-status/effects/task-audit-log.effects';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { MessageService } from 'primeng/api';
+import { LibraryModule } from 'app/library/library.module';
+import { RouterTestingModule } from '@angular/router/testing';
+import { BreadcrumbAdaptor } from 'app/adaptors/breadcrumb.adaptor';
+
+describe('TaskAuditLogPageComponent', () => {
+  let component: TaskAuditLogPageComponent;
+  let fixture: ComponentFixture<TaskAuditLogPageComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        LibraryModule,
+        RouterTestingModule,
+        HttpClientTestingModule,
+        TranslateModule.forRoot(),
+        LoggerModule.forRoot(),
+        StoreModule.forRoot({}),
+        StoreModule.forFeature(TASK_AUDIT_LOG_FEATURE_KEY, reducer),
+        EffectsModule.forRoot([]),
+        EffectsModule.forFeature([TaskAuditLogEffects]),
+        TableModule
+      ],
+      declarations: [TaskAuditLogPageComponent],
+      providers: [MessageService, BreadcrumbAdaptor]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TaskAuditLogPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/comixed-frontend/src/app/backend-status/pages/task-audit-log-page/task-audit-log-page.component.ts
+++ b/comixed-frontend/src/app/backend-status/pages/task-audit-log-page/task-audit-log-page.component.ts
@@ -1,0 +1,94 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { TaskAuditLogEntry } from 'app/backend-status/models/task-audit-log-entry';
+import { LoggerService } from '@angular-ru/logger';
+import { TaskAuditLogAdaptor } from 'app/backend-status/adaptors/task-audit-log.adaptor';
+import { LibraryDisplayAdaptor } from 'app/user/adaptors/library-display.adaptor';
+import { BreadcrumbAdaptor } from 'app/adaptors/breadcrumb.adaptor';
+import { TranslateService } from '@ngx-translate/core';
+import { Title } from '@angular/platform-browser';
+
+@Component({
+  selector: 'app-task-audit-log-page',
+  templateUrl: './task-audit-log-page.component.html',
+  styleUrls: ['./task-audit-log-page.component.scss']
+})
+export class TaskAuditLogPageComponent implements OnInit, OnDestroy {
+  fetchingSubscription: Subscription;
+  fetching = false;
+  entriesSubscription: Subscription;
+  entries: TaskAuditLogEntry[] = [];
+  rowsSubscription: Subscription;
+  rows = 0;
+  langChangeSubscription: Subscription;
+
+  constructor(
+    private logger: LoggerService,
+    private taskAuditLogAdaptor: TaskAuditLogAdaptor,
+    private libraryDisplayAdaptor: LibraryDisplayAdaptor,
+    private breadcrumbAdaptor: BreadcrumbAdaptor,
+    private translateService: TranslateService,
+    private titleService: Title
+  ) {
+    this.fetchingSubscription = this.taskAuditLogAdaptor.fetchingEntries$.subscribe(
+      fetching => {
+        this.fetching = fetching;
+        if (fetching === false) {
+          this.taskAuditLogAdaptor.getEntries();
+        }
+      }
+    );
+    this.entriesSubscription = this.taskAuditLogAdaptor.entries$.subscribe(
+      entries => (this.entries = entries)
+    );
+    this.rowsSubscription = this.libraryDisplayAdaptor.rows$.subscribe(
+      rows => (this.rows = rows)
+    );
+    this.langChangeSubscription = this.translateService.onLangChange.subscribe(
+      () => {
+        this.loadTranslations();
+      }
+    );
+    this.loadTranslations();
+  }
+
+  ngOnInit() {}
+
+  ngOnDestroy() {
+    this.fetchingSubscription.unsubscribe();
+    this.entriesSubscription.unsubscribe();
+    this.rowsSubscription.unsubscribe();
+  }
+
+  private loadTranslations() {
+    this.titleService.setTitle(
+      this.translateService.instant('task-audit-log-page.title')
+    );
+    this.breadcrumbAdaptor.loadEntries([
+      { label: this.translateService.instant('breadcrumb.entry.admin.root') },
+      {
+        label: this.translateService.instant(
+          'breadcrumb.entry.admin.task-audit-log'
+        )
+      }
+    ]);
+  }
+}

--- a/comixed-frontend/src/app/backend-status/reducers/task-audit-log.reducer.spec.ts
+++ b/comixed-frontend/src/app/backend-status/reducers/task-audit-log.reducer.spec.ts
@@ -1,0 +1,122 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import {
+  initialState,
+  reducer,
+  TaskAuditLogState
+} from './task-audit-log.reducer';
+import {
+  GetTaskAuditLogEntries,
+  GetTaskAuditLogEntriesFailed,
+  ReceivedTaskAuditLogEntries
+} from 'app/backend-status/actions/task-audit-log.actions';
+import {
+  TASK_AUDIT_LOG_ENTRY_1,
+  TASK_AUDIT_LOG_ENTRY_2,
+  TASK_AUDIT_LOG_ENTRY_3,
+  TASK_AUDIT_LOG_ENTRY_4,
+  TASK_AUDIT_LOG_ENTRY_5
+} from 'app/backend-status/models/task-audit-log-entry.fixtures';
+
+describe('TaskAuditLog Reducer', () => {
+  const LOG_ENTRIES = [
+    TASK_AUDIT_LOG_ENTRY_1,
+    TASK_AUDIT_LOG_ENTRY_3,
+    TASK_AUDIT_LOG_ENTRY_4,
+    TASK_AUDIT_LOG_ENTRY_5
+  ];
+
+  let state: TaskAuditLogState;
+
+  beforeEach(() => {
+    state = initialState;
+  });
+
+  describe('the initial state', () => {
+    beforeEach(() => {
+      state = reducer(state, {} as any);
+    });
+
+    it('clears the fetching entries flag', () => {
+      expect(state.fetchingEntries).toBeFalsy();
+    });
+
+    it('has an empty set of entries', () => {
+      expect(state.entries).toEqual([]);
+    });
+
+    it('has a last entry date of 0', () => {
+      expect(state.lastEntryDate).toEqual(0);
+    });
+  });
+
+  describe('fetching a set of entries', () => {
+    beforeEach(() => {
+      state = reducer(
+        { ...state, fetchingEntries: false },
+        new GetTaskAuditLogEntries({ cutoff: 0 })
+      );
+    });
+
+    it('sets the fetching flag', () => {
+      expect(state.fetchingEntries).toBeTruthy();
+    });
+  });
+
+  describe('receiving a set of entries', () => {
+    beforeEach(() => {
+      state = reducer(
+        {
+          ...state,
+          fetchingEntries: true,
+          entries: [TASK_AUDIT_LOG_ENTRY_2],
+          lastEntryDate: null
+        },
+        new ReceivedTaskAuditLogEntries({ entries: LOG_ENTRIES })
+      );
+    });
+
+    it('clears the fetching flag', () => {
+      expect(state.fetchingEntries).toBeFalsy();
+    });
+
+    it('merges the set of entries', () => {
+      expect(
+        LOG_ENTRIES.every(entry => state.entries.includes(entry))
+      ).toBeTruthy();
+    });
+
+    it('updates the last entry date', () => {
+      expect(state.lastEntryDate).not.toBeNull();
+    });
+  });
+
+  describe('failure to receive audit log entries', () => {
+    beforeEach(() => {
+      state = reducer(
+        { ...state, fetchingEntries: true },
+        new GetTaskAuditLogEntriesFailed()
+      );
+    });
+
+    it('clears the fetching flag', () => {
+      expect(state.fetchingEntries).toBeFalsy();
+    });
+  });
+});

--- a/comixed-frontend/src/app/backend-status/reducers/task-audit-log.reducer.ts
+++ b/comixed-frontend/src/app/backend-status/reducers/task-audit-log.reducer.ts
@@ -1,0 +1,69 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import {
+  TaskAuditLogActions,
+  TaskAuditLogActionTypes
+} from '../actions/task-audit-log.actions';
+import { TaskAuditLogEntry } from 'app/backend-status/models/task-audit-log-entry';
+
+export const TASK_AUDIT_LOG_FEATURE_KEY = 'task_audit_log_state';
+
+export interface TaskAuditLogState {
+  fetchingEntries: boolean;
+  entries: TaskAuditLogEntry[];
+  lastEntryDate: number;
+}
+
+export const initialState: TaskAuditLogState = {
+  fetchingEntries: false,
+  entries: [],
+  lastEntryDate: 0
+};
+
+export function reducer(
+  state = initialState,
+  action: TaskAuditLogActions
+): TaskAuditLogState {
+  switch (action.type) {
+    case TaskAuditLogActionTypes.GetEntries:
+      return { ...state, fetchingEntries: true };
+
+    case TaskAuditLogActionTypes.ReceivedEntries: {
+      const entries = state.entries.concat(action.payload.entries);
+      let lastEntryDate = state.lastEntryDate;
+      entries.forEach(entry => {
+        if (entry.startTime > lastEntryDate) {
+          lastEntryDate = entry.startTime;
+        }
+      });
+      return {
+        ...state,
+        fetchingEntries: false,
+        entries: entries,
+        lastEntryDate: lastEntryDate
+      };
+    }
+
+    case TaskAuditLogActionTypes.GetEntriesFailed:
+      return { ...state, fetchingEntries: false };
+
+    default:
+      return state;
+  }
+}

--- a/comixed-frontend/src/app/backend-status/services/task-audit-log.service.spec.ts
+++ b/comixed-frontend/src/app/backend-status/services/task-audit-log.service.spec.ts
@@ -1,0 +1,77 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { TestBed } from '@angular/core/testing';
+
+import { TaskAuditLogService } from './task-audit-log.service';
+import {
+  TASK_AUDIT_LOG_ENTRY_1,
+  TASK_AUDIT_LOG_ENTRY_2,
+  TASK_AUDIT_LOG_ENTRY_3,
+  TASK_AUDIT_LOG_ENTRY_4,
+  TASK_AUDIT_LOG_ENTRY_5
+} from 'app/backend-status/backend-status.fixtures';
+import { LoggerModule } from '@angular-ru/logger';
+import {
+  HttpClientTestingModule,
+  HttpTestingController
+} from '@angular/common/http/testing';
+import { interpolate } from 'app/app.functions';
+import { GET_TASK_LOG_ENTRIES_URL } from 'app/backend-status/backend-status.constants';
+
+describe('TaskAuditLogService', () => {
+  const LAST_ENTRY_DATE = new Date().getTime();
+  const LOG_ENTRIES = [
+    TASK_AUDIT_LOG_ENTRY_1,
+    TASK_AUDIT_LOG_ENTRY_2,
+    TASK_AUDIT_LOG_ENTRY_3,
+    TASK_AUDIT_LOG_ENTRY_4,
+    TASK_AUDIT_LOG_ENTRY_5
+  ];
+
+  let taskAuditLogService: TaskAuditLogService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, LoggerModule.forRoot()],
+      providers: [TaskAuditLogService]
+    });
+
+    taskAuditLogService = TestBed.get(TaskAuditLogService);
+    httpMock = TestBed.get(HttpTestingController);
+  });
+
+  it('should be created', () => {
+    expect(taskAuditLogService).toBeTruthy();
+  });
+
+  it('can get a list of log entries', () => {
+    taskAuditLogService
+      .getLogEntries(LAST_ENTRY_DATE)
+      .subscribe(response => expect(response).toEqual(LOG_ENTRIES));
+
+    const req = httpMock.expectOne(
+      interpolate(GET_TASK_LOG_ENTRIES_URL, {
+        timestamp: LAST_ENTRY_DATE
+      })
+    );
+    expect(req.request.method).toEqual('GET');
+    req.flush(LOG_ENTRIES);
+  });
+});

--- a/comixed-frontend/src/app/backend-status/services/task-audit-log.service.ts
+++ b/comixed-frontend/src/app/backend-status/services/task-audit-log.service.ts
@@ -1,0 +1,41 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { LoggerService } from '@angular-ru/logger';
+import { HttpClient } from '@angular/common/http';
+import { GET_TASK_LOG_ENTRIES_URL } from 'app/backend-status/backend-status.constants';
+import { interpolate } from 'app/app.functions';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TaskAuditLogService {
+  constructor(private logger: LoggerService, private http: HttpClient) {}
+
+  getLogEntries(timestamp: number): Observable<any> {
+    this.logger.debug(
+      '[GET] http request: get task audit log entries:',
+        timestamp
+    );
+    return this.http.get(
+      interpolate(GET_TASK_LOG_ENTRIES_URL, { timestamp: timestamp })
+    );
+  }
+}

--- a/comixed-frontend/src/app/components/navigation-bar/navigation-bar.component.ts
+++ b/comixed-frontend/src/app/components/navigation-bar/navigation-bar.component.ts
@@ -179,6 +179,14 @@ export class NavigationBarComponent implements OnInit {
           },
           {
             label: this.translateService.instant(
+              'main-menu.item.admin.task-audit-log'
+            ),
+            icon: 'fa fa-fw fas fa-tasks',
+            routerLink: ['/admin/tasks/logs'],
+            visible: this.isAdmin
+          },
+          {
+            label: this.translateService.instant(
               'main-menu.item.admin.clear-image-cache'
             ),
             icon: 'fa fa-fw fa-trash',

--- a/comixed-frontend/src/assets/i18n/en/app.json
+++ b/comixed-frontend/src/assets/i18n/en/app.json
@@ -413,7 +413,8 @@
         "users-admin": "Users",
         "import-page": "Import Comics",
         "duplicates-page": "Duplicates Page",
-        "missing-comics": "Missing Comics"
+        "missing-comics": "Missing Comics",
+        "task-audit-log": "Task Log"
       }
     }
   },

--- a/comixed-frontend/src/assets/i18n/en/backend-status.json
+++ b/comixed-frontend/src/assets/i18n/en/backend-status.json
@@ -20,5 +20,12 @@
       "dirty": "Built From Uncommitted Code?",
       "remote-origin-url": "Remote Origin"
     }
+  },
+  "task-audit-log-effects": {
+    "get-log-entries": {
+      "error": {
+        "detail": "Failed to get task audit log entries."
+      }
+    }
   }
 }

--- a/comixed-frontend/src/assets/i18n/en/backend-status.json
+++ b/comixed-frontend/src/assets/i18n/en/backend-status.json
@@ -27,5 +27,16 @@
         "detail": "Failed to get task audit log entries."
       }
     }
+  },
+  "task-audit-log-page": {
+    "title": "Task Logs",
+    "table": {
+      "header": {
+        "start-time": "Started",
+        "end-time": "Ended",
+        "successful": "Success?",
+        "description": "Description"
+      }
+    }
   }
 }

--- a/comixed-frontend/src/assets/i18n/en/common.json
+++ b/comixed-frontend/src/assets/i18n/en/common.json
@@ -31,6 +31,7 @@
         "import": "Import",
         "duplicate-pages": "Duplicate Pages",
         "missing-comics": "Missing Comics",
+        "task-audit-log": "Task Logs",
         "clear-image-cache": "Clear Image Cache"
       },
       "help": {

--- a/comixed-frontend/src/assets/i18n/es/app.json
+++ b/comixed-frontend/src/assets/i18n/es/app.json
@@ -413,7 +413,8 @@
         "users-admin": "Usuarios",
         "import-page": "Importar cómics",
         "duplicates-page": "Páginas duplicadas",
-        "missing-comics": "Cómics no encontrados"
+        "missing-comics": "Cómics no encontrados",
+        "task-audit-log": "Task Log"
       }
     }
   },

--- a/comixed-frontend/src/assets/i18n/es/backend-status.json
+++ b/comixed-frontend/src/assets/i18n/es/backend-status.json
@@ -27,5 +27,16 @@
         "detail": "Failed to get task audit log entries."
       }
     }
+  },
+  "task-audit-log-page": {
+    "title": "Task Logs",
+    "table": {
+      "header": {
+        "start-time": "Started",
+        "end-time": "Ended",
+        "successful": "Success?",
+        "description": "Description"
+      }
+    }
   }
 }

--- a/comixed-frontend/src/assets/i18n/es/backend-status.json
+++ b/comixed-frontend/src/assets/i18n/es/backend-status.json
@@ -20,5 +20,12 @@
       "dirty": "¿Compilado desde código Uncommitted?",
       "remote-origin-url": "Remote Origin"
     }
+  },
+  "task-audit-log-effects": {
+    "get-log-entries": {
+      "error": {
+        "detail": "Failed to get task audit log entries."
+      }
+    }
   }
 }

--- a/comixed-frontend/src/assets/i18n/es/common.json
+++ b/comixed-frontend/src/assets/i18n/es/common.json
@@ -31,6 +31,7 @@
         "import": "Importar",
         "duplicate-pages": "Páginas duplicadas",
         "missing-comics": "Cómics que faltan",
+        "task-audit-log": "Task Logs",
         "clear-image-cache": "Clear Image Cache"
       },
       "help": {

--- a/comixed-frontend/src/assets/i18n/fr/app.json
+++ b/comixed-frontend/src/assets/i18n/fr/app.json
@@ -418,7 +418,8 @@
         "users-admin": "Utilisateurs",
         "import-page": "Importer des bandes dessinées",
         "duplicates-page": "Page dupliquées",
-        "missing-comics": "Bandes dessinées manquantes"
+        "missing-comics": "Bandes dessinées manquantes",
+        "task-audit-log": "Task Log"
       }
     }
   },

--- a/comixed-frontend/src/assets/i18n/fr/backend-status.json
+++ b/comixed-frontend/src/assets/i18n/fr/backend-status.json
@@ -20,5 +20,12 @@
       "dirty": "Construit à partir d'un code non comité?",
       "remote-origin-url": "url du \"Remote Origin\""
     }
+  },
+  "task-audit-log-effects": {
+    "get-log-entries": {
+      "error": {
+        "detail": "Failed to get task audit log entries."
+      }
+    }
   }
 }

--- a/comixed-frontend/src/assets/i18n/fr/backend-status.json
+++ b/comixed-frontend/src/assets/i18n/fr/backend-status.json
@@ -27,5 +27,16 @@
         "detail": "Failed to get task audit log entries."
       }
     }
+  },
+  "task-audit-log-page": {
+    "title": "Task Logs",
+    "table": {
+      "header": {
+        "start-time": "Started",
+        "end-time": "Ended",
+        "successful": "Success?",
+        "description": "Description"
+      }
+    }
   }
 }

--- a/comixed-frontend/src/assets/i18n/fr/common.json
+++ b/comixed-frontend/src/assets/i18n/fr/common.json
@@ -31,6 +31,7 @@
         "import": "Importer",
         "duplicate-pages": "Pages dupliquées",
         "missing-comics": "Bandes dessinées manquantes",
+        "task-audit-log": "Task Logs",
         "clear-image-cache": "Vider le cache des images"
       },
       "help": {

--- a/comixed-frontend/src/assets/i18n/pt/app.json
+++ b/comixed-frontend/src/assets/i18n/pt/app.json
@@ -413,7 +413,8 @@
         "users-admin": "Users",
         "import-page": "Import Comics",
         "duplicates-page": "Duplicates Page",
-        "missing-comics": "Missing Comics"
+        "missing-comics": "Missing Comics",
+        "task-audit-log": "Task Log"
       }
     }
   },

--- a/comixed-frontend/src/assets/i18n/pt/backend-status.json
+++ b/comixed-frontend/src/assets/i18n/pt/backend-status.json
@@ -20,5 +20,12 @@
       "dirty": "Built From Uncommitted Code?",
       "remote-origin-url": "Remote Origin"
     }
+  },
+  "task-audit-log-effects": {
+    "get-log-entries": {
+      "error": {
+        "detail": "Failed to get task audit log entries."
+      }
+    }
   }
 }

--- a/comixed-frontend/src/assets/i18n/pt/backend-status.json
+++ b/comixed-frontend/src/assets/i18n/pt/backend-status.json
@@ -27,5 +27,16 @@
         "detail": "Failed to get task audit log entries."
       }
     }
+  },
+  "task-audit-log-page": {
+    "title": "Task Logs",
+    "table": {
+      "header": {
+        "start-time": "Started",
+        "end-time": "Ended",
+        "successful": "Success?",
+        "description": "Description"
+      }
+    }
   }
 }

--- a/comixed-frontend/src/assets/i18n/pt/common.json
+++ b/comixed-frontend/src/assets/i18n/pt/common.json
@@ -31,6 +31,7 @@
         "import": "Import",
         "duplicate-pages": "Duplicate Pages",
         "missing-comics": "Missing Comics",
+        "task-audit-log": "Task Logs",
         "clear-image-cache": "Clear Image Cache"
       },
       "help": {

--- a/comixed-library/src/main/java/org/comixedproject/model/tasks/TaskAuditLogEntry.java
+++ b/comixed-library/src/main/java/org/comixedproject/model/tasks/TaskAuditLogEntry.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 import javax.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
-import org.comixed.views.View;
+import org.comixedproject.views.View;
 
 /**
  * <code>TaskAuditLogEntry</code> represents a single entry in the task audit log table.

--- a/comixed-library/src/main/java/org/comixedproject/model/tasks/TaskAuditLogEntry.java
+++ b/comixed-library/src/main/java/org/comixedproject/model/tasks/TaskAuditLogEntry.java
@@ -18,11 +18,15 @@
 
 package org.comixedproject.model.tasks;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonView;
 import java.util.Date;
 import java.util.Objects;
 import javax.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.comixed.views.View;
 
 /**
  * <code>TaskAuditLogEntry</code> represents a single entry in the task audit log table.
@@ -41,21 +45,31 @@ public class TaskAuditLogEntry {
   @Column(name = "start_time", nullable = false, updatable = false)
   @Getter
   @Setter
+  @JsonProperty("startTime")
+  @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+  @JsonView(View.TaskAuditLogEntryList.class)
   private Date startTime = new Date();
 
   @Column(name = "end_time", nullable = false, updatable = false)
   @Getter
   @Setter
+  @JsonProperty("endTime")
+  @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+  @JsonView(View.TaskAuditLogEntryList.class)
   private Date endTime = new Date();
 
   @Column(name = "successful", nullable = false, updatable = false)
   @Getter
   @Setter
+  @JsonProperty("successful")
+  @JsonView(View.TaskAuditLogEntryList.class)
   private Boolean successful;
 
   @Column(name = "description", nullable = false, updatable = false, length = 2048)
   @Getter
   @Setter
+  @JsonProperty("description")
+  @JsonView(View.TaskAuditLogEntryList.class)
   private String description;
 
   @Override

--- a/comixed-library/src/main/java/org/comixedproject/views/View.java
+++ b/comixed-library/src/main/java/org/comixedproject/views/View.java
@@ -62,4 +62,7 @@ public class View {
 
   /** Used when viewing the list of plugins. */
   public interface PluginList {}
+
+  /** Uses when viewing the list of task audit log entries. */
+  public interface TaskAuditLogEntryList {}
 }

--- a/comixed-rest-api/src/main/java/org/comixed/controller/ComiXedControllerException.java
+++ b/comixed-rest-api/src/main/java/org/comixed/controller/ComiXedControllerException.java
@@ -1,0 +1,31 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixed.controller;
+
+/**
+ * <code>ComiXedControllerException</code> is throw when an error occurs during the processing of a
+ * REST API request.
+ *
+ * @author Darryl L. Pierce
+ */
+public class ComiXedControllerException extends Exception {
+  public ComiXedControllerException(final String message, final Exception cause) {
+    super(message, cause);
+  }
+}

--- a/comixed-rest-api/src/main/java/org/comixed/controller/tasks/TaskController.java
+++ b/comixed-rest-api/src/main/java/org/comixed/controller/tasks/TaskController.java
@@ -1,0 +1,71 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixed.controller.tasks;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import java.util.Date;
+import java.util.List;
+import lombok.extern.log4j.Log4j2;
+import org.comixed.controller.ComiXedControllerException;
+import org.comixed.model.tasks.TaskAuditLogEntry;
+import org.comixed.repositories.tasks.TaskAuditLogRepository;
+import org.comixed.service.ComiXedServiceException;
+import org.comixed.service.task.TaskService;
+import org.comixed.views.View;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * <code>TaskController</code> provides REST APIs for interacting with the tasks system.
+ *
+ * @author Darryl L. Pierce
+ */
+@RestController
+@RequestMapping(value = "/api/tasks")
+@Log4j2
+public class TaskController {
+  @Autowired private TaskAuditLogRepository taskAuditLogRepository;
+  @Autowired private TaskService taskService;
+
+  /**
+   * Retrieve the list of log entries after the cutoff time.
+   *
+   * @param cutoff the cutoff
+   * @return the log entries
+   */
+  @GetMapping(value = "/entries/{cutoff}", produces = MediaType.APPLICATION_JSON_VALUE)
+  @PreAuthorize("hasRole('ADMIN')")
+  @JsonView(View.TaskAuditLogEntryList.class)
+  public List<TaskAuditLogEntry> getAllAfterDate(@PathVariable("cutoff") final Long timestamp)
+      throws ComiXedControllerException {
+    final Date cutoff = new Date(timestamp);
+    log.debug("Getting all task audit log entries after: {}", cutoff);
+
+    try {
+      return this.taskService.getAuditLogEntriesAfter(cutoff);
+    } catch (ComiXedServiceException error) {
+      throw new ComiXedControllerException("unable to get task audit log entries", error);
+    }
+  }
+}

--- a/comixed-rest-api/src/main/java/org/comixedproject/controller/ComiXedControllerException.java
+++ b/comixed-rest-api/src/main/java/org/comixedproject/controller/ComiXedControllerException.java
@@ -1,6 +1,6 @@
 /*
  * ComiXed - A digital comic book library management application.
- * Copyright (C) 2020, The ComiXed Project.
+ * Copyright (C) 2020, The ComiXed Project
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,15 +16,16 @@
  * along with this program. If not, see <http://www.gnu.org/licenses>
  */
 
-package org.comixed.service;
+package org.comixedproject.controller;
 
 /**
- * <code>ComiXedServiceException</code> is thrown when a service-level exception occurs.
+ * <code>ComiXedControllerException</code> is throw when an error occurs during the processing of a
+ * REST API request.
  *
  * @author Darryl L. Pierce
  */
-public class ComiXedServiceException extends Exception {
-  public ComiXedServiceException(final String message, final InterruptedException cause) {
+public class ComiXedControllerException extends Exception {
+  public ComiXedControllerException(final String message, final Exception cause) {
     super(message, cause);
   }
 }

--- a/comixed-rest-api/src/main/java/org/comixedproject/controller/scraping/ComicVineScraperController.java
+++ b/comixed-rest-api/src/main/java/org/comixedproject/controller/scraping/ComicVineScraperController.java
@@ -21,7 +21,7 @@ package org.comixedproject.controller.scraping;
 import com.fasterxml.jackson.annotation.JsonView;
 import java.util.List;
 import lombok.extern.log4j.Log4j2;
-import org.comixedproject.controller.RESTException;
+import org.comixedproject.controller.ComiXedControllerException;
 import org.comixedproject.model.comic.Comic;
 import org.comixedproject.net.ComicScrapeRequest;
 import org.comixedproject.net.GetScrapingIssueRequest;

--- a/comixed-rest-api/src/main/java/org/comixedproject/controller/scraping/ComicVineScraperController.java
+++ b/comixed-rest-api/src/main/java/org/comixedproject/controller/scraping/ComicVineScraperController.java
@@ -55,7 +55,7 @@ public class ComicVineScraperController {
    * @param volume the volume id
    * @param request the request body
    * @return the issue
-   * @throws RESTException if an error occurs
+   * @throws ComiXedControllerException if an error occurs
    */
   @PostMapping(
       value = "/volumes/{volume}/issues",
@@ -64,7 +64,7 @@ public class ComicVineScraperController {
   public ScrapingIssue queryForIssue(
       @PathVariable("volume") final Integer volume,
       @RequestBody() final GetScrapingIssueRequest request)
-      throws RESTException {
+      throws ComiXedControllerException {
     String issue = request.getIssueNumber();
     boolean skipCache = request.isSkipCache();
     String apiKey = request.getApiKey();
@@ -75,7 +75,7 @@ public class ComicVineScraperController {
     try {
       return this.scrapingAdaptor.getIssue(apiKey, volume, issue, skipCache);
     } catch (ScrapingException error) {
-      throw new RESTException("Failed to get single scraping issue", error);
+      throw new ComiXedControllerException("Failed to get single scraping issue", error);
     }
   }
 
@@ -84,14 +84,14 @@ public class ComicVineScraperController {
    *
    * @param request the reqwuest body
    * @return the list of volumes
-   * @throws RESTException if an error occurs
+   * @throws ComiXedControllerException if an error occurs
    */
   @PostMapping(
       value = "/volumes",
       produces = MediaType.APPLICATION_JSON_VALUE,
       consumes = MediaType.APPLICATION_JSON_VALUE)
   public List<ScrapingVolume> queryForVolumes(@RequestBody() final GetVolumesRequest request)
-      throws RESTException {
+      throws ComiXedControllerException {
     String apiKey = request.getApiKey();
     boolean skipCache = request.getSkipCache();
     String series = request.getSeries();
@@ -105,7 +105,7 @@ public class ComicVineScraperController {
 
       return result;
     } catch (ScrapingException error) {
-      throw new RESTException("Failed to get list of volumes", error);
+      throw new ComiXedControllerException("Failed to get list of volumes", error);
     }
   }
 
@@ -116,7 +116,7 @@ public class ComicVineScraperController {
    * @param issueId the issue id
    * @param request the request body
    * @return the scraped and updaed {@link Comic}
-   * @throws RESTException if an error occurs
+   * @throws ComiXedControllerException if an error occurs
    */
   @PostMapping(
       value = "/comics/{comicId}/issue/{issueId}",
@@ -127,7 +127,7 @@ public class ComicVineScraperController {
       @PathVariable("comicId") final Long comicId,
       @PathVariable("issueId") final String issueId,
       @RequestBody() final ComicScrapeRequest request)
-      throws RESTException {
+      throws ComiXedControllerException {
     boolean skipCache = request.getSkipCache();
     String apiKey = request.getApiKey();
 
@@ -138,7 +138,7 @@ public class ComicVineScraperController {
     try {
       comic = this.comicService.getComic(comicId);
     } catch (ComicException error) {
-      throw new RESTException("Failed to load comic", error);
+      throw new ComiXedControllerException("Failed to load comic", error);
     }
 
     try {
@@ -150,7 +150,7 @@ public class ComicVineScraperController {
 
       return comic;
     } catch (ScrapingException error) {
-      throw new RESTException("Failed to scrape comic", error);
+      throw new ComiXedControllerException("Failed to scrape comic", error);
     }
   }
 }

--- a/comixed-rest-api/src/main/java/org/comixedproject/controller/tasks/TaskController.java
+++ b/comixed-rest-api/src/main/java/org/comixedproject/controller/tasks/TaskController.java
@@ -16,18 +16,18 @@
  * along with this program. If not, see <http://www.gnu.org/licenses>
  */
 
-package org.comixed.controller.tasks;
+package org.comixedproject.controller.tasks;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import java.util.Date;
 import java.util.List;
 import lombok.extern.log4j.Log4j2;
-import org.comixed.controller.ComiXedControllerException;
-import org.comixed.model.tasks.TaskAuditLogEntry;
-import org.comixed.repositories.tasks.TaskAuditLogRepository;
-import org.comixed.service.ComiXedServiceException;
-import org.comixed.service.task.TaskService;
-import org.comixed.views.View;
+import org.comixedproject.controller.ComiXedControllerException;
+import org.comixedproject.model.tasks.TaskAuditLogEntry;
+import org.comixedproject.repositories.tasks.TaskAuditLogRepository;
+import org.comixedproject.service.ComiXedServiceException;
+import org.comixedproject.service.task.TaskService;
+import org.comixedproject.views.View;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;

--- a/comixed-rest-api/src/main/java/org/comixedproject/web/authentication/ComiXedWebSecurityConfig.java
+++ b/comixed-rest-api/src/main/java/org/comixedproject/web/authentication/ComiXedWebSecurityConfig.java
@@ -35,7 +35,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true)
-@ComponentScan("org.comixed.controller")
+@ComponentScan("org.comixedprojectcontroller")
 @Log4j2
 public class ComiXedWebSecurityConfig extends WebSecurityConfigurerAdapter {
   @Autowired private ComiXedAuthenticationEntryPoint unauthorizedHandler;

--- a/comixed-rest-api/src/main/java/org/comixedproject/web/authentication/ComiXedWebSecurityConfig.java
+++ b/comixed-rest-api/src/main/java/org/comixedproject/web/authentication/ComiXedWebSecurityConfig.java
@@ -21,6 +21,7 @@ package org.comixedproject.web.authentication;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -34,6 +35,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true)
+@ComponentScan("org.comixed.controller")
 @Log4j2
 public class ComiXedWebSecurityConfig extends WebSecurityConfigurerAdapter {
   @Autowired private ComiXedAuthenticationEntryPoint unauthorizedHandler;

--- a/comixed-rest-api/src/test/java/org/comixed/controller/tasks/TaskControllerTest.java
+++ b/comixed-rest-api/src/test/java/org/comixed/controller/tasks/TaskControllerTest.java
@@ -1,0 +1,61 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixed.controller.tasks;
+
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertSame;
+
+import java.util.Date;
+import java.util.List;
+import org.comixed.controller.ComiXedControllerException;
+import org.comixed.model.tasks.TaskAuditLogEntry;
+import org.comixed.service.ComiXedServiceException;
+import org.comixed.service.task.TaskService;
+import org.comixed.service.user.UserService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TaskControllerTest {
+  private static final Date TEST_LAST_UPDATED_DATE = new Date();
+  private static final String TEST_USER_EMAIL = "user@domain.tld";
+
+  @InjectMocks private TaskController taskController;
+  @Mock private UserService userService;
+  @Mock private TaskService taskService;
+  @Mock private List<TaskAuditLogEntry> auditLogEntries;
+
+  @Test
+  public void testGetAllEntries() throws ComiXedServiceException, ComiXedControllerException {
+    Mockito.when(taskService.getAuditLogEntriesAfter(Mockito.any(Date.class)))
+        .thenReturn(auditLogEntries);
+
+    final List<TaskAuditLogEntry> result =
+        taskController.getAllAfterDate(TEST_LAST_UPDATED_DATE.getTime());
+
+    assertNotNull(result);
+    assertSame(auditLogEntries, result);
+
+    Mockito.verify(taskService, Mockito.times(1)).getAuditLogEntriesAfter(TEST_LAST_UPDATED_DATE);
+  }
+}

--- a/comixed-rest-api/src/test/java/org/comixedproject/controller/scraping/ComicVineScraperControllerTest.java
+++ b/comixed-rest-api/src/test/java/org/comixedproject/controller/scraping/ComicVineScraperControllerTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 
 import java.util.List;
-import org.comixedproject.controller.RESTException;
+import org.comixedproject.controller.ComiXedControllerException;
 import org.comixedproject.model.comic.Comic;
 import org.comixedproject.net.ComicScrapeRequest;
 import org.comixedproject.net.GetScrapingIssueRequest;

--- a/comixed-rest-api/src/test/java/org/comixedproject/controller/scraping/ComicVineScraperControllerTest.java
+++ b/comixed-rest-api/src/test/java/org/comixedproject/controller/scraping/ComicVineScraperControllerTest.java
@@ -59,8 +59,9 @@ public class ComicVineScraperControllerTest {
   @Mock private ComicService comicService;
   @Mock private Comic comic;
 
-  @Test(expected = RESTException.class)
-  public void testQueryForVolumesAdaptorRaisesException() throws ScrapingException, RESTException {
+  @Test(expected = ComiXedControllerException.class)
+  public void testQueryForVolumesAdaptorRaisesException()
+      throws ScrapingException, ComiXedControllerException {
     Mockito.when(
             scrapingAdaptor.getVolumes(
                 Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean()))
@@ -75,7 +76,7 @@ public class ComicVineScraperControllerTest {
   }
 
   @Test
-  public void testQueryForVolumes() throws RESTException, ScrapingException {
+  public void testQueryForVolumes() throws ComiXedControllerException, ScrapingException {
     Mockito.when(
             scrapingAdaptor.getVolumes(
                 Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean()))
@@ -91,7 +92,7 @@ public class ComicVineScraperControllerTest {
   }
 
   @Test
-  public void testQueryForVolumesSkipCache() throws ScrapingException, RESTException {
+  public void testQueryForVolumesSkipCache() throws ScrapingException, ComiXedControllerException {
     Mockito.when(
             scrapingAdaptor.getVolumes(
                 Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean()))
@@ -106,8 +107,9 @@ public class ComicVineScraperControllerTest {
         .getVolumes(TEST_API_KEY, TEST_SERIES_NAME, true);
   }
 
-  @Test(expected = RESTException.class)
-  public void testQueryForIssueAdaptorRaisesException() throws ScrapingException, RESTException {
+  @Test(expected = ComiXedControllerException.class)
+  public void testQueryForIssueAdaptorRaisesException()
+      throws ScrapingException, ComiXedControllerException {
     Mockito.when(
             scrapingAdaptor.getIssue(
                 Mockito.anyString(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyBoolean()))
@@ -124,7 +126,7 @@ public class ComicVineScraperControllerTest {
   }
 
   @Test
-  public void testQueryForIssue() throws ScrapingException, RESTException {
+  public void testQueryForIssue() throws ScrapingException, ComiXedControllerException {
     Mockito.when(
             scrapingAdaptor.getIssue(
                 Mockito.anyString(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyBoolean()))
@@ -142,8 +144,9 @@ public class ComicVineScraperControllerTest {
         .getIssue(TEST_API_KEY, TEST_VOLUME, TEST_ISSUE_NUMBER, TEST_SKIP_CACHE);
   }
 
-  @Test(expected = RESTException.class)
-  public void testScrapeAndSaveComicDetailsNoSuchComic() throws ComicException, RESTException {
+  @Test(expected = ComiXedControllerException.class)
+  public void testScrapeAndSaveComicDetailsNoSuchComic()
+      throws ComicException, ComiXedControllerException {
     Mockito.when(comicService.getComic(Mockito.anyLong())).thenThrow(ComicException.class);
 
     try {
@@ -154,9 +157,9 @@ public class ComicVineScraperControllerTest {
     }
   }
 
-  @Test(expected = RESTException.class)
+  @Test(expected = ComiXedControllerException.class)
   public void testScrapeAndSaveComicDetailsScrapingAdaptorRaisesException()
-      throws ComicException, ScrapingException, RESTException {
+      throws ComicException, ScrapingException, ComiXedControllerException {
     Mockito.when(comicService.getComic(Mockito.anyLong())).thenReturn(comic);
     Mockito.doThrow(ScrapingException.class)
         .when(scrapingAdaptor)
@@ -177,7 +180,7 @@ public class ComicVineScraperControllerTest {
 
   @Test
   public void testScrapeAndSaveComicDetails()
-      throws ComicException, ScrapingException, RESTException {
+      throws ComicException, ScrapingException, ComiXedControllerException {
     Mockito.when(comicService.getComic(Mockito.anyLong())).thenReturn(comic);
 
     Comic result =

--- a/comixed-rest-api/src/test/java/org/comixedproject/controller/tasks/TaskControllerTest.java
+++ b/comixed-rest-api/src/test/java/org/comixedproject/controller/tasks/TaskControllerTest.java
@@ -16,18 +16,18 @@
  * along with this program. If not, see <http://www.gnu.org/licenses>
  */
 
-package org.comixed.controller.tasks;
+package org.comixedproject.controller.tasks;
 
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertSame;
 
 import java.util.Date;
 import java.util.List;
-import org.comixed.controller.ComiXedControllerException;
-import org.comixed.model.tasks.TaskAuditLogEntry;
-import org.comixed.service.ComiXedServiceException;
-import org.comixed.service.task.TaskService;
-import org.comixed.service.user.UserService;
+import org.comixedproject.controller.ComiXedControllerException;
+import org.comixedproject.model.tasks.TaskAuditLogEntry;
+import org.comixedproject.service.ComiXedServiceException;
+import org.comixedproject.service.task.TaskService;
+import org.comixedproject.service.user.UserService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;

--- a/comixed-services/src/main/java/org/comixed/service/ComiXedServiceException.java
+++ b/comixed-services/src/main/java/org/comixed/service/ComiXedServiceException.java
@@ -1,0 +1,30 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixed.service;
+
+/**
+ * <code>ComiXedServiceException</code> is thrown when a service-level exception occurs.
+ *
+ * @author Darryl L. Pierce
+ */
+public class ComiXedServiceException extends Exception {
+  public ComiXedServiceException(final String message, final InterruptedException cause) {
+    super(message, cause);
+  }
+}

--- a/comixed-services/src/main/java/org/comixedproject/service/ComiXedServiceException.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/ComiXedServiceException.java
@@ -1,6 +1,6 @@
 /*
  * ComiXed - A digital comic book library management application.
- * Copyright (C) 2020, The ComiXed Project
+ * Copyright (C) 2020, The ComiXed Project.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,16 +16,15 @@
  * along with this program. If not, see <http://www.gnu.org/licenses>
  */
 
-package org.comixed.controller;
+package org.comixedproject.service;
 
 /**
- * <code>ComiXedControllerException</code> is throw when an error occurs during the processing of a
- * REST API request.
+ * <code>ComiXedServiceException</code> is thrown when a service-level exception occurs.
  *
  * @author Darryl L. Pierce
  */
-public class ComiXedControllerException extends Exception {
-  public ComiXedControllerException(final String message, final Exception cause) {
+public class ComiXedServiceException extends Exception {
+  public ComiXedServiceException(final String message, final InterruptedException cause) {
     super(message, cause);
   }
 }

--- a/comixed-services/src/main/java/org/comixedproject/service/task/TaskService.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/task/TaskService.java
@@ -21,8 +21,11 @@ package org.comixedproject.service.task;
 import java.util.Date;
 import java.util.List;
 import lombok.extern.log4j.Log4j2;
+import org.comixedproject.model.tasks.TaskAuditLogEntry;
 import org.comixedproject.model.tasks.TaskType;
+import org.comixedproject.repositories.tasks.TaskAuditLogRepository;
 import org.comixedproject.repositories.tasks.TaskRepository;
+import org.comixedproject.service.ComiXedServiceException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 

--- a/comixed-services/src/test/java/org/comixedproject/service/task/TaskServiceTest.java
+++ b/comixed-services/src/test/java/org/comixedproject/service/task/TaskServiceTest.java
@@ -18,7 +18,7 @@
 
 package org.comixedproject.service.task;
 
-import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.*;
 
 import org.comixedproject.model.tasks.TaskType;
 import org.comixedproject.repositories.tasks.TaskRepository;
@@ -32,17 +32,35 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class TaskServiceTest {
   private static final int TEST_TASK_COUNT = 279;
+  private static final Date TEST_AUDIT_LOG_CUTOFF_DATE = new Date();
 
-  @InjectMocks private TaskService service;
+  @InjectMocks private TaskService taskService;
   @Mock private TaskRepository taskRepository;
+  @Mock private TaskAuditLogRepository taskAuditLogRepository;
+  @Mock private List<TaskAuditLogEntry> auditLogEntryList;
 
   @Test
   public void testGetTaskCount() {
     Mockito.when(taskRepository.getTaskCount(Mockito.any(TaskType.class)))
         .thenReturn(TEST_TASK_COUNT);
 
-    final int result = service.getTaskCount(TaskType.ADD_COMIC);
+    final int result = taskService.getTaskCount(TaskType.ADD_COMIC);
 
     assertEquals(TEST_TASK_COUNT, result);
+  }
+
+  @Test
+  public void testGetAuditLogEntriesAfter() throws ComiXedServiceException {
+    Mockito.when(taskAuditLogRepository.findAllByStartTimeGreaterThan(Mockito.any(Date.class)))
+        .thenReturn(auditLogEntryList);
+
+    final List<TaskAuditLogEntry> result =
+        taskService.getAuditLogEntriesAfter(TEST_AUDIT_LOG_CUTOFF_DATE);
+
+    assertNotNull(result);
+    assertSame(auditLogEntryList, result);
+
+    Mockito.verify(taskAuditLogRepository, Mockito.times(1))
+        .findAllByStartTimeGreaterThan(TEST_AUDIT_LOG_CUTOFF_DATE);
   }
 }

--- a/comixed-services/src/test/java/org/comixedproject/service/task/TaskServiceTest.java
+++ b/comixed-services/src/test/java/org/comixedproject/service/task/TaskServiceTest.java
@@ -20,8 +20,13 @@ package org.comixedproject.service.task;
 
 import static junit.framework.TestCase.*;
 
+import java.util.Date;
+import java.util.List;
+import org.comixedproject.model.tasks.TaskAuditLogEntry;
 import org.comixedproject.model.tasks.TaskType;
+import org.comixedproject.repositories.tasks.TaskAuditLogRepository;
 import org.comixedproject.repositories.tasks.TaskRepository;
+import org.comixedproject.service.ComiXedServiceException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Add a page and REST APIs for viewing the contents of the task audit log table.