### PR TITLE
Pages can be marked and unmarked for deletion

### DIFF
--- a/comixed-frontend/src/app/comics/actions/comic.actions.ts
+++ b/comixed-frontend/src/app/comics/actions/comic.actions.ts
@@ -37,6 +37,9 @@ export enum ComicActionTypes {
   SavePageFailed = '[COMIC] Page was not saved',
   SetPageType = '[COMIC] Set the page type',
   PageTypeSet = '[COMIC] The page type is set',
+  SetPageDeleted = '[COMIC] Set the deleted state for a page',
+  PageDeletedSet = '[COMIC] The deleted state for a page is set',
+  SetPageDeletedFailed = '[COMIC] Failed to set the deleted state for a page',
   SetPageTypeFailed = '[COMIC] Set the page type failed',
   SetPageHashBlocking = '[COMIC] Set the blocking state for a page hash',
   PageHashBlockingSet = '[COMIC] The blocking state is set for a page hash',
@@ -162,6 +165,24 @@ export class ComicPageTypeSet implements Action {
 
 export class ComicSetPageTypeFailed implements Action {
   readonly type = ComicActionTypes.SetPageTypeFailed;
+
+  constructor() {}
+}
+
+export class ComicSetPageDeleted implements Action {
+  readonly type = ComicActionTypes.SetPageDeleted;
+
+  constructor(public payload: { page: Page; deleted: boolean }) {}
+}
+
+export class ComicPageDeletedSet implements Action {
+  readonly type = ComicActionTypes.PageDeletedSet;
+
+  constructor(public payload: { comic: Comic }) {}
+}
+
+export class ComicSetPageDeletedFailed implements Action {
+  readonly type = ComicActionTypes.SetPageDeletedFailed;
 
   constructor() {}
 }
@@ -293,6 +314,9 @@ export type ComicActions =
   | ComicSetPageType
   | ComicPageTypeSet
   | ComicSetPageTypeFailed
+  | ComicSetPageDeleted
+  | ComicPageDeletedSet
+  | ComicSetPageDeletedFailed
   | ComicSetPageHashBlocking
   | ComicPageHashBlockingSet
   | ComicSetPageHashBlockingFailed

--- a/comixed-frontend/src/app/comics/adaptors/comic.adaptor.spec.ts
+++ b/comixed-frontend/src/app/comics/adaptors/comic.adaptor.spec.ts
@@ -38,12 +38,15 @@ import {
   ComicMarkAsRead,
   ComicMarkAsReadFailed,
   ComicMarkedAsRead,
+  ComicPageDeletedSet,
   ComicPageTypeSet,
   ComicRestore,
   ComicRestored,
   ComicRestoreFailed,
   ComicSave,
   ComicSavePage,
+  ComicSetPageDeleted,
+  ComicSetPageDeletedFailed,
   ComicSetPageHashBlocking,
   ComicSetPageType,
   ComicSetPageTypeFailed
@@ -527,6 +530,98 @@ describe('ComicAdaptor', () => {
       it('provides updates on the comic', () => {
         adaptor.comic$.subscribe(response =>
           expect(response.lastRead).toEqual(LAST_READ_DATE.lastRead)
+        );
+      });
+    });
+  });
+
+  describe('deleting a page', () => {
+    beforeEach(() => {
+      adaptor.deletePage(PAGE);
+    });
+
+    it('fires an action', () => {
+      expect(store.dispatch).toHaveBeenCalledWith(
+        new ComicSetPageDeleted({ page: PAGE, deleted: true })
+      );
+    });
+
+    it('provides updates on deleting', () => {
+      adaptor.deletingPage$.subscribe(response =>
+        expect(response).toBeTruthy()
+      );
+    });
+
+    describe('success', () => {
+      beforeEach(() => {
+        store.dispatch(new ComicPageDeletedSet({ comic: COMIC }));
+      });
+
+      it('provides updates on deleting', () => {
+        adaptor.deletingPage$.subscribe(response =>
+          expect(response).toBeFalsy()
+        );
+      });
+
+      it('updates the comic', () => {
+        adaptor.comic$.subscribe(response => expect(response).toEqual(COMIC));
+      });
+    });
+
+    describe('failure', () => {
+      beforeEach(() => {
+        store.dispatch(new ComicSetPageDeletedFailed());
+      });
+
+      it('provides updates on deleting', () => {
+        adaptor.deletingPage$.subscribe(response =>
+          expect(response).toBeFalsy()
+        );
+      });
+    });
+  });
+
+  describe('undeleting a page', () => {
+    beforeEach(() => {
+      adaptor.undeletePage(PAGE);
+    });
+
+    it('fires an action', () => {
+      expect(store.dispatch).toHaveBeenCalledWith(
+        new ComicSetPageDeleted({ page: PAGE, deleted: false })
+      );
+    });
+
+    it('provides updates on deleting', () => {
+      adaptor.deletingPage$.subscribe(response =>
+        expect(response).toBeTruthy()
+      );
+    });
+
+    describe('success', () => {
+      beforeEach(() => {
+        store.dispatch(new ComicPageDeletedSet({ comic: COMIC }));
+      });
+
+      it('provides updates on deleting', () => {
+        adaptor.deletingPage$.subscribe(response =>
+          expect(response).toBeFalsy()
+        );
+      });
+
+      it('updates the comic', () => {
+        adaptor.comic$.subscribe(response => expect(response).toEqual(COMIC));
+      });
+    });
+
+    describe('failure', () => {
+      beforeEach(() => {
+        store.dispatch(new ComicSetPageDeletedFailed());
+      });
+
+      it('provides updates on deleting', () => {
+        adaptor.deletingPage$.subscribe(response =>
+          expect(response).toBeFalsy()
         );
       });
     });

--- a/comixed-frontend/src/app/comics/adaptors/comic.adaptor.ts
+++ b/comixed-frontend/src/app/comics/adaptors/comic.adaptor.ts
@@ -37,6 +37,7 @@ import {
   ComicRestore,
   ComicSave,
   ComicSavePage,
+  ComicSetPageDeleted,
   ComicSetPageHashBlocking,
   ComicSetPageType
 } from 'app/comics/actions/comic.actions';
@@ -65,6 +66,7 @@ export class ComicAdaptor {
   private _restoringComic$ = new BehaviorSubject<boolean>(false);
   private _markingAsRead$ = new BehaviorSubject<boolean>(false);
   private _settingPageType$ = new BehaviorSubject<boolean>(false);
+  private _deletingPage$ = new BehaviorSubject<boolean>(false);
 
   constructor(private logger: LoggerService, private store: Store<AppState>) {
     this.store
@@ -113,6 +115,9 @@ export class ComicAdaptor {
         }
         if (state.settingPageType !== this._settingPageType$.getValue()) {
           this._settingPageType$.next(state.settingPageType);
+        }
+        if (state.deletingPage !== this._deletingPage$.getValue()) {
+          this._deletingPage$.next(state.deletingPage);
         }
       });
   }
@@ -251,5 +256,21 @@ export class ComicAdaptor {
 
   get settingPageType$(): Observable<boolean> {
     return this._settingPageType$.asObservable();
+  }
+
+  deletePage(page: Page) {
+    this.logger.debug('deleting a page:', page);
+    this.store.dispatch(new ComicSetPageDeleted({ page: page, deleted: true }));
+  }
+
+  undeletePage(page: Page) {
+    this.logger.debug('undeleting a page:', page);
+    this.store.dispatch(
+      new ComicSetPageDeleted({ page: page, deleted: false })
+    );
+  }
+
+  get deletingPage$(): Observable<boolean> {
+    return this._deletingPage$.asObservable();
   }
 }

--- a/comixed-frontend/src/app/comics/comics.constants.ts
+++ b/comixed-frontend/src/app/comics/comics.constants.ts
@@ -17,6 +17,7 @@
  */
 
 import { API_ROOT_URL } from 'app/app.functions';
+import {COMIXED_API_ROOT} from "app/app.constants";
 
 export const GET_SCAN_TYPES_URL = `${API_ROOT_URL}/comics/scan_types`;
 export const GET_FORMATS_URL = `${API_ROOT_URL}/comics/formats`;
@@ -30,6 +31,8 @@ export const DOWNLOAD_COMIC_URL = `${API_ROOT_URL}/comics/\${id}/download`;
 export const GET_COMIC_COVER_URL = `${API_ROOT_URL}/comics/\${id}/cover/content`;
 export const MARK_COMIC_AS_READ_URL = `${API_ROOT_URL}/comics/\${id}/read`;
 export const MARK_COMIC_AS_UNREAD_URL = `${API_ROOT_URL}/comics/\${id}/read`;
+export const MARK_PAGE_DELETED_URL = `${COMIXED_API_ROOT}/pages/\${id}`;
+export const UNMARK_PAGE_DELETED_URL = `${COMIXED_API_ROOT}/pages/\${id}/undelete`;
 
 export const MISSING_COMIC_IMAGE_URL = '/assets/img/missing-comic-file.png';
 

--- a/comixed-frontend/src/app/comics/comics.constants.ts
+++ b/comixed-frontend/src/app/comics/comics.constants.ts
@@ -17,7 +17,7 @@
  */
 
 import { API_ROOT_URL } from 'app/app.functions';
-import {COMIXED_API_ROOT} from "app/app.constants";
+import { COMIXED_API_ROOT } from 'app/app.constants';
 
 export const GET_SCAN_TYPES_URL = `${API_ROOT_URL}/comics/scan_types`;
 export const GET_FORMATS_URL = `${API_ROOT_URL}/comics/formats`;

--- a/comixed-frontend/src/app/comics/components/comic-pages/comic-pages.component.html
+++ b/comixed-frontend/src/app/comics/components/comic-pages/comic-pages.component.html
@@ -3,7 +3,7 @@
           [resizable]="false"
           (onHide)="clearSelectedPage()">
   <img *ngIf="!!selectedPage"
-       [style.height]="'50vh'"
+       [style.height]="'75vh'"
        [src]="selectedPage|comicPageUrl"
        [alt]="selectedPage.filename"/>
 </p-dialog>
@@ -24,6 +24,7 @@
     <col/>
     <col class="cx-table-column-medium"/>
     <col class="cx-table-column-medium"/>
+    <col class="cx-table-column-medium"/>
   </ng-template>
   <ng-template pTemplate="header">
     <tr>
@@ -34,6 +35,7 @@
       <th id="cx-page-hash">{{ "comic-pages.table.header.hash" | translate }}</th>
       <th id="cx-page-dimensions">{{ "comic-pages.table.header.dimensions" | translate }}</th>
       <th id="cx-page-blocked-status">{{ "comic-pages.table.header.blocked-status" | translate }}</th>
+      <th id="cx-page-deleted-status">{{ "comic-pages.table.header.deleted-status" | translate }}</th>
     </tr>
   </ng-template>
   <ng-template pTemplate="body"
@@ -71,6 +73,14 @@
           (click)="page.blocked ? unblockPage(page) : blockPage(page)"
           [pTooltip]="'comic-pages.tooltip.blocked'|translate:{blocked:page.blocked}">
         {{"comic-pages.table.column.blocked-status"|translate: {blocked: page.blocked} }}
+        </span>
+      </td>
+      <td class="cx-table-column-align-center">
+        <span
+          class="fa fa-fw fa-switch"
+          (click)="page.deleted ? undeletePage(page) : deletePage(page)"
+          [pTooltip]="'comic-pages.tooltip.deleted'|translate:{deleted:page.deleted}">
+        {{"comic-pages.table.column.deleted-status"|translate: {deleted: page.deleted} }}
         </span>
       </td>
     </tr>

--- a/comixed-frontend/src/app/comics/components/comic-pages/comic-pages.component.html
+++ b/comixed-frontend/src/app/comics/components/comic-pages/comic-pages.component.html
@@ -3,7 +3,7 @@
           [resizable]="false"
           (onHide)="clearSelectedPage()">
   <img *ngIf="!!selectedPage"
-       [style.height]="'75vh'"
+       [style.height]="'50vh'"
        [src]="selectedPage|comicPageUrl"
        [alt]="selectedPage.filename"/>
 </p-dialog>

--- a/comixed-frontend/src/app/comics/components/comic-pages/comic-pages.component.ts
+++ b/comixed-frontend/src/app/comics/components/comic-pages/comic-pages.component.ts
@@ -90,4 +90,14 @@ export class ComicPagesComponent implements OnInit, OnDestroy {
     this.logger.debug('clearing selected page');
     this.selectedPage = null;
   }
+
+  undeletePage(page: Page) {
+    this.logger.debug('undeleting page:', page);
+    this.comicAdaptor.undeletePage(page);
+  }
+
+  deletePage(page: Page) {
+    this.logger.debug('deleting page:', page);
+    this.comicAdaptor.deletePage(page);
+  }
 }

--- a/comixed-frontend/src/app/comics/effects/comic.effects.ts
+++ b/comixed-frontend/src/app/comics/effects/comic.effects.ts
@@ -82,7 +82,7 @@ export class ComicEffects {
           this.messageService.add({
             severity: 'error',
             detail: this.translateService.instant(
-              'comics-effects.get-scan-types.error.detail'
+              'comic-effects.get-scan-types.error.detail'
             )
           });
           return of(new ComicGetScanTypesFailed());
@@ -113,7 +113,7 @@ export class ComicEffects {
           this.messageService.add({
             severity: 'error',
             detail: this.translateService.instant(
-              'comics-effects.get-formats.error.detail'
+              'comic-effects.get-formats.error.detail'
             )
           });
           return of(new ComicGetFormatsFailed());
@@ -145,7 +145,7 @@ export class ComicEffects {
           this.messageService.add({
             severity: 'error',
             detail: this.translateService.instant(
-              'comics-effects.get-page-types.error.detail'
+              'comic-effects.get-page-types.error.detail'
             )
           });
           return of(new ComicGetPageTypesFailed());
@@ -175,7 +175,7 @@ export class ComicEffects {
           this.messageService.add({
             severity: 'error',
             detail: this.translateService.instant(
-              'comics-effects.get-issue.error.detail',
+              'comic-effects.get-issue.error.detail',
               { id: action.id }
             )
           });
@@ -204,7 +204,7 @@ export class ComicEffects {
           this.messageService.add({
             severity: 'info',
             detail: this.translateService.instant(
-              'comics-effects.save-page.success.detail'
+              'comic-effects.save-page.success.detail'
             )
           })
         ),
@@ -213,7 +213,7 @@ export class ComicEffects {
           this.messageService.add({
             severity: 'error',
             detail: this.translateService.instant(
-              'comics-effects.save-page.error.detail'
+              'comic-effects.save-page.error.detail'
             )
           });
           return of(new ComicSavePageFailed());
@@ -243,7 +243,7 @@ export class ComicEffects {
           this.messageService.add({
             severity: 'info',
             detail: this.translateService.instant(
-              'comics-effects.set-page-type.success.detail'
+              'comic-effects.set-page-type.success.detail'
             )
           })
         ),
@@ -253,7 +253,7 @@ export class ComicEffects {
           this.messageService.add({
             severity: 'error',
             detail: this.translateService.instant(
-              'comics-effects.set-page-type.error.detail'
+              'comic-effects.set-page-type.error.detail'
             )
           });
           return of(new ComicSetPageTypeFailed());
@@ -282,7 +282,7 @@ export class ComicEffects {
           this.messageService.add({
             severity: 'info',
             detail: this.translateService.instant(
-              'comics-effects.set-page-hash-blocking.success.detail',
+              'comic-effects.set-page-hash-blocking.success.detail',
               { hash: action.page.hash, state: action.state }
             )
           })
@@ -294,7 +294,7 @@ export class ComicEffects {
           this.messageService.add({
             severity: 'error',
             detail: this.translateService.instant(
-              'comics-effects.set-page-hash-blocking.error.detail'
+              'comic-effects.set-page-hash-blocking.error.detail'
             )
           });
           return of(new ComicSetPageHashBlockingFailed());
@@ -322,7 +322,7 @@ export class ComicEffects {
           this.messageService.add({
             severity: 'info',
             detail: this.translateService.instant(
-              'comics-effects.save-comic.success.detail'
+              'comic-effects.save-comic.success.detail'
             )
           })
         ),
@@ -331,7 +331,7 @@ export class ComicEffects {
           this.messageService.add({
             severity: 'error',
             detail: this.translateService.instant(
-              'comics-effects.save-comic.error.detail'
+              'comic-effects.save-comic.error.detail'
             )
           });
           return of(new ComicSaveFailed());
@@ -359,7 +359,7 @@ export class ComicEffects {
           this.messageService.add({
             severity: 'info',
             detail: this.translateService.instant(
-              'comics-effects.clear-metadata.success.detail'
+              'comic-effects.clear-metadata.success.detail'
             )
           })
         ),
@@ -368,7 +368,7 @@ export class ComicEffects {
           this.messageService.add({
             severity: 'error',
             detail: this.translateService.instant(
-              'comics-effects.clear-metadata.error.detail'
+              'comic-effects.clear-metadata.error.detail'
             )
           });
           return of(new ComicClearMetadataFailed());
@@ -396,7 +396,7 @@ export class ComicEffects {
           this.messageService.add({
             severity: 'info',
             detail: this.translateService.instant(
-              'comics-effects.delete-comic.success.detail'
+              'comic-effects.delete-comic.success.detail'
             )
           })
         ),
@@ -405,7 +405,7 @@ export class ComicEffects {
           this.messageService.add({
             severity: 'error',
             detail: this.translateService.instant(
-              'comics-effects.delete-comics.error.detail'
+              'comic-effects.delete-comics.error.detail'
             )
           });
           return of(new ComicDeleteFailed());
@@ -433,7 +433,7 @@ export class ComicEffects {
           this.messageService.add({
             severity: 'info',
             detail: this.translateService.instant(
-              'comics-effects.restore-comic.success.detail'
+              'comic-effects.restore-comic.success.detail'
             )
           })
         ),
@@ -442,7 +442,7 @@ export class ComicEffects {
           this.messageService.add({
             severity: 'error',
             detail: this.translateService.instant(
-              'comics-effects.restore-comic.error.detail'
+              'comic-effects.restore-comic.error.detail'
             )
           });
           return of(new ComicRestoreFailed());
@@ -479,7 +479,7 @@ export class ComicEffects {
           this.messageService.add({
             severity: 'error',
             detail: this.translateService.instant(
-              'comics-effects.mark-as-read.error-details'
+              'comic-effects.mark-as-read.error-details'
             )
           });
           return of(new ComicMarkAsReadFailed());
@@ -512,7 +512,7 @@ export class ComicEffects {
           this.messageService.add({
             severity: 'info',
             detail: this.translateService.instant(
-              'comics-effects.set-page-deleted.success.detail',
+              'comic-effects.set-page-deleted.success.detail',
               { deleted: action.deleted }
             )
           })
@@ -526,7 +526,7 @@ export class ComicEffects {
           this.messageService.add({
             severity: 'error',
             detail: this.translateService.instant(
-              'comics-effects.set-page-deleted.error.detail',
+              'comic-effects.set-page-deleted.error.detail',
               { deleted: action.deleted }
             )
           });

--- a/comixed-frontend/src/app/comics/reducers/comic.reducer.spec.ts
+++ b/comixed-frontend/src/app/comics/reducers/comic.reducer.spec.ts
@@ -17,6 +17,7 @@
  */
 
 import {
+  ComicSetPageDeletedFailed,
   ComicClearMetadata,
   ComicClearMetadataFailed,
   ComicDelete,
@@ -38,6 +39,7 @@ import {
   ComicMarkAsReadFailed,
   ComicMarkedAsRead,
   ComicMetadataCleared,
+  ComicPageDeletedSet,
   ComicPageHashBlockingSet,
   ComicPageSaved,
   ComicPageTypeSet,
@@ -49,6 +51,7 @@ import {
   ComicSaveFailed,
   ComicSavePage,
   ComicSavePageFailed,
+  ComicSetPageDeleted,
   ComicSetPageHashBlocking,
   ComicSetPageHashBlockingFailed,
   ComicSetPageType,
@@ -146,6 +149,10 @@ describe('Comic Reducer', () => {
 
     it('clears the setting page type flag', () => {
       expect(state.settingPageType).toBeFalsy();
+    });
+
+    it('clears the deleting page flag', () => {
+      expect(state.deletingPage).toBeFalsy();
     });
 
     it('clears the blocking hash state flag', () => {
@@ -488,6 +495,49 @@ describe('Comic Reducer', () => {
 
     it('clears the setting page type flag', () => {
       expect(state.settingPageType).toBeFalsy();
+    });
+  });
+
+  describe('deleting a page', () => {
+    beforeEach(() => {
+      state = reducer(
+        { ...state, deletingPage: false },
+        new ComicSetPageDeleted({ page: COMIC.pages[0], deleted: true })
+      );
+    });
+
+    it('sets the deleting page flag', () => {
+      expect(state.deletingPage).toBeTruthy();
+    });
+  });
+
+  describe('when a page is deleted', () => {
+    beforeEach(() => {
+      state = reducer(
+        { ...state, deletingPage: true, comic: null },
+        new ComicPageDeletedSet({ comic: COMIC })
+      );
+    });
+
+    it('clears the deleting page flag', () => {
+      expect(state.deletingPage).toBeFalsy();
+    });
+
+    it('updates the comic', () => {
+      expect(state.comic).toEqual(COMIC);
+    });
+  });
+
+  describe('failure to delete a page', () => {
+    beforeEach(() => {
+      state = reducer(
+        { ...state, deletingPage: true },
+        new ComicSetPageDeletedFailed()
+      );
+    });
+
+    it('clears the deleting page flag', () => {
+      expect(state.deletingPage).toBeFalsy();
     });
   });
 

--- a/comixed-frontend/src/app/comics/reducers/comic.reducer.ts
+++ b/comixed-frontend/src/app/comics/reducers/comic.reducer.ts
@@ -36,6 +36,7 @@ export interface ComicState {
   comic: Comic;
   savingPage: boolean;
   settingPageType: boolean;
+  deletingPage: boolean;
   blockingPageHash: boolean;
   savingComic: boolean;
   clearingMetadata: boolean;
@@ -60,6 +61,7 @@ export const initialState: ComicState = {
   comic: null,
   savingPage: false,
   settingPageType: false,
+  deletingPage: false,
   blockingPageHash: false,
   savingComic: false,
   clearingMetadata: false,
@@ -147,6 +149,15 @@ export function reducer(
 
     case ComicActionTypes.SetPageTypeFailed:
       return { ...state, settingPageType: false };
+
+    case ComicActionTypes.SetPageDeleted:
+      return { ...state, deletingPage: true };
+
+    case ComicActionTypes.PageDeletedSet:
+      return { ...state, deletingPage: false, comic: action.payload.comic };
+
+    case ComicActionTypes.SetPageDeletedFailed:
+      return { ...state, deletingPage: false };
 
     case ComicActionTypes.SetPageHashBlocking:
       return { ...state, blockingPageHash: true };

--- a/comixed-frontend/src/app/comics/services/comic.service.spec.ts
+++ b/comixed-frontend/src/app/comics/services/comic.service.spec.ts
@@ -31,8 +31,10 @@ import {
   GET_PAGE_TYPES_URL,
   GET_SCAN_TYPES_URL,
   MARK_COMIC_AS_READ_URL,
+  MARK_PAGE_DELETED_URL,
   RESTORE_COMIC_URL,
-  SAVE_COMIC_URL
+  SAVE_COMIC_URL,
+  UNMARK_PAGE_DELETED_URL
 } from 'app/comics/comics.constants';
 import {
   FORMAT_1,
@@ -50,11 +52,13 @@ import {
 import { ComicService } from './comic.service';
 import { COMIC_1_LAST_READ_DATE } from 'app/library/models/last-read-date.fixtures';
 import { LoggerModule } from '@angular-ru/logger';
+import { PAGE_2 } from 'app/comics/comics.fixtures';
 
 describe('ComicService', () => {
   const COMIC = COMIC_1;
   const SKIP_CACHE = false;
   const LAST_READ_DATE = COMIC_1_LAST_READ_DATE;
+  const PAGE = PAGE_2;
 
   let service: ComicService;
   let httpMock: HttpTestingController;
@@ -197,5 +201,33 @@ describe('ComicService', () => {
     );
     expect(req.request.method).toEqual('DELETE');
     req.flush(null);
+  });
+
+  it('can mark a page as deleted', () => {
+    service
+      .deletePage(PAGE, true)
+      .subscribe(response => expect(response).toEqual(COMIC));
+
+    const req = httpMock.expectOne(
+      interpolate(MARK_PAGE_DELETED_URL, {
+        id: PAGE.id
+      })
+    );
+    expect(req.request.method).toEqual('DELETE');
+    req.flush(COMIC);
+  });
+
+  it('can unmark a page as deleted', () => {
+    service
+      .deletePage(PAGE, false)
+      .subscribe(response => expect(response).toEqual(COMIC));
+
+    const req = httpMock.expectOne(
+      interpolate(UNMARK_PAGE_DELETED_URL, {
+        id: PAGE.id
+      })
+    );
+    expect(req.request.method).toEqual('POST');
+    req.flush(COMIC);
   });
 });

--- a/comixed-frontend/src/app/comics/services/comic.service.ts
+++ b/comixed-frontend/src/app/comics/services/comic.service.ts
@@ -19,7 +19,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { interpolate } from 'app/app.functions';
-import { Comic } from 'app/comics';
+import { Comic, Page } from 'app/comics';
 import {
   CLEAR_METADATA_URL,
   DELETE_COMIC_URL,
@@ -29,8 +29,10 @@ import {
   GET_SCAN_TYPES_URL,
   MARK_COMIC_AS_READ_URL,
   MARK_COMIC_AS_UNREAD_URL,
+  MARK_PAGE_DELETED_URL,
   RESTORE_COMIC_URL,
-  SAVE_COMIC_URL
+  SAVE_COMIC_URL,
+  UNMARK_PAGE_DELETED_URL
 } from 'app/comics/comics.constants';
 import { Observable } from 'rxjs';
 import { LoggerService } from '@angular-ru/logger';
@@ -84,6 +86,25 @@ export class ComicService {
       this.logger.debug('http [DELETE]: Unmarking comic as read');
       return this.http.delete(
         interpolate(MARK_COMIC_AS_UNREAD_URL, { id: comic.id })
+      );
+    }
+  }
+
+  deletePage(page: Page, mark: boolean): Observable<any> {
+    if (mark) {
+      this.logger.debug('http [DELETE]: Marking page as deleted');
+      return this.http.delete(
+        interpolate(MARK_PAGE_DELETED_URL, {
+          id: page.id
+        })
+      );
+    } else {
+      this.logger.debug('http [POST]: Unmarking page as deleted');
+      return this.http.post(
+        interpolate(UNMARK_PAGE_DELETED_URL, {
+          id: page.id
+        }),
+        {}
       );
     }
   }

--- a/comixed-frontend/src/assets/i18n/en/comics.json
+++ b/comixed-frontend/src/assets/i18n/en/comics.json
@@ -88,6 +88,14 @@
       "error": {
         "detail": "Failed to change the last read date."
       }
+    },
+    "set-page-deleted": {
+      "success": {
+        "detail": "Page {deleted, select, true{marked} other{unmarked}} for deletion..."
+      },
+      "error": {
+        "detail": "Failed to {deleted, select, true{marked} other{unmarked}} for deletion..."
+      }
     }
   },
   "comic-overview": {

--- a/comixed-frontend/src/assets/i18n/en/comics.json
+++ b/comixed-frontend/src/assets/i18n/en/comics.json
@@ -186,10 +186,12 @@
         "page-type": "Page Type",
         "hash": "Page Hash",
         "dimensions": "Size",
-        "blocked-status": "Blocked"
+        "blocked-status": "Blocked",
+        "deleted-status": "Delete"
       },
       "column": {
-        "blocked-status": "{blocked, select, true{Yes} other{No}}"
+        "blocked-status": "{blocked, select, true{Yes} other{No}}",
+        "deleted-status": "{deleted, select, true{Yes} other{No}}"
       }
     },
     "page-type": {
@@ -206,7 +208,8 @@
       "filtered": "Filtered"
     },
     "tooltip": {
-      "blocked": "Click to {blocked, select, true{unblock} other{block}} this page type..."
+      "blocked": "Click to {blocked, select, true{unblock} other{block}} this page type...",
+      "deleted": "Click to {deleted, select, true{undelete} other{delete}} this page..."
     }
   },
   "comic-details-editor": {

--- a/comixed-frontend/src/assets/i18n/en/comics.json
+++ b/comixed-frontend/src/assets/i18n/en/comics.json
@@ -1,5 +1,5 @@
 {
-  "comics-effects": {
+  "comic-effects": {
     "get-scan-types": {
       "error": {
         "detail": "Failed to load scan types."

--- a/comixed-frontend/src/assets/i18n/es/comics.json
+++ b/comixed-frontend/src/assets/i18n/es/comics.json
@@ -88,6 +88,14 @@
       "error": {
         "detail": "Failed to change the last read date."
       }
+    },
+    "set-page-deleted": {
+      "success": {
+        "detail": "Page {deleted, select, true{marked} other{unmarked}} for deletion..."
+      },
+      "error": {
+        "detail": "Failed to {deleted, select, true{marked} other{unmarked}} for deletion..."
+      }
     }
   },
   "comic-overview": {

--- a/comixed-frontend/src/assets/i18n/es/comics.json
+++ b/comixed-frontend/src/assets/i18n/es/comics.json
@@ -179,13 +179,37 @@
     }
   },
   "comic-pages": {
-    "label": {
-      "filename": "Nombre",
-      "dimensions": "Dimensiones"
+    "table": {
+      "header": {
+        "thumbnail": "Thumbnail",
+        "filename": "Filename",
+        "page-type": "Page Type",
+        "hash": "Page Hash",
+        "dimensions": "Size",
+        "blocked-status": "Blocked",
+        "deleted-status": "Delete"
+      },
+      "column": {
+        "blocked-status": "{blocked, select, true{Yes} other{No}}",
+        "deleted-status": "{deleted, select, true{Yes} other{No}}"
+      }
     },
-    "text": {
-      "marked-for-deletion": "Esta página está marcada para eliminación.",
-      "page-is-blocked": "Esta página está bloqueada."
+    "page-type": {
+      "front-cover": "Front Cover",
+      "inner-cover": "Inner Cover",
+      "back-cover": "Back Cover",
+      "roundup": "Roundup",
+      "story": "Story",
+      "advertisement": "Advertisement",
+      "editorial": "Editorial",
+      "letters": "Letters Page",
+      "preview": "Preview",
+      "other": "Other",
+      "filtered": "Filtered"
+    },
+    "tooltip": {
+      "blocked": "Click to {blocked, select, true{unblock} other{block}} this page type...",
+      "deleted": "Click to {deleted, select, true{undelete} other{delete}} this page..."
     }
   },
   "comic-details-editor": {

--- a/comixed-frontend/src/assets/i18n/es/comics.json
+++ b/comixed-frontend/src/assets/i18n/es/comics.json
@@ -1,5 +1,5 @@
 {
-  "comics-effects": {
+  "comic-effects": {
     "get-scan-types": {
       "error": {
         "detail": "Error al cargar tipos de escaneados."

--- a/comixed-frontend/src/assets/i18n/fr/comics.json
+++ b/comixed-frontend/src/assets/i18n/fr/comics.json
@@ -179,13 +179,38 @@
     }
   },
   "comic-pages": {
-    "label": {
-      "filename": "Nom du fichier",
-      "dimensions": "Dimensions"
+    "table": {
+      "header": {
+        "thumbnail": "Thumbnail",
+        "filename": "Filename",
+        "page-type": "Page Type",
+        "hash": "Page Hash",
+        "dimensions": "Size",
+        "blocked-status": "Blocked",
+        "deleted-status": "Delete"
+      },
+      "column": {
+        "blocked-status": "{blocked, select, true{Yes} other{No}}",
+        "deleted-status": "{deleted, select, true{Yes} other{No}}"
+      }
     },
-    "text": {
-      "marked-for-deletion": "Cette page est marquée pour suppression.",
-      "page-is-blocked": "Cette page est bloquée."
+    "page-type": {
+      "front-cover": "Front Cover",
+      "inner-cover": "Inner Cover",
+      "back-cover": "Back Cover",
+      "roundup": "Roundup",
+      "story": "Story",
+      "advertisement": "Advertisement",
+      "editorial": "Editorial",
+      "letters": "Letters Page",
+      "preview": "Preview",
+      "other": "Other",
+      "filtered": "Filtered"
+    },
+    "tooltip": {
+      "blocked": "Click to {blocked, select, true{unblock} other{block}} this page type...",
+      "deleted": "Click to {deleted, select, true{undelete} other{delete}} this page..."
+    }
     }
   },
   "comic-details-editor": {

--- a/comixed-frontend/src/assets/i18n/fr/comics.json
+++ b/comixed-frontend/src/assets/i18n/fr/comics.json
@@ -1,5 +1,5 @@
 {
-  "comics-effects": {
+  "comic-effects": {
     "get-scan-types": {
       "error": {
         "detail": "Échec du chargement des types de scan."

--- a/comixed-frontend/src/assets/i18n/fr/comics.json
+++ b/comixed-frontend/src/assets/i18n/fr/comics.json
@@ -88,6 +88,14 @@
       "error": {
         "detail": "Échec de la modification de la date de dernière lecture."
       }
+    },
+    "set-page-deleted": {
+      "success": {
+        "detail": "Page {deleted, select, true{marked} other{unmarked}} for deletion..."
+      },
+      "error": {
+        "detail": "Failed to {deleted, select, true{marked} other{unmarked}} for deletion..."
+      }
     }
   },
   "comic-overview": {

--- a/comixed-frontend/src/assets/i18n/pt/comics.json
+++ b/comixed-frontend/src/assets/i18n/pt/comics.json
@@ -88,6 +88,14 @@
       "error": {
         "detail": "Failed to change the last read date."
       }
+    },
+    "set-page-deleted": {
+      "success": {
+        "detail": "Page {deleted, select, true{marked} other{unmarked}} for deletion..."
+      },
+      "error": {
+        "detail": "Failed to {deleted, select, true{marked} other{unmarked}} for deletion..."
+      }
     }
   },
   "comic-overview": {

--- a/comixed-frontend/src/assets/i18n/pt/comics.json
+++ b/comixed-frontend/src/assets/i18n/pt/comics.json
@@ -186,10 +186,12 @@
         "page-type": "Page Type",
         "hash": "Page Hash",
         "dimensions": "Size",
-        "blocked-status": "Blocked"
+        "blocked-status": "Blocked",
+        "deleted-status": "Delete"
       },
       "column": {
-        "blocked-status": "{blocked, select, true{Yes} other{No}}"
+        "blocked-status": "{blocked, select, true{Yes} other{No}}",
+        "deleted-status": "{deleted, select, true{Yes} other{No}}"
       }
     },
     "page-type": {
@@ -206,7 +208,8 @@
       "filtered": "Filtered"
     },
     "tooltip": {
-      "blocked": "Click to {blocked, select, true{unblock} other{block}} this page type..."
+      "blocked": "Click to {blocked, select, true{unblock} other{block}} this page type...",
+      "deleted": "Click to {deleted, select, true{undelete} other{delete}} this page..."
     }
   },
   "comic-details-editor": {

--- a/comixed-frontend/src/assets/i18n/pt/comics.json
+++ b/comixed-frontend/src/assets/i18n/pt/comics.json
@@ -1,5 +1,5 @@
 {
-  "comics-effects": {
+  "comic-effects": {
     "get-scan-types": {
       "error": {
         "detail": "Failed to load scan types."

--- a/comixed-rest-api/src/main/java/org/comixedproject/controller/comic/PageController.java
+++ b/comixed-rest-api/src/main/java/org/comixedproject/controller/comic/PageController.java
@@ -43,6 +43,7 @@ import org.comixedproject.views.View.PageList;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -74,11 +75,19 @@ public class PageController {
     return this.pageService.deleteAllWithHash(hash);
   }
 
+  /**
+   * Marks a page for deletion.
+   *
+   * @param id the page id
+   * @return the parent comic
+   */
   @DeleteMapping(value = "/pages/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-  public boolean deletePage(@PathVariable("id") long id) {
+  @PreAuthorize("hasRole('ADMIN')")
+  @JsonView(View.ComicDetails.class)
+  public Comic deletePage(@PathVariable("id") long id) {
     log.info("Deleting page: id={}", id);
 
-    return this.pageService.deletePage(id) != null;
+    return this.pageService.deletePage(id);
   }
 
   @GetMapping(value = "/comics/{id}/pages", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -192,11 +201,19 @@ public class PageController {
     return this.pageService.undeleteAllWithHash(hash);
   }
 
+  /**
+   * Unmarks the page for deletion.
+   *
+   * @param id the page id
+   * @return the parent comic
+   */
   @PostMapping(value = "/pages/{id}/undelete", produces = MediaType.APPLICATION_JSON_VALUE)
-  public boolean undeletePage(@PathVariable("id") long id) {
+  @PreAuthorize("hasRole('ADMIN')")
+  @JsonView(View.ComicDetails.class)
+  public Comic undeletePage(@PathVariable("id") long id) {
     log.info("Undeleting page: id={}", id);
 
-    return this.pageService.undeletePage(id) != null;
+    return this.pageService.undeletePage(id);
   }
 
   @PutMapping(value = "/pages/{id}/type", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/comixed-rest-api/src/test/java/org/comixedproject/controller/comic/PageControllerTest.java
+++ b/comixed-rest-api/src/test/java/org/comixedproject/controller/comic/PageControllerTest.java
@@ -190,16 +190,21 @@ public class PageControllerTest {
   public void testDeletePageInvalidId() {
     Mockito.when(pageService.deletePage(Mockito.anyLong())).thenReturn(null);
 
-    assertFalse(pageController.deletePage(TEST_PAGE_ID));
+    final Comic result = pageController.deletePage(TEST_PAGE_ID);
+
+    assertNull(result);
 
     Mockito.verify(pageService, Mockito.times(1)).deletePage(TEST_PAGE_ID);
   }
 
   @Test
   public void testDeletePage() {
-    Mockito.when(pageService.deletePage(Mockito.anyLong())).thenReturn(page);
+    Mockito.when(pageService.deletePage(Mockito.anyLong())).thenReturn(comic);
 
-    assertTrue(pageController.deletePage(TEST_PAGE_ID));
+    final Comic result = pageController.deletePage(TEST_PAGE_ID);
+
+    assertNotNull(result);
+    assertSame(comic, result);
 
     Mockito.verify(pageService, Mockito.times(1)).deletePage(TEST_PAGE_ID);
   }
@@ -208,16 +213,21 @@ public class PageControllerTest {
   public void testUndeletePageForNonexistentPage() {
     Mockito.when(pageService.undeletePage(Mockito.anyLong())).thenReturn(null);
 
-    assertFalse(pageController.undeletePage(TEST_PAGE_ID));
+    final Comic result = pageController.undeletePage(TEST_PAGE_ID);
+
+    assertNull(result);
 
     Mockito.verify(pageService, Mockito.times(1)).undeletePage(TEST_PAGE_ID);
   }
 
   @Test
   public void testUndeletePage() {
-    Mockito.when(pageService.undeletePage(Mockito.anyLong())).thenReturn(page);
+    Mockito.when(pageService.undeletePage(Mockito.anyLong())).thenReturn(comic);
 
-    assertTrue(pageController.undeletePage(TEST_PAGE_ID));
+    final Comic result = pageController.undeletePage(TEST_PAGE_ID);
+
+    assertNotNull(result);
+    assertSame(comic, result);
 
     Mockito.verify(pageService, Mockito.times(1)).undeletePage(TEST_PAGE_ID);
   }

--- a/comixed-services/src/main/java/org/comixedproject/service/comic/PageService.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/comic/PageService.java
@@ -131,20 +131,26 @@ public class PageService {
     return null;
   }
 
+  /**
+   * Marks a page for deletion.
+   *
+   * @param id the page id
+   * @return the comic
+   */
   @Transactional
-  public Page deletePage(final long id) {
+  public Comic deletePage(final long id) {
     log.debug("Marking page as deleted: id={}", id);
     final Optional<Page> page = this.pageRepository.findById(id);
 
     if (page.isPresent()) {
       if (page.get().isDeleted()) {
         log.debug("Page was already marked as deleted");
-        return page.get();
+        return page.get().getComic();
       } else {
         page.get().setDeleted(true);
         final Page result = this.pageRepository.save(page.get());
         log.debug("Page deleted");
-        return result;
+        return result.getComic();
       }
     }
 
@@ -152,21 +158,26 @@ public class PageService {
     return null;
   }
 
+  /**
+   * Unmarks a page for deletion.
+   *
+   * @param id the page id
+   * @return the comic
+   */
   @Transactional
-  public Page undeletePage(final long id) {
+  public Comic undeletePage(final long id) {
     log.debug("Marking page as not deleted: id={}", id);
-
     final Optional<Page> page = this.pageRepository.findById(id);
 
     if (page.isPresent()) {
       if (page.get().isDeleted()) {
         page.get().setDeleted(false);
         log.debug("Page undeleted");
-        return this.pageRepository.save(page.get());
+        return this.pageRepository.save(page.get()).getComic();
 
       } else {
         log.debug("Page was not marked as deleted");
-        return page.get();
+        return page.get().getComic();
       }
     } else {
       log.warn("No such page");

--- a/comixed-services/src/test/java/org/comixedproject/service/comic/PageServiceTest.java
+++ b/comixed-services/src/test/java/org/comixedproject/service/comic/PageServiceTest.java
@@ -269,11 +269,12 @@ public class PageServiceTest {
   public void testDeletePageAlreadyMarkedAsDeleted() {
     Mockito.when(pageRepository.findById(TEST_PAGE_ID)).thenReturn(Optional.of(page));
     Mockito.when(page.isDeleted()).thenReturn(true);
+    Mockito.when(page.getComic()).thenReturn(comic);
 
-    final Page result = pageService.deletePage(TEST_PAGE_ID);
+    final Comic result = pageService.deletePage(TEST_PAGE_ID);
 
     assertNotNull(result);
-    assertSame(page, result);
+    assertSame(comic, result);
 
     Mockito.verify(pageRepository, Mockito.times(1)).findById(TEST_PAGE_ID);
     Mockito.verify(page, Mockito.times(1)).isDeleted();
@@ -285,11 +286,12 @@ public class PageServiceTest {
     Mockito.when(page.isDeleted()).thenReturn(false);
     Mockito.doNothing().when(page).setDeleted(Mockito.anyBoolean());
     Mockito.when(pageRepository.save(Mockito.any(Page.class))).thenReturn(page);
+    Mockito.when(page.getComic()).thenReturn(comic);
 
-    final Page result = pageService.deletePage(TEST_PAGE_ID);
+    final Comic result = pageService.deletePage(TEST_PAGE_ID);
 
     assertNotNull(result);
-    assertSame(page, result);
+    assertSame(comic, result);
 
     Mockito.verify(pageRepository, Mockito.times(1)).findById(TEST_PAGE_ID);
     Mockito.verify(page, Mockito.times(1)).isDeleted();
@@ -310,11 +312,12 @@ public class PageServiceTest {
   public void testUndeletePageForUnmarkedPage() {
     Mockito.when(pageRepository.findById(Mockito.anyLong())).thenReturn(Optional.of(page));
     Mockito.when(page.isDeleted()).thenReturn(false);
+    Mockito.when(page.getComic()).thenReturn(comic);
 
-    final Page result = pageService.undeletePage(TEST_PAGE_ID);
+    final Comic result = pageService.undeletePage(TEST_PAGE_ID);
 
     assertNotNull(result);
-    assertSame(page, result);
+    assertSame(comic, result);
 
     Mockito.verify(pageRepository, Mockito.times(1)).findById(TEST_PAGE_ID);
     Mockito.verify(page, Mockito.times(1)).isDeleted();
@@ -326,11 +329,12 @@ public class PageServiceTest {
     Mockito.when(page.isDeleted()).thenReturn(true);
     Mockito.doNothing().when(page).setDeleted(Mockito.anyBoolean());
     Mockito.when(pageRepository.save(Mockito.any(Page.class))).thenReturn(page);
+    Mockito.when(page.getComic()).thenReturn(comic);
 
-    final Page result = pageService.undeletePage(TEST_PAGE_ID);
+    final Comic result = pageService.undeletePage(TEST_PAGE_ID);
 
     assertNotNull(result);
-    assertSame(page, result);
+    assertSame(comic, result);
 
     Mockito.verify(pageRepository, Mockito.times(1)).findById(TEST_PAGE_ID);
     Mockito.verify(page, Mockito.times(1)).isDeleted();


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Added a new column to the pages tab to show the deleted state of a page. Clicking on that value will toggle being marked for deletion on/off for that page in that specific comic.