### PR TITLE
Add annotation to create audit log entries for REST APIs

### DIFF
--- a/comixed-model/src/main/java/org/comixedproject/model/auditlog/RestAuditLogEntry.java
+++ b/comixed-model/src/main/java/org/comixedproject/model/auditlog/RestAuditLogEntry.java
@@ -1,0 +1,85 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.model.auditlog;
+
+import java.util.Date;
+import javax.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * <code>RestAuditLogEntry</code> represents a single entry in the REST API audit log table.
+ *
+ * @author Darryl L. Pierce
+ */
+@Entity
+@Table(name = "rest_audit_log")
+public class RestAuditLogEntry {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Getter
+  private Long id;
+
+  @Column(name = "remote_ip", nullable = false, updatable = false)
+  @Getter
+  @Setter
+  private String remoteIp;
+
+  @Column(name = "url", nullable = false, updatable = false)
+  @Getter
+  @Setter
+  private String url;
+
+  @Column(name = "method", nullable = false, updatable = false)
+  @Getter
+  @Setter
+  private String method;
+
+  @Column(name = "content", nullable = true, updatable = false)
+  @Lob
+  @Getter
+  @Setter
+  private String content;
+
+  @Column(name = "email", nullable = true, updatable = false)
+  @Getter
+  @Setter
+  private String emai;
+
+  @Column(name = "start_time", nullable = false, updatable = false)
+  @Getter
+  @Setter
+  private Date startTime = new Date();
+
+  @Column(name = "end_time", nullable = false, updatable = false)
+  @Getter
+  @Setter
+  private Date endTime = new Date();
+
+  @Column(name = "successful", nullable = false, updatable = false)
+  @Getter
+  @Setter
+  private Boolean successful;
+
+  @Column(name = "exception", nullable = true, updatable = false)
+  @Lob
+  @Getter
+  @Setter
+  private String exception;
+}

--- a/comixed-model/src/main/resources/db/migrations/0.7.0/006_issue-474_add_rest_audit_log.xml
+++ b/comixed-model/src/main/resources/db/migrations/0.7.0/006_issue-474_add_rest_audit_log.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="006_issue-474_add_rest_audit_log.xml"
+             author="mcpierce">
+    <createTable tableName="rest_audit_log">
+      <column name="id"
+              type="bigint">
+        <constraints nullable="false"
+                     unique="true"
+                     primaryKey="true"/>
+      </column>
+      <column name="remote_ip"
+              type="varchar(15)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="url"
+              type="varchar(256)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="method"
+              type="varchar(32)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="email"
+              type="varchar(256)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="start_time"
+              type="timestamp">
+        <constraints nullable="false"/>
+      </column>
+      <column name="end_time"
+              type="timestamp"
+              defaultValueComputed="NOW()">
+        <constraints nullable="false"/>
+      </column>
+      <column name="successful"
+              type="boolean">
+        <constraints nullable="false"/>
+      </column>
+      <column name="content"
+              type="clob">
+        <constraints nullable="true"/>
+      </column>
+      <column name="exception"
+              type="clob">
+        <constraints nullable="true"/>
+      </column>
+    </createTable>
+
+    <addAutoIncrement tableName="rest_audit_log"
+                      columnName="id"
+                      columnDataType="bigint"
+                      incrementBy="1"
+                      startWith="1"/>
+
+    <createIndex tableName="rest_audit_log"
+                 indexName="rest_audit_log_start_time_idx">
+      <column name="start_time"/>
+    </createIndex>
+
+    <createIndex tableName="rest_audit_log"
+                 indexName="rest_audit_log_successful_idx">
+      <column name="successful"/>
+    </createIndex>
+  </changeSet>
+</databaseChangeLog>

--- a/comixed-model/src/main/resources/db/migrations/0.7.0/changelog-0.7.0.xml
+++ b/comixed-model/src/main/resources/db/migrations/0.7.0/changelog-0.7.0.xml
@@ -11,5 +11,6 @@
   <include file="/db/migrations/0.7.0/003_issue-301_add_scraping_cache_table.xml"/>
   <include file="/db/migrations/0.7.0/004_issue-204_add_task_audit_log.xml"/>
   <include file="/db/migrations/0.7.0/005_issue-471_add_exception_field_to_task_audit_log.xml"/>
+  <include file="/db/migrations/0.7.0/006_issue-474_add_rest_audit_log.xml"/>
 
 </databaseChangeLog>

--- a/comixed-repositories/src/main/java/org/comixedproject/repositories/auditlog/RestAuditLogRepository.java
+++ b/comixed-repositories/src/main/java/org/comixedproject/repositories/auditlog/RestAuditLogRepository.java
@@ -1,0 +1,31 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.repositories.auditlog;
+
+import org.comixedproject.model.auditlog.RestAuditLogEntry;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * <code>RestAuditLogRepository</code> manages persisted instances of {@link RestAuditLogEntry}.
+ *
+ * @author Darryl L. Pierce
+ */
+@Repository
+public interface RestAuditLogRepository extends JpaRepository<RestAuditLogEntry, Long> {}

--- a/comixed-rest-api/src/main/java/org/comixedproject/aspect/AuditableEndpoint.java
+++ b/comixed-rest-api/src/main/java/org/comixedproject/aspect/AuditableEndpoint.java
@@ -1,0 +1,8 @@
+package org.comixedproject.aspect;
+
+/**
+ * <code>AuditableEndpoint</code> is used to indicate that a method is to be audited whenever it's invoked. The method <b>must</b> return a {@link ApiResponse} object.
+ *
+ * @author Darryl L. Pierce
+ */
+public @interface AuditableEndpoint {}

--- a/comixed-rest-api/src/main/java/org/comixedproject/aspect/AuditableEndpointAspect.java
+++ b/comixed-rest-api/src/main/java/org/comixedproject/aspect/AuditableEndpointAspect.java
@@ -1,0 +1,99 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.aspect;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Date;
+import javax.servlet.http.HttpServletRequest;
+import lombok.extern.log4j.Log4j2;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.comixedproject.model.auditlog.RestAuditLogEntry;
+import org.comixedproject.net.ApiResponse;
+import org.comixedproject.service.auditlog.RestAuditLogService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+/**
+ * <code>AuditableEndpointAspect</code> manages aspects relating to the REST APIs.
+ *
+ * @author Darryl L. Pierce
+ */
+@Aspect
+@Configuration
+@Log4j2
+public class AuditableEndpointAspect {
+  @Autowired private RestAuditLogService restAuditLogService;
+
+  /**
+   * Wraps REST API calls and records the results.
+   *
+   * @param joinPoint the join point.
+   * @return the response object
+   */
+  @Around("@annotation(org.comixedproject.aspect.AuditableEndpoint)")
+  public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
+    Throwable error = null;
+    Object response = null;
+
+    final Date started = new Date();
+    try {
+      response = joinPoint.proceed();
+    } catch (Throwable throwable) {
+      error = throwable;
+    }
+    final Date ended = new Date();
+    if (response instanceof ApiResponse<?>) {
+      final ApiResponse<?> apiResponse = (ApiResponse<?>) response;
+      final RestAuditLogEntry entry = new RestAuditLogEntry();
+      HttpServletRequest request =
+          ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+      if (request.getUserPrincipal() != null) {
+        entry.setEmai(request.getUserPrincipal().getName());
+      } else {
+        entry.setException("anonymous");
+      }
+      entry.setRemoteIp(request.getRemoteAddr());
+      entry.setUrl(request.getRequestURI());
+      entry.setMethod(request.getMethod());
+      entry.setContent(
+          new String(((ContentCachingRequestWrapper) request).getContentAsByteArray()));
+      entry.setStartTime(started);
+      entry.setEndTime(ended);
+      entry.setSuccessful(apiResponse.isSuccess());
+      entry.setException(apiResponse.getError());
+      if (apiResponse.getThrowable() != null) {
+        log.debug("Storing stacktrace");
+        final StringWriter stringWriter = new StringWriter();
+        final PrintWriter printWriter = new PrintWriter(stringWriter);
+        entry.setException(printWriter.toString());
+      }
+
+      this.restAuditLogService.save(entry);
+    }
+    if (error != null) throw error;
+    return response;
+  }
+}

--- a/comixed-rest-api/src/main/java/org/comixedproject/controller/file/FileController.java
+++ b/comixed-rest-api/src/main/java/org/comixedproject/controller/file/FileController.java
@@ -61,6 +61,14 @@ public class FileController {
 
   private int requestId = 0;
 
+  /**
+   * Retrieves all comic files under the specified directory.
+   *
+   * @param request the request body
+   * @return the list of comic files
+   * @throws IOException if an error occurs
+   * @throws JSONException if an error occurs
+   */
   @PostMapping(
       value = "/contents",
       produces = MediaType.APPLICATION_JSON_VALUE,

--- a/comixed-rest-api/src/main/java/org/comixedproject/controller/tasks/TaskController.java
+++ b/comixed-rest-api/src/main/java/org/comixedproject/controller/tasks/TaskController.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 import java.util.Date;
 import java.util.List;
 import lombok.extern.log4j.Log4j2;
+import org.comixedproject.aspect.AuditableEndpoint;
 import org.comixedproject.controller.ComiXedControllerException;
 import org.comixedproject.model.tasks.TaskAuditLogEntry;
 import org.comixedproject.net.ApiResponse;
@@ -56,26 +57,28 @@ public class TaskController {
   @GetMapping(value = "/entries/{cutoff}", produces = MediaType.APPLICATION_JSON_VALUE)
   @PreAuthorize("hasRole('ADMIN')")
   @JsonView(View.TaskAuditLogEntryList.class)
+  @AuditableEndpoint
   public ApiResponse<GetTaskAuditLogResponse> getAllAfterDate(
       @PathVariable("cutoff") final Long timestamp) throws ComiXedControllerException {
-    ApiResponse<GetTaskAuditLogResponse> result = new ApiResponse<>();
+    ApiResponse<GetTaskAuditLogResponse> response = new ApiResponse<>();
 
     final Date cutoff = new Date(timestamp);
     log.debug("Getting all task audit log entries after: {}", cutoff);
 
     try {
       final List<TaskAuditLogEntry> entries = this.taskService.getAuditLogEntriesAfter(cutoff);
-      result.setResult(new GetTaskAuditLogResponse());
-      result.getResult().setEntries(entries);
-      result.getResult().setLatest(entries.get(entries.size() - 1).getStartTime());
-      result.setSuccess(true);
+      response.setResult(new GetTaskAuditLogResponse());
+      response.getResult().setEntries(entries);
+      response.getResult().setLatest(entries.get(entries.size() - 1).getStartTime());
+      response.setSuccess(true);
     } catch (ComiXedServiceException error) {
       log.error("Failed to load task audit log entries", error);
-      result.setSuccess(false);
-      result.setError(error.getMessage());
+      response.setSuccess(false);
+      response.setError(error.getMessage());
+      response.setThrowable(error);
     }
 
-    return result;
+    return response;
   }
 
   /**
@@ -86,6 +89,7 @@ public class TaskController {
   @DeleteMapping(value = "/entries", produces = MediaType.APPLICATION_JSON_VALUE)
   @PreAuthorize("hasRole('ADMIN')")
   @JsonView(View.ApiResponse.class)
+  @AuditableEndpoint
   public ApiResponse<Void> clearTaskAuditLog() {
     log.debug("Clearing task audit log");
     final ApiResponse<Void> response = new ApiResponse<>();
@@ -97,6 +101,7 @@ public class TaskController {
       log.error("Failed to clear audit log", error);
       response.setSuccess(false);
       response.setError(error.getMessage());
+      response.setThrowable(error);
     }
 
     return response;

--- a/comixed-rest-api/src/main/java/org/comixedproject/net/ApiResponse.java
+++ b/comixed-rest-api/src/main/java/org/comixedproject/net/ApiResponse.java
@@ -18,6 +18,7 @@
 
 package org.comixedproject.net;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 import lombok.Getter;
@@ -42,6 +43,8 @@ public class ApiResponse<T> {
   @JsonProperty("error")
   @JsonView(View.ApiResponse.class)
   private String error;
+
+  @Getter @Setter @JsonIgnore private Throwable throwable;
 
   @Getter
   @Setter

--- a/comixed-rest-api/src/main/java/org/comixedproject/web/authentication/CachingRequestBodyFilter.java
+++ b/comixed-rest-api/src/main/java/org/comixedproject/web/authentication/CachingRequestBodyFilter.java
@@ -1,0 +1,42 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2018, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.web.authentication;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.GenericFilterBean;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+@Component
+public class CachingRequestBodyFilter extends GenericFilterBean {
+  @Override
+  public void doFilter(
+      ServletRequest servletRequest, ServletResponse servletResponse, FilterChain chain)
+      throws IOException, ServletException {
+    HttpServletRequest currentRequest = (HttpServletRequest) servletRequest;
+    ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(currentRequest);
+
+    chain.doFilter(wrappedRequest, servletResponse);
+  }
+}

--- a/comixed-rest-api/src/test/java/org/comixedproject/aspect/AuditableEndpointAspectTest.java
+++ b/comixed-rest-api/src/test/java/org/comixedproject/aspect/AuditableEndpointAspectTest.java
@@ -1,0 +1,67 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.aspect;
+
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertSame;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.comixedproject.model.auditlog.RestAuditLogEntry;
+import org.comixedproject.net.ApiResponse;
+import org.comixedproject.service.auditlog.RestAuditLogService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.*;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuditableEndpointAspectTest {
+  @InjectMocks private AuditableEndpointAspect auditableEndpointAspect;
+  @Mock private RestAuditLogService restAuditLogService;
+  @Mock private ProceedingJoinPoint proceedingJoinPoint;
+  @Mock private ApiResponse<?> apiResponse;
+  @Captor private ArgumentCaptor<RestAuditLogEntry> restAuditLogEntryArgumentCaptor;
+  @Mock private RestAuditLogEntry savedEntry;
+
+  @Before
+  public void setUp() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+  }
+
+  @Test
+  public void testAround() throws Throwable {
+    Mockito.when(restAuditLogService.save(restAuditLogEntryArgumentCaptor.capture()))
+        .thenReturn(savedEntry);
+    Mockito.when(proceedingJoinPoint.proceed()).thenReturn(apiResponse);
+
+    final Object result = auditableEndpointAspect.around(proceedingJoinPoint);
+
+    assertNotNull(result);
+    assertSame(apiResponse, result);
+
+    Mockito.verify(restAuditLogService, Mockito.times(1))
+        .save(restAuditLogEntryArgumentCaptor.getValue());
+    Mockito.verify(proceedingJoinPoint, Mockito.times(1)).proceed();
+  }
+}

--- a/comixed-services/src/main/java/org/comixedproject/service/auditlog/RestAuditLogService.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/auditlog/RestAuditLogService.java
@@ -1,0 +1,50 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.service.auditlog;
+
+import lombok.extern.log4j.Log4j2;
+import org.comixedproject.model.auditlog.RestAuditLogEntry;
+import org.comixedproject.repositories.auditlog.RestAuditLogRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * <code>RestAuditLogService</code> provides business logic services for instances of {@link
+ * RestAuditLogEntry}.
+ *
+ * @author Darryl L. Pierce
+ */
+@Service
+@Log4j2
+public class RestAuditLogService {
+  @Autowired private RestAuditLogRepository auditLogRepository;
+
+  /**
+   * Save a new entry to the log.
+   *
+   * @param entry the entry
+   * @return the saved entry
+   */
+  @Transactional
+  public RestAuditLogEntry save(final RestAuditLogEntry entry) {
+    log.debug("Saving new REST audit log entry: started={}", entry.getStartTime());
+    return this.auditLogRepository.save(entry);
+  }
+}

--- a/comixed-services/src/test/java/org/comixedproject/service/auditlog/RestAuditLogServiceTest.java
+++ b/comixed-services/src/test/java/org/comixedproject/service/auditlog/RestAuditLogServiceTest.java
@@ -1,0 +1,51 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2020, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.service.auditlog;
+
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertSame;
+
+import org.comixedproject.model.auditlog.RestAuditLogEntry;
+import org.comixedproject.repositories.auditlog.RestAuditLogRepository;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RestAuditLogServiceTest {
+  @InjectMocks private RestAuditLogService restAuditLogService;
+  @Mock private RestAuditLogRepository restAuditLogRepository;
+  @Mock private RestAuditLogEntry incomingEntry;
+  @Mock private RestAuditLogEntry savedEntry;
+
+  @Test
+  public void testSave() {
+    Mockito.when(restAuditLogRepository.save(Mockito.any())).thenReturn(savedEntry);
+
+    final RestAuditLogEntry result = this.restAuditLogService.save(incomingEntry);
+
+    assertNotNull(result);
+    assertSame(savedEntry, result);
+
+    Mockito.verify(restAuditLogRepository, Mockito.times(1)).save(incomingEntry);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,10 @@
       <artifactId>spring-boot-starter-test</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-aop</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
     </dependency>
@@ -149,6 +153,14 @@
       <artifactId>powermock-module-junit4-rule</artifactId>
       <version>2.0.7</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-aspects</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-instrument</artifactId>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
## Status
**READY**

## Migrations
YES

## Description
Introduces a new annotation for auditing REST API calls. It doesn't annotate all requests since they're going to each need to be refactored to return ApiResponse<?> objects, which the annotation will process.