### PR TITLE
Fixed loading task audit log entries [#468]

### DIFF
--- a/comixed-frontend/src/app/backend-status/actions/load-task-audit-log.actions.ts
+++ b/comixed-frontend/src/app/backend-status/actions/load-task-audit-log.actions.ts
@@ -20,10 +20,17 @@ import { createAction, props } from '@ngrx/store';
 import { TaskAuditLogEntry } from 'app/backend-status/models/task-audit-log-entry';
 
 /**
+ * Starts the process of loading task audit log entries.
+ */
+export const startLoadingTaskAuditLogEntries = createAction(
+  '[Load Task Audit Log] Start loading entries'
+);
+
+/**
  * Loads all task audit log entries after the specified date.
  */
 export const loadTaskAuditLogEntries = createAction(
-  '[LoadTaskAuditLog] Load task audit log entries',
+  '[Load Task Audit Log] Load task audit log entries',
   props<{ since: number }>()
 );
 
@@ -31,7 +38,7 @@ export const loadTaskAuditLogEntries = createAction(
  * Receives additional task audit log entries.
  */
 export const taskAuditLogEntriesLoaded = createAction(
-  '[LoadTaskAuditLog] Task audit log entries loaded',
+  '[Load Task Audit Log] Task audit log entries loaded',
   props<{ entries: TaskAuditLogEntry[]; latest: number }>()
 );
 
@@ -39,5 +46,12 @@ export const taskAuditLogEntriesLoaded = createAction(
  * Failed to get task audit log entries.
  */
 export const loadTaskAuditLogFailed = createAction(
-  '[LoadTaskAuditLog] Failed to load the task audit log entries'
+  '[Load Task Audit Log] Failed to load the task audit log entries'
+);
+
+/**
+ * Stops loading task audit log entries.
+ */
+export const stopLoadingTaskAuditLogEntries = createAction(
+  '[Load Task Audit Log] Stop loading task audit log entries'
 );

--- a/comixed-frontend/src/app/backend-status/pages/task-audit-log-page/task-audit-log-page.component.html
+++ b/comixed-frontend/src/app/backend-status/pages/task-audit-log-page/task-audit-log-page.component.html
@@ -8,7 +8,7 @@
   </div>
 </p-toolbar>
 <p-table [value]="entries"
-         [rows]="rows"
+         [rows]="10"
          [paginator]="true"
          paginatorPosition="both"
          [loading]="clearingAuditLog">

--- a/comixed-frontend/src/app/backend-status/pages/task-audit-log-page/task-audit-log-page.component.spec.ts
+++ b/comixed-frontend/src/app/backend-status/pages/task-audit-log-page/task-audit-log-page.component.spec.ts
@@ -54,7 +54,6 @@ describe('TaskAuditLogPageComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         CoreModule,
-        LibraryModule,
         RouterTestingModule,
         HttpClientTestingModule,
         TranslateModule.forRoot(),

--- a/comixed-frontend/src/app/backend-status/reducers/load-task-audit-log.reducer.spec.ts
+++ b/comixed-frontend/src/app/backend-status/reducers/load-task-audit-log.reducer.spec.ts
@@ -24,6 +24,8 @@ import {
 import {
   loadTaskAuditLogEntries,
   loadTaskAuditLogFailed,
+  startLoadingTaskAuditLogEntries,
+  stopLoadingTaskAuditLogEntries,
   taskAuditLogEntriesLoaded
 } from 'app/backend-status/actions/load-task-audit-log.actions';
 import {
@@ -59,11 +61,41 @@ describe('LoadTaskAuditLog Reducer', () => {
       expect(state.loading).toBeFalsy();
     });
 
+    it('clears the stopped flag', () => {
+      expect(state.stopped).toBeFalsy();
+    });
+
     it('has no entries', () => {
       expect(state.entries).toEqual([]);
     });
 
     it('has a default latest date', () => {
+      expect(state.latest).toEqual(0);
+    });
+  });
+
+  describe('starting loading entries', () => {
+    beforeEach(() => {
+      state = reducer(
+        {
+          ...state,
+          stopped: true,
+          entries: LOG_ENTRIES,
+          latest: new Date().getTime()
+        },
+        startLoadingTaskAuditLogEntries()
+      );
+    });
+
+    it('clears the stopped flag', () => {
+      expect(state.stopped).toBeFalsy();
+    });
+
+    it('clears the entries', () => {
+      expect(state.entries).toEqual([]);
+    });
+
+    it('resets the latest date', () => {
       expect(state.latest).toEqual(0);
     });
   });
@@ -116,6 +148,19 @@ describe('LoadTaskAuditLog Reducer', () => {
 
     it('clears the load flag', () => {
       expect(state.loading).toBeFalsy();
+    });
+  });
+
+  describe('stopping loading entries', () => {
+    beforeEach(() => {
+      state = reducer(
+        { ...state, stopped: false },
+        stopLoadingTaskAuditLogEntries()
+      );
+    });
+
+    it('sets the stopped flag', () => {
+      expect(state.stopped).toBeTruthy();
     });
   });
 });

--- a/comixed-frontend/src/app/backend-status/reducers/load-task-audit-log.reducer.ts
+++ b/comixed-frontend/src/app/backend-status/reducers/load-task-audit-log.reducer.ts
@@ -21,6 +21,8 @@ import { TaskAuditLogEntry } from 'app/backend-status/models/task-audit-log-entr
 import {
   loadTaskAuditLogEntries,
   loadTaskAuditLogFailed,
+  startLoadingTaskAuditLogEntries,
+  stopLoadingTaskAuditLogEntries,
   taskAuditLogEntriesLoaded
 } from 'app/backend-status/actions/load-task-audit-log.actions';
 
@@ -28,12 +30,14 @@ export const LOAD_TASK_AUDIT_LOG_FEATURE_KEY = 'load_task_audit_log_state';
 
 export interface LoadTaskAuditLogState {
   loading: boolean;
+  stopped: boolean;
   entries: TaskAuditLogEntry[];
   latest: number;
 }
 
 export const initialState: LoadTaskAuditLogState = {
   loading: false,
+  stopped: false,
   entries: [],
   latest: 0
 };
@@ -41,6 +45,12 @@ export const initialState: LoadTaskAuditLogState = {
 const loadTaskAuditLogReducer = createReducer(
   initialState,
 
+  on(startLoadingTaskAuditLogEntries, state => ({
+    ...state,
+    stopped: false,
+    entries: [],
+    latest: 0
+  })),
   on(loadTaskAuditLogEntries, state => ({ ...state, loading: true })),
   on(taskAuditLogEntriesLoaded, (state, action) => {
     const entries = state.entries.concat(action.entries);
@@ -51,7 +61,8 @@ const loadTaskAuditLogReducer = createReducer(
       latest: action.latest
     };
   }),
-  on(loadTaskAuditLogFailed, state => ({ ...state, loading: false }))
+  on(loadTaskAuditLogFailed, state => ({ ...state, loading: false })),
+  on(stopLoadingTaskAuditLogEntries, state => ({ ...state, stopped: true }))
 );
 
 export function reducer(

--- a/comixed-rest-api/src/main/java/org/comixedproject/controller/core/AuditLogController.java
+++ b/comixed-rest-api/src/main/java/org/comixedproject/controller/core/AuditLogController.java
@@ -73,8 +73,10 @@ public class AuditLogController {
       final List<TaskAuditLogEntry> entries = this.taskService.getAuditLogEntriesAfter(cutoff);
       response.setResult(new GetTaskAuditLogResponse());
       response.getResult().setEntries(entries);
-      if (!entries.isEmpty())
-        response.getResult().setLatest(entries.get(entries.size() - 1).getStartTime());
+      response
+          .getResult()
+          .setLatest(
+              entries.isEmpty() ? new Date() : entries.get(entries.size() - 1).getStartTime());
       response.setSuccess(true);
     } catch (ComiXedServiceException error) {
       log.error("Failed to load task audit log entries", error);


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
The issue was mainly with the return value when no entries were found. The API was returning an empty latest value, which caused the frontend to exclude that parameter on subsequent requests. It now returns the current timestamp as the latest when no records are found.