### PR TITLE
Changed where and when the persisted task is deleted [#487]

### DIFF
--- a/comixed-tasks/src/main/java/org/comixedproject/task/encoders/AbstractWorkerTaskEncoder.java
+++ b/comixed-tasks/src/main/java/org/comixedproject/task/encoders/AbstractWorkerTaskEncoder.java
@@ -19,11 +19,7 @@
 package org.comixedproject.task.encoders;
 
 import lombok.extern.log4j.Log4j2;
-import org.comixedproject.model.tasks.Task;
-import org.comixedproject.service.task.TaskService;
 import org.comixedproject.task.model.AbstractWorkerTask;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * <code>AbstractWorkerTaskEncoder</code> provides a foundation for building new {@link
@@ -33,12 +29,4 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Log4j2
 public abstract class AbstractWorkerTaskEncoder<T extends AbstractWorkerTask>
-    implements WorkerTaskEncoder<T> {
-  @Autowired private TaskService taskService;
-
-  @Transactional
-  public void deleteTask(final Task task) {
-    log.debug("Deleting persisted task: id={} type={}", task.getId(), task.getTaskType());
-    this.taskService.delete(task);
-  }
-}
+    implements WorkerTaskEncoder<T> {}

--- a/comixed-tasks/src/main/java/org/comixedproject/task/encoders/AddComicWorkerTaskEncoder.java
+++ b/comixed-tasks/src/main/java/org/comixedproject/task/encoders/AddComicWorkerTaskEncoder.java
@@ -66,7 +66,6 @@ public class AddComicWorkerTaskEncoder extends AbstractWorkerTaskEncoder<AddComi
 
   @Override
   public AddComicWorkerTask decode(final Task task) {
-    this.deleteTask(task);
     log.debug("Decoding persisted task: id={} type={}", task.getId(), task.getTaskType());
     final AddComicWorkerTask result = this.addComicWorkerTaskObjectFactory.getObject();
 

--- a/comixed-tasks/src/main/java/org/comixedproject/task/encoders/DeleteComicWorkerTaskEncoder.java
+++ b/comixed-tasks/src/main/java/org/comixedproject/task/encoders/DeleteComicWorkerTaskEncoder.java
@@ -18,6 +18,7 @@
 
 package org.comixedproject.task.encoders;
 
+import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 import org.comixedproject.model.comic.Comic;
 import org.comixedproject.model.tasks.Task;
@@ -43,8 +44,8 @@ public class DeleteComicWorkerTaskEncoder extends AbstractWorkerTaskEncoder<Dele
 
   @Autowired private ObjectFactory<DeleteComicWorkerTask> deleteComicWorkerTaskObjectFactory;
 
-  private Comic comic;
-  private boolean deleteComicFile;
+  @Setter private Comic comic;
+  @Setter private boolean deleteComicFile;
 
   @Override
   public Task encode() {
@@ -59,20 +60,9 @@ public class DeleteComicWorkerTaskEncoder extends AbstractWorkerTaskEncoder<Dele
 
   @Override
   public DeleteComicWorkerTask decode(final Task task) {
-    log.debug("Decoding delete comic task");
-    this.deleteTask(task);
-
     final DeleteComicWorkerTask result = this.deleteComicWorkerTaskObjectFactory.getObject();
     result.setComic(task.getComic());
     result.setDeleteFile(Boolean.valueOf(task.getProperty(DELETE_COMIC)));
     return result;
-  }
-
-  public void setComic(final Comic comic) {
-    this.comic = comic;
-  }
-
-  public void setDeleteComicFile(final boolean deleteComicFile) {
-    this.deleteComicFile = deleteComicFile;
   }
 }

--- a/comixed-tasks/src/main/java/org/comixedproject/task/encoders/ProcessComicWorkerTaskEncoder.java
+++ b/comixed-tasks/src/main/java/org/comixedproject/task/encoders/ProcessComicWorkerTaskEncoder.java
@@ -63,7 +63,6 @@ public class ProcessComicWorkerTaskEncoder
 
   @Override
   public ProcessComicWorkerTask decode(final Task task) {
-    this.deleteTask(task);
     log.debug("Decoding process comic task: comic={}", task.getComic().getId());
 
     final ProcessComicWorkerTask result = this.processComicTaskObjectFactory.getObject();

--- a/comixed-tasks/src/main/java/org/comixedproject/task/model/DeleteComicWorkerTask.java
+++ b/comixed-tasks/src/main/java/org/comixedproject/task/model/DeleteComicWorkerTask.java
@@ -22,6 +22,8 @@ import java.io.File;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.Date;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.io.FileUtils;
 import org.comixedproject.model.comic.Comic;
@@ -44,12 +46,8 @@ public class DeleteComicWorkerTask extends AbstractWorkerTask implements WorkerT
   @Autowired private ComicService comicService;
   @Autowired private ReadingListService readingListService;
 
-  private boolean deleteFile;
-  private Comic comic;
-
-  public void setDeleteFile(boolean deleteFile) {
-    this.deleteFile = deleteFile;
-  }
+  @Getter @Setter private Boolean deleteFile;
+  @Getter @Setter private Comic comic;
 
   @Override
   @Transactional
@@ -95,9 +93,5 @@ public class DeleteComicWorkerTask extends AbstractWorkerTask implements WorkerT
   protected String createDescription() {
     return MessageFormat.format(
         "Deleting comic: id={0} [delete file={1}]", this.comic.getId(), this.deleteFile);
-  }
-
-  public void setComic(final Comic comic) {
-    this.comic = comic;
   }
 }

--- a/comixed-tasks/src/main/java/org/comixedproject/task/model/MonitorTaskQueueWorkerTask.java
+++ b/comixed-tasks/src/main/java/org/comixedproject/task/model/MonitorTaskQueueWorkerTask.java
@@ -68,7 +68,7 @@ public class MonitorTaskQueueWorkerTask extends AbstractWorkerTask implements In
       }
       WorkerTask nextTask = decoder.decode(task);
       log.debug("Passing task to task manager");
-      this.taskManager.runTask(nextTask);
+      this.taskManager.runTask(nextTask, task);
     }
     try {
       Thread.sleep(1000L);

--- a/comixed-tasks/src/test/java/org/comixedproject/task/encoders/AddComicWorkerTaskEncoderTest.java
+++ b/comixed-tasks/src/test/java/org/comixedproject/task/encoders/AddComicWorkerTaskEncoderTest.java
@@ -23,7 +23,6 @@ import static junit.framework.TestCase.assertNotNull;
 
 import java.util.Random;
 import org.comixedproject.model.tasks.Task;
-import org.comixedproject.service.task.TaskService;
 import org.comixedproject.task.model.AddComicWorkerTask;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,7 +41,6 @@ public class AddComicWorkerTaskEncoderTest {
   @InjectMocks private AddComicWorkerTaskEncoder adaptor;
   @Mock private ObjectFactory<AddComicWorkerTask> addComicWorkerTaskObjectFactory;
   @Mock private AddComicWorkerTask addComicWorkerTask;
-  @Mock private TaskService taskService;
 
   private boolean deleteBlockedPages = RANDOM.nextBoolean();
   private boolean ignoreMetadata = !deleteBlockedPages;
@@ -75,7 +73,6 @@ public class AddComicWorkerTaskEncoderTest {
         AddComicWorkerTaskEncoder.IGNORE_METADATA, String.valueOf(this.ignoreMetadata));
 
     Mockito.when(addComicWorkerTaskObjectFactory.getObject()).thenReturn(addComicWorkerTask);
-    Mockito.doNothing().when(taskService).delete(Mockito.any());
 
     final AddComicWorkerTask result = adaptor.decode(task);
 
@@ -83,6 +80,5 @@ public class AddComicWorkerTaskEncoderTest {
     Mockito.verify(addComicWorkerTask, Mockito.times(1))
         .setDeleteBlockedPages(this.deleteBlockedPages);
     Mockito.verify(addComicWorkerTask, Mockito.times(1)).setIgnoreMetadata(this.ignoreMetadata);
-    Mockito.verify(taskService, Mockito.times(1)).delete(task);
   }
 }

--- a/comixed-tasks/src/test/java/org/comixedproject/task/encoders/DeleteComicWorkerTaskEncoderTest.java
+++ b/comixed-tasks/src/test/java/org/comixedproject/task/encoders/DeleteComicWorkerTaskEncoderTest.java
@@ -22,7 +22,6 @@ import static junit.framework.TestCase.*;
 
 import org.comixedproject.model.comic.Comic;
 import org.comixedproject.model.tasks.Task;
-import org.comixedproject.service.task.TaskService;
 import org.comixedproject.task.model.DeleteComicWorkerTask;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,7 +35,6 @@ import org.springframework.beans.factory.ObjectFactory;
 public class DeleteComicWorkerTaskEncoderTest {
   @InjectMocks private DeleteComicWorkerTaskEncoder encoder;
   @Mock private Comic comic;
-  @Mock private TaskService taskService;
   @Mock private ObjectFactory<DeleteComicWorkerTask> deleteComicsWorkerTaskObjectFactory;
   @Mock private DeleteComicWorkerTask deleteComicWorkerTask;
 
@@ -79,8 +77,8 @@ public class DeleteComicWorkerTaskEncoderTest {
     assertNotNull(result);
     assertSame(deleteComicWorkerTask, result);
 
-    Mockito.verify(taskService, Mockito.times(1)).delete(task);
     Mockito.verify(deleteComicWorkerTask, Mockito.times(1)).setComic(comic);
+    Mockito.verify(deleteComicWorkerTask, Mockito.times(1)).setDeleteFile(false);
   }
 
   @Test
@@ -96,7 +94,7 @@ public class DeleteComicWorkerTaskEncoderTest {
     assertNotNull(result);
     assertSame(deleteComicWorkerTask, result);
 
-    Mockito.verify(taskService, Mockito.times(1)).delete(task);
     Mockito.verify(deleteComicWorkerTask, Mockito.times(1)).setComic(comic);
+    Mockito.verify(deleteComicWorkerTask, Mockito.times(1)).setDeleteFile(true);
   }
 }

--- a/comixed-tasks/src/test/java/org/comixedproject/task/encoders/ProcessComicWorkerWorkerTaskEncoderTest.java
+++ b/comixed-tasks/src/test/java/org/comixedproject/task/encoders/ProcessComicWorkerWorkerTaskEncoderTest.java
@@ -24,7 +24,6 @@ import java.util.Random;
 import org.comixedproject.model.comic.Comic;
 import org.comixedproject.model.tasks.Task;
 import org.comixedproject.model.tasks.TaskType;
-import org.comixedproject.service.task.TaskService;
 import org.comixedproject.task.model.ProcessComicWorkerTask;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,7 +40,6 @@ public class ProcessComicWorkerWorkerTaskEncoderTest {
   @Mock private Comic comic;
   @Mock private ObjectFactory<ProcessComicWorkerTask> processComicTaskObjectFactory;
   @Mock private ProcessComicWorkerTask workerTask;
-  @Mock private TaskService taskService;
 
   private final Boolean deleteBlockedPages = RANDOM.nextBoolean();
   private final Boolean ignoreMetadata = !this.deleteBlockedPages;
@@ -85,6 +83,5 @@ public class ProcessComicWorkerWorkerTaskEncoderTest {
     Mockito.verify(workerTask, Mockito.times(1)).setComic(comic);
     Mockito.verify(workerTask, Mockito.times(1)).setDeleteBlockedPages(this.deleteBlockedPages);
     Mockito.verify(workerTask, Mockito.times(1)).setIgnoreMetadata(this.ignoreMetadata);
-    Mockito.verify(taskService, Mockito.times(1)).delete(task);
   }
 }

--- a/comixed-tasks/src/test/java/org/comixedproject/task/model/MonitorTaskQueueWorkerTaskTest.java
+++ b/comixed-tasks/src/test/java/org/comixedproject/task/model/MonitorTaskQueueWorkerTaskTest.java
@@ -103,7 +103,7 @@ public class MonitorTaskQueueWorkerTaskTest {
     Mockito.verify(task, Mockito.times(taskList.size())).getTaskType();
     Mockito.verify(workerTaskAdaptor, Mockito.times(taskList.size())).getEncoder(TEST_TASK_TYPE);
     Mockito.verify(workerTaskEncoder, Mockito.times(taskList.size())).decode(task);
-    Mockito.verify(taskManager, Mockito.times(taskList.size())).runTask(workerTask);
+    Mockito.verify(taskManager, Mockito.times(taskList.size())).runTask(workerTask, task);
   }
 
   @Test


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Previously, the persisted task was deleted from the database when it was
decoded and before it was enqueued.

Now the persisted task, along with the executable one, is given to the
TaskManager. When the executable task completes then the persisted one
is removed from the database.