### PR TITLE
Added scrubbing of filename components when moving comics [#491]

### DIFF
--- a/comixed-frontend/src/app/library/components/consolidate-library/consolidate-library.component.html
+++ b/comixed-frontend/src/app/library/components/consolidate-library/consolidate-library.component.html
@@ -25,7 +25,9 @@
       <input pInputText
              id="cx-renaming-rule"
              class="cx-input-field"
-             formControlName="renamingRule">
+             formControlName="renamingRule"
+             (paste)="onPaste($event)"
+             (input)="onInput()">
     </div>
     <div class="ui-g-12">
       <p>{{"library.move-comics.variables-note"|translate}}</p>

--- a/comixed-frontend/src/app/library/components/consolidate-library/consolidate-library.component.spec.ts
+++ b/comixed-frontend/src/app/library/components/consolidate-library/consolidate-library.component.spec.ts
@@ -262,4 +262,27 @@ describe('ConsolidateLibraryComponent', () => {
       expect(confirmationService.confirm).not.toHaveBeenCalled();
     });
   });
+
+  describe('invalid characters are scrubbed', () => {
+    it('applies to typed characters', () => {
+      component.consolidationForm.controls.renamingRule.setValue('[]:\\*?|<>');
+      component.onInput();
+      expect(component.consolidationForm.controls.renamingRule.value).toEqual(
+        '_________'
+      );
+    });
+
+    it('applies to pasted characters', () => {
+      const event = new ClipboardEvent('paste', {
+        clipboardData: new DataTransfer()
+      });
+      event.clipboardData.setData('text', '[]:\\*?|<>');
+      console.log('*** event:', event);
+      component.onPaste(event);
+      fixture.detectChanges();
+      expect(component.consolidationForm.controls.renamingRule.value).toEqual(
+        '_________'
+      );
+    });
+  });
 });

--- a/comixed-frontend/src/app/library/components/consolidate-library/consolidate-library.component.ts
+++ b/comixed-frontend/src/app/library/components/consolidate-library/consolidate-library.component.ts
@@ -77,7 +77,7 @@ export class ConsolidateLibraryComponent implements OnInit, OnDestroy {
     this.userSubscription = this.authenticationAdaptor.user$.subscribe(() => {
       this.consolidationForm.controls['deletePhysicalFiles'].setValue(
         this.authenticationAdaptor.getPreference(
-            MOVE_COMICS_DELETE_PHYSICAL_FILE
+          MOVE_COMICS_DELETE_PHYSICAL_FILE
         ) === 'true'
       );
     });
@@ -120,7 +120,7 @@ export class ConsolidateLibraryComponent implements OnInit, OnDestroy {
           .value;
         this.authenticationAdaptor.setPreference(
           MOVE_COMICS_DELETE_PHYSICAL_FILE,
-            `${deletePhysicalFiles}`
+          `${deletePhysicalFiles}`
         );
         this.authenticationAdaptor.setPreference(
           MOVE_COMICS_TARGET_DIRECTORY,
@@ -154,5 +154,20 @@ export class ConsolidateLibraryComponent implements OnInit, OnDestroy {
         reject: () => (this.deletePhysicalFiles = false)
       });
     }
+  }
+
+  onPaste(event: ClipboardEvent): void {
+    this.filterRenamingRule(event.clipboardData.getData('text'));
+  }
+
+  onInput() {
+    this.filterRenamingRule(this.consolidationForm.controls.renamingRule.value);
+  }
+
+  private filterRenamingRule(rule: string): void {
+    console.log('*** rule:', rule);
+    const re = /[:\\*?|<>\[\]]/gi;
+    rule = rule.replace(re, '_');
+    this.consolidationForm.controls.renamingRule.setValue(rule);
   }
 }

--- a/comixed-frontend/src/app/user/adaptors/library-display.adaptor.spec.ts
+++ b/comixed-frontend/src/app/user/adaptors/library-display.adaptor.spec.ts
@@ -38,7 +38,7 @@ import { BehaviorSubject } from 'rxjs';
 import { EffectsModule } from '@ngrx/effects';
 import { LoggerModule } from '@angular-ru/logger';
 
-fdescribe('LibraryDisplayAdaptor', () => {
+describe('LibraryDisplayAdaptor', () => {
   const USER = { ...USER_READER };
 
   let libraryDisplayAdaptor: LibraryDisplayAdaptor;

--- a/comixed-tasks/src/test/java/org/comixedproject/task/model/MoveComicWorkerTaskTest.java
+++ b/comixed-tasks/src/test/java/org/comixedproject/task/model/MoveComicWorkerTaskTest.java
@@ -106,6 +106,34 @@ public class MoveComicWorkerTaskTest {
           TEST_VOLUME,
           TEST_ISSUE,
           "No Cover Date");
+  private static final String TEST_PUBLISHER_WITH_UNSUPPORTED_CHARACTERS = "?Publisher*";
+  private static final String TEST_PUBLISHER_WITH_UNSUPPORTED_CHARACTERS_SCRUBBED = "_Publisher_";
+  private static final String TEST_SERIES_WITH_UNSUPPORTED_CHARACTERS = "<|Series?>";
+  private static final String TEST_SERIES_WITH_UNSUPPORTED_CHARACTERS_SCRUBBED = "__Series__";
+  private static final String TEST_ISSUE_WITH_UNSUPPORTED_CHARACTERS = "\\/717:";
+  private static final String TEST_ISSUE_WITH_UNSUPPORTED_CHARACTERS_SCRUBBED = "__717_";
+  private static final String TEST_RELATIVE_NAME_SCRUBBED =
+      String.format(
+          "%s/%s/%s/%s v%s #%s (%s)",
+          TEST_PUBLISHER_WITH_UNSUPPORTED_CHARACTERS_SCRUBBED,
+          TEST_SERIES_WITH_UNSUPPORTED_CHARACTERS_SCRUBBED,
+          TEST_VOLUME,
+          TEST_SERIES_WITH_UNSUPPORTED_CHARACTERS_SCRUBBED,
+          TEST_VOLUME,
+          TEST_ISSUE_WITH_UNSUPPORTED_CHARACTERS_SCRUBBED,
+          TEST_FORMATTED_COVER_DATE);
+  private static final String TEST_RENAMING_RULE_WITH_UNSUPPORTED_CHARACTERS =
+      "?*$PUBLISHER/<|?>$SERIES/\\:$VOLUME/$SERIES v$VOLUME #$ISSUE ($COVERDATE)";
+  private static final String TEST_RELATIVE_NAME_WITH_RULE_WITH_SCRUBBED_CHARACTERS =
+      String.format(
+          "__%s/____%s/__%s/%s v%s #%s (%s)",
+          TEST_PUBLISHER,
+          TEST_SERIES,
+          TEST_VOLUME,
+          TEST_SERIES,
+          TEST_VOLUME,
+          TEST_ISSUE,
+          TEST_FORMATTED_COVER_DATE);
 
   @InjectMocks private MoveComicWorkerTask task;
   @Mock private ComicService comicService;
@@ -138,6 +166,26 @@ public class MoveComicWorkerTaskTest {
     final String result = task.getRelativeComicFilename();
 
     assertEquals(TEST_RELATIVE_NAME_WITH_RULE, result);
+  }
+
+  @Test
+  public void testGetRelativeComicFilenameRenamingRuleHasUnsupportedCharacters() {
+    task.setRenamingRule(TEST_RENAMING_RULE_WITH_UNSUPPORTED_CHARACTERS);
+
+    final String result = task.getRelativeComicFilename();
+
+    assertEquals(TEST_RELATIVE_NAME_WITH_RULE_WITH_SCRUBBED_CHARACTERS, result);
+  }
+
+  @Test
+  public void testGetRelativeComicFilenameWithUnsupportedCharacters() {
+    Mockito.when(comic.getPublisher()).thenReturn(TEST_PUBLISHER_WITH_UNSUPPORTED_CHARACTERS);
+    Mockito.when(comic.getSeries()).thenReturn(TEST_SERIES_WITH_UNSUPPORTED_CHARACTERS);
+    Mockito.when(comic.getIssueNumber()).thenReturn(TEST_ISSUE_WITH_UNSUPPORTED_CHARACTERS);
+
+    final String result = task.getRelativeComicFilename();
+
+    assertEquals(TEST_RELATIVE_NAME_SCRUBBED, result);
   }
 
   @Test


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Replace invalid characters in the renaming rule and also in a comic's metadata when creating a new filename.