### PR TITLE
Changed TaskManger to catch Exception [#528]

### DIFF
--- a/comixed-tasks/src/main/java/org/comixedproject/task/runner/TaskManager.java
+++ b/comixed-tasks/src/main/java/org/comixedproject/task/runner/TaskManager.java
@@ -29,7 +29,6 @@ import org.comixedproject.model.tasks.TaskAuditLogEntry;
 import org.comixedproject.service.task.TaskService;
 import org.comixedproject.task.model.MonitorTaskQueueWorkerTask;
 import org.comixedproject.task.model.WorkerTask;
-import org.comixedproject.task.model.WorkerTaskException;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -71,7 +70,7 @@ public class TaskManager implements InitializingBean {
             workerTask.startTask();
             if (!(workerTask instanceof MonitorTaskQueueWorkerTask))
               this.updateAuditLog(true, started, description, null);
-          } catch (WorkerTaskException error) {
+          } catch (Exception error) {
             log.error("Error executing task: {}" + description, description, error);
             if (!(workerTask instanceof MonitorTaskQueueWorkerTask))
               this.updateAuditLog(false, started, description, error);


### PR DESCRIPTION
## Status
**READY**

## Migrations
YES | NO

## Description
Rather than a specific exception, changed TaskManager to catch any
exception thrown to avoid unexpected errors slipping through the
cracks.