### PR TITLE
Added setting the comic title from the scraping data [#542]

### DIFF
--- a/comixed-services/src/main/java/org/comixedproject/service/scraping/ScrapingService.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/scraping/ScrapingService.java
@@ -232,6 +232,7 @@ public class ScrapingService {
       comic.setVolume(issueDetails.getVolume());
       comic.setIssueNumber(issueDetails.getIssueNumber());
       comic.setCoverDate(issueDetails.getCoverDate());
+      comic.setTitle(issueDetails.getTitle());
       comic.setDescription(issueDetails.getDescription());
       comic.getCharacters().clear();
       issueDetails.getCharacters().forEach(character -> comic.getCharacters().add(character));

--- a/comixed-services/src/test/java/org/comixedproject/service/scraping/ScrapingServiceTest.java
+++ b/comixed-services/src/test/java/org/comixedproject/service/scraping/ScrapingServiceTest.java
@@ -55,6 +55,7 @@ public class ScrapingServiceTest {
   private static final String TEST_PUBLISHER = "Publisher Name";
   private static final String TEST_VOLUME = "2020";
   private static final Date TEST_COVER_DATE = new Date();
+  private static final String TEST_TITLE = "The Title";
   private static final String TEST_DESCRIPTION = "This is the comic's description";
   private static final String TEST_ISSUE_DETAILS_KEY = "IssueDetailsKey";
 
@@ -87,6 +88,7 @@ public class ScrapingServiceTest {
     Mockito.when(scrapingIssueDetails.getVolume()).thenReturn(TEST_VOLUME);
     Mockito.when(scrapingIssueDetails.getIssueNumber()).thenReturn(TEST_ISSUE_NUMBER);
     Mockito.when(scrapingIssueDetails.getCoverDate()).thenReturn(TEST_COVER_DATE);
+    Mockito.when(scrapingIssueDetails.getTitle()).thenReturn(TEST_TITLE);
     Mockito.when(scrapingIssueDetails.getDescription()).thenReturn(TEST_DESCRIPTION);
   }
 
@@ -458,6 +460,7 @@ public class ScrapingServiceTest {
     Mockito.verify(this.loadedComic, Mockito.times(1)).setSeries(TEST_SERIES_NAME);
     Mockito.verify(this.loadedComic, Mockito.times(1)).setVolume(TEST_VOLUME);
     Mockito.verify(this.loadedComic, Mockito.times(1)).setCoverDate(TEST_COVER_DATE);
+    Mockito.verify(this.loadedComic, Mockito.times(1)).setTitle(TEST_TITLE);
     Mockito.verify(this.loadedComic, Mockito.times(1)).setDescription(TEST_DESCRIPTION);
   }
 }


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Fixes a bug that caused the comic title to not get scraped into the comic.