### PR TITLE
Added clearing the selection after comics are removed from a reading list [#535]

### DIFF
--- a/comixed-frontend/src/app/library/adaptors/reading-list.adaptor.spec.ts
+++ b/comixed-frontend/src/app/library/adaptors/reading-list.adaptor.spec.ts
@@ -49,6 +49,7 @@ import { NEW_READING_LIST } from 'app/library/library.constants';
 import { READING_LIST_1 } from 'app/comics/models/reading-list.fixtures';
 import { ReadingList } from 'app/comics/models/reading-list';
 import { COMIC_1, COMIC_2, COMIC_3 } from 'app/comics/comics.fixtures';
+import { SelectRemoveAllComics } from 'app/library/actions/selection.actions';
 
 describe('ReadingListAdaptor', () => {
   const READING_LIST = READING_LIST_1;
@@ -310,6 +311,10 @@ describe('ReadingListAdaptor', () => {
           comics: COMICS
         })
       );
+    });
+
+    it('clears the selection list', () => {
+      expect(store.dispatch).toHaveBeenCalledWith(new SelectRemoveAllComics());
     });
 
     it('provides updates on removing comics', () => {

--- a/comixed-frontend/src/app/library/adaptors/reading-list.adaptor.ts
+++ b/comixed-frontend/src/app/library/adaptors/reading-list.adaptor.ts
@@ -38,6 +38,7 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { ReadingList } from 'app/comics/models/reading-list';
 import { Comic } from 'app/comics';
+import { SelectRemoveAllComics } from 'app/library/actions/selection.actions';
 
 @Injectable()
 export class ReadingListAdaptor {
@@ -50,7 +51,10 @@ export class ReadingListAdaptor {
   private _showSelectionDialog$ = new BehaviorSubject<boolean>(false);
   private _removingComics$ = new BehaviorSubject<boolean>(false);
 
-  constructor(private store: Store<LibraryModuleState>, private logger: LoggerService) {
+  constructor(
+    private store: Store<LibraryModuleState>,
+    private logger: LoggerService
+  ) {
     this.store
       .select(READING_LIST_FEATURE_KEY)
       .pipe(filter(state => !!state))
@@ -164,6 +168,7 @@ export class ReadingListAdaptor {
     this.store.dispatch(
       new ReadingListRemoveComics({ readingList: readingList, comics: comics })
     );
+    this.store.dispatch(new SelectRemoveAllComics());
   }
 
   get removingComics$(): Observable<boolean> {


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Fire an action to clear the list after the selections are removed.