### PR TITLE
Added dependency on hosted-git-info@^3.0.8 [CVE-2021-23362]

### DIFF
--- a/comixed-web/package.json
+++ b/comixed-web/package.json
@@ -52,6 +52,7 @@
     "@ngx-translate/http-loader": "^6.0.0",
     "@tragically-slick/edit-in-place": "^0.1.0-2",
     "file-saver": "^2.0.5",
+    "hosted-git-info": "^3.0.8",
     "ini": "^1.3.6",
     "is-svg": "^4.2.2",
     "jasmine-marbles": "^0.6.0",

--- a/comixed-web/yarn.lock
+++ b/comixed-web/yarn.lock
@@ -4341,6 +4341,13 @@ hosted-git-info@^3.0.2, hosted-git-info@^3.0.6:
   dependencies:
     lru-cache "^6.0.0"
 
+hosted-git-info@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-3.0.8.tgz#6e35d4cc87af2c5f816e4cb9ce350ba87a3f370d"
+  integrity sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==
+  dependencies:
+    lru-cache "^6.0.0"
+
 hpack.js@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/hpack.js/-/hpack.js-2.1.6.tgz#87774c0949e513f42e84575b3c45681fade2a0b2"


### PR DESCRIPTION
## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [X] Security fix.
