### PR TITLE
Added a page to view comics with duplicate pages [#602]

### DIFF
--- a/comixed-messaging/src/main/java/org/comixedproject/messaging/library/PublishDuplicatePageListUpdateAction.java
+++ b/comixed-messaging/src/main/java/org/comixedproject/messaging/library/PublishDuplicatePageListUpdateAction.java
@@ -1,0 +1,45 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.messaging.library;
+
+import java.util.List;
+import lombok.extern.log4j.Log4j2;
+import org.comixedproject.messaging.AbstractPublishAction;
+import org.comixedproject.messaging.PublishingException;
+import org.comixedproject.model.library.DuplicatePage;
+import org.comixedproject.model.messaging.Constants;
+import org.comixedproject.views.View;
+import org.springframework.stereotype.Component;
+
+/**
+ * <code>PublishDuplicatePageListUpdateAction</code> publishes updates to the list of duplicate
+ * pages.
+ *
+ * @author Darryl L. Pierce
+ */
+@Component
+@Log4j2
+public class PublishDuplicatePageListUpdateAction
+    extends AbstractPublishAction<List<DuplicatePage>> {
+  @Override
+  public void publish(final List<DuplicatePage> pages) throws PublishingException {
+    log.trace("Publishing duplicate page list");
+    this.doPublish(Constants.DUPLICATE_PAGE_LIST_TOPIC, pages, View.DuplicatePageList.class);
+  }
+}

--- a/comixed-messaging/src/test/java/org/comixedproject/messaging/library/PublishDuplicatePageListUpdateActionTest.java
+++ b/comixed-messaging/src/test/java/org/comixedproject/messaging/library/PublishDuplicatePageListUpdateActionTest.java
@@ -1,0 +1,69 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.messaging.library;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import java.util.ArrayList;
+import java.util.List;
+import org.comixedproject.messaging.PublishingException;
+import org.comixedproject.model.library.DuplicatePage;
+import org.comixedproject.model.library.LastRead;
+import org.comixedproject.model.messaging.Constants;
+import org.comixedproject.views.View;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PublishDuplicatePageListUpdateActionTest {
+  private static final String TEST_DUPLICATE_PAGE_LIST_AS_JSON = "This is the JSON encoded list";
+
+  @InjectMocks private PublishDuplicatePageListUpdateAction action;
+  @Mock private SimpMessagingTemplate messagingTemplate;
+  @Mock private ObjectMapper objectMapper;
+  @Mock private ObjectWriter objectWriter;
+  @Mock private LastRead lastRead;
+
+  private List<DuplicatePage> duplicatePageList = new ArrayList<>();
+
+  @Before
+  public void setUp() throws JsonProcessingException {
+    Mockito.when(objectMapper.writerWithView(Mockito.any())).thenReturn(objectWriter);
+  }
+
+  @Test
+  public void testPublish() throws PublishingException, JsonProcessingException {
+    Mockito.when(objectWriter.writeValueAsString(Mockito.any()))
+        .thenReturn(TEST_DUPLICATE_PAGE_LIST_AS_JSON);
+
+    action.publish(duplicatePageList);
+
+    Mockito.verify(objectMapper, Mockito.times(1)).writerWithView(View.DuplicatePageList.class);
+    Mockito.verify(objectWriter, Mockito.times(1)).writeValueAsString(duplicatePageList);
+    Mockito.verify(messagingTemplate, Mockito.times(1))
+        .convertAndSend(Constants.DUPLICATE_PAGE_LIST_TOPIC, TEST_DUPLICATE_PAGE_LIST_AS_JSON);
+  }
+}

--- a/comixed-model/src/main/java/org/comixedproject/model/comic/Comic.java
+++ b/comixed-model/src/main/java/org/comixedproject/model/comic/Comic.java
@@ -54,10 +54,31 @@ import org.springframework.stereotype.Component;
 @NoArgsConstructor
 @JsonIdentityInfo(generator = ObjectIdGenerators.UUIDGenerator.class, property = "@id")
 public class Comic {
+  @OneToMany(mappedBy = "comic", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OrderColumn(name = "PageNumber")
+  @JsonProperty("pages")
+  @JsonView({View.ComicDetailsView.class, View.AuditLogEntryDetail.class})
+  @Getter
+  List<Page> pages = new ArrayList<>();
+
+  @ElementCollection
+  @LazyCollection(LazyCollectionOption.FALSE)
+  @CollectionTable(name = "Stories", joinColumns = @JoinColumn(name = "ComicId"))
+  @Column(name = "Name")
+  @JsonProperty("storyArcs")
+  @JsonView({View.ComicListView.class, View.AuditLogEntryDetail.class})
+  @Getter
+  List<String> storyArcs = new ArrayList<>();
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @JsonProperty("id")
-  @JsonView({View.ComicListView.class, View.LastReadList.class, View.AuditLogEntryDetail.class})
+  @JsonView({
+    View.ComicListView.class,
+    View.LastReadList.class,
+    View.AuditLogEntryDetail.class,
+    View.DuplicatePageList.class
+  })
   @Getter
   @Setter
   private Long id;
@@ -92,7 +113,11 @@ public class Comic {
   private ComicState comicState;
 
   @OneToOne(cascade = CascadeType.ALL, mappedBy = "comic", orphanRemoval = true)
-  @JsonView({View.ComicListView.class, View.AuditLogEntryDetail.class})
+  @JsonView({
+    View.ComicListView.class,
+    View.AuditLogEntryDetail.class,
+    View.DuplicatePageList.class
+  })
   @Getter
   @Setter
   private ComicFileDetails fileDetails;
@@ -116,21 +141,33 @@ public class Comic {
 
   @Column(name = "Series", length = 128)
   @JsonProperty("series")
-  @JsonView({View.ComicListView.class, View.AuditLogEntryDetail.class})
+  @JsonView({
+    View.ComicListView.class,
+    View.AuditLogEntryDetail.class,
+    View.DuplicatePageList.class
+  })
   @Getter
   @Setter
   private String series;
 
   @Column(name = "Volume", length = 4)
   @JsonProperty("volume")
-  @JsonView({View.ComicListView.class, View.AuditLogEntryDetail.class})
+  @JsonView({
+    View.ComicListView.class,
+    View.AuditLogEntryDetail.class,
+    View.DuplicatePageList.class
+  })
   @Getter
   @Setter
   private String volume;
 
   @Column(name = "IssueNumber", length = 16)
   @JsonProperty("issueNumber")
-  @JsonView({View.ComicListView.class, View.AuditLogEntryDetail.class})
+  @JsonView({
+    View.ComicListView.class,
+    View.AuditLogEntryDetail.class,
+    View.DuplicatePageList.class
+  })
   @Getter
   private String issueNumber;
 
@@ -147,13 +184,6 @@ public class Comic {
   @Getter
   @Setter
   private String notes;
-
-  @OneToMany(mappedBy = "comic", cascade = CascadeType.ALL, orphanRemoval = true)
-  @OrderColumn(name = "PageNumber")
-  @JsonProperty("pages")
-  @JsonView({View.ComicDetailsView.class, View.AuditLogEntryDetail.class})
-  @Getter
-  List<Page> pages = new ArrayList<>();
 
   @OneToMany(mappedBy = "comic", cascade = CascadeType.ALL, orphanRemoval = true)
   @OrderColumn(name = "FileNumber")
@@ -238,7 +268,11 @@ public class Comic {
 
   @Column(name = "Title", length = 128)
   @JsonProperty("title")
-  @JsonView({View.ComicListView.class, View.AuditLogEntryDetail.class})
+  @JsonView({
+    View.ComicListView.class,
+    View.AuditLogEntryDetail.class,
+    View.DuplicatePageList.class
+  })
   @Getter
   @Setter
   private String title;
@@ -277,15 +311,6 @@ public class Comic {
   @JsonView({View.ComicListView.class, View.AuditLogEntryDetail.class})
   @Getter
   private List<String> locations = new ArrayList<>();
-
-  @ElementCollection
-  @LazyCollection(LazyCollectionOption.FALSE)
-  @CollectionTable(name = "Stories", joinColumns = @JoinColumn(name = "ComicId"))
-  @Column(name = "Name")
-  @JsonProperty("storyArcs")
-  @JsonView({View.ComicListView.class, View.AuditLogEntryDetail.class})
-  @Getter
-  List<String> storyArcs = new ArrayList<>();
 
   @OneToMany(mappedBy = "comic", cascade = CascadeType.ALL, orphanRemoval = true)
   @JsonProperty("credits")
@@ -521,16 +546,16 @@ public class Comic {
   }
 
   @Override
+  public int hashCode() {
+    return 17 * Objects.hash(filename);
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     Comic comic = (Comic) o;
     return this.filename.equals(comic.getFilename());
-  }
-
-  @Override
-  public int hashCode() {
-    return 17 * Objects.hash(filename);
   }
 
   public void removeDeletedPages(final boolean deletePages) {

--- a/comixed-model/src/main/java/org/comixedproject/model/library/DuplicatePage.java
+++ b/comixed-model/src/main/java/org/comixedproject/model/library/DuplicatePage.java
@@ -19,35 +19,37 @@ package org.comixedproject.model.library;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
-import org.comixedproject.model.comic.Page;
+import org.comixedproject.model.comic.Comic;
 import org.comixedproject.views.View;
 
 /**
- * <code>DuplicatePage</code> represents a single duplicate page hash and the set of pages in the
- * library that have that hash.
+ * <code>DuplicatePage</code> represents a page that appears in more than one comic.
  *
  * @author Darryl L. Pierce
  */
+@RequiredArgsConstructor
 public class DuplicatePage {
   @JsonProperty("hash")
   @JsonView(View.DuplicatePageList.class)
+  @NonNull
   @Getter
-  @Setter
   private String hash;
 
   @JsonProperty("blocked")
   @JsonView(View.DuplicatePageList.class)
+  @NonNull
   @Getter
-  @Setter
   private boolean blocked;
 
-  @JsonProperty("pages")
+  @JsonProperty("comics")
   @JsonView(View.DuplicatePageList.class)
   @Getter
   @Setter
-  private List<Page> pages = new ArrayList<>();
+  private Set<Comic> comics = new HashSet<>();
 }

--- a/comixed-model/src/main/java/org/comixedproject/model/messaging/Constants.java
+++ b/comixed-model/src/main/java/org/comixedproject/model/messaging/Constants.java
@@ -41,4 +41,7 @@ public interface Constants {
 
   /** Topic which receives notices when last read entries are removed. */
   String LAST_READ_REMOVAL_TOPIC = "/topic/last-read-list.removal";
+
+  /** Topic which receives notices when the duplicate page list is updated. */
+  String DUPLICATE_PAGE_LIST_TOPIC = "/topic/duplicate-page-list.update";
 }

--- a/comixed-repositories/src/main/java/org/comixedproject/repositories/comic/PageRepository.java
+++ b/comixed-repositories/src/main/java/org/comixedproject/repositories/comic/PageRepository.java
@@ -35,7 +35,7 @@ public interface PageRepository extends CrudRepository<Page, Long> {
    * @return a list of Page objects with duplicate hashes
    */
   @Query(
-      "SELECT p FROM Page p JOIN p.comic WHERE p.hash IN (SELECT d.hash FROM Page d GROUP BY d.hash HAVING COUNT(*) > 1) GROUP BY p.id, p.hash")
+      "SELECT p FROM Page p JOIN FETCH p.comic WHERE p.hash IN (SELECT d.hash FROM Page d GROUP BY d.hash HAVING COUNT(*) > 1) GROUP BY p.id, p.hash")
   List<Page> getDuplicatePages();
 
   /**

--- a/comixed-rest-api/src/main/java/org/comixedproject/controller/comic/PageController.java
+++ b/comixed-rest-api/src/main/java/org/comixedproject/controller/comic/PageController.java
@@ -30,7 +30,6 @@ import org.comixedproject.handlers.ComicFileHandler;
 import org.comixedproject.model.comic.Comic;
 import org.comixedproject.model.comic.Page;
 import org.comixedproject.model.comic.PageType;
-import org.comixedproject.model.library.DuplicatePage;
 import org.comixedproject.model.net.SetPageTypeRequest;
 import org.comixedproject.service.comic.ComicException;
 import org.comixedproject.service.comic.PageCacheService;
@@ -87,15 +86,6 @@ public class PageController {
     return this.pageService.getAllPagesForComic(id);
   }
 
-  @GetMapping(value = "/pages/duplicates", produces = MediaType.APPLICATION_JSON_VALUE)
-  @JsonView(View.DuplicatePageList.class)
-  @AuditableEndpoint
-  public List<DuplicatePage> getDuplicatePages() {
-    log.info("Getting duplicate pages");
-
-    return this.pageService.getDuplicatePages();
-  }
-
   /**
    * Retrieves the content for a single comic page by comic id and page index.
    *
@@ -103,11 +93,11 @@ public class PageController {
    * @return the page content
    * @throws ComicException if an error occurs
    */
-  @GetMapping(value = "/pages/{pageId}/content", produces = MediaType.APPLICATION_JSON_VALUE)
+  @GetMapping(value = "/pages/{pageId}/content")
   @AuditableEndpoint
   public ResponseEntity<byte[]> getPageContent(@PathVariable("pageId") long pageId)
       throws ComicException {
-    log.debug("Getting image content for page: pageId={}", pageId);
+    log.info("Getting image content for page: pageId={}", pageId);
     return this.getResponseEntityForPage(this.pageService.getForId(pageId));
   }
 
@@ -150,6 +140,21 @@ public class PageController {
         .header("Content-Disposition", "attachment; filename=\"" + page.getFilename() + "\"")
         .contentType(MediaType.valueOf(type))
         .body(content);
+  }
+
+  /**
+   * Returns the page content for the given hash value.
+   *
+   * @param hash the page hash
+   * @return the page content
+   * @throws ComicException if an error occurs
+   */
+  @GetMapping(value = "/pages/hashes/{hash}/content")
+  @AuditableEndpoint
+  public ResponseEntity<byte[]> getPageForHash(@PathVariable("hash") final String hash)
+      throws ComicException {
+    log.info("Getting image content for page hash: {}", hash);
+    return this.getResponseEntityForPage(this.pageService.getOneForHash(hash));
   }
 
   /**

--- a/comixed-rest-api/src/main/java/org/comixedproject/controller/library/DuplicatePageController.java
+++ b/comixed-rest-api/src/main/java/org/comixedproject/controller/library/DuplicatePageController.java
@@ -1,0 +1,56 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.controller.library;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import java.util.List;
+import lombok.extern.log4j.Log4j2;
+import org.comixedproject.model.library.DuplicatePage;
+import org.comixedproject.service.comic.PageService;
+import org.comixedproject.views.View;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * <code>DuplicatePageController</code> provides endpoints for working with {@link DuplicatePage}
+ * instances.
+ *
+ * @author Darryl L. Pierce
+ */
+@RestController
+@Log4j2
+public class DuplicatePageController {
+  @Autowired private PageService pageService;
+
+  /**
+   * Returns the list of duplicate pages.
+   *
+   * @return the duplicate page list
+   */
+  @GetMapping(value = "/api/library/pages/duplicates", produces = MediaType.APPLICATION_JSON_VALUE)
+  @JsonView(View.DuplicatePageList.class)
+  @PreAuthorize("hasRole('ADMIN')")
+  public List<DuplicatePage> getDuplicatePageList() {
+    log.info("Getting list of duplicate pages");
+    return this.pageService.getDuplicatePages();
+  }
+}

--- a/comixed-rest-api/src/test/java/org/comixedproject/controller/comic/PageControllerTest.java
+++ b/comixed-rest-api/src/test/java/org/comixedproject/controller/comic/PageControllerTest.java
@@ -21,7 +21,6 @@ package org.comixedproject.controller.comic;
 import static org.junit.Assert.*;
 
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.List;
 import org.comixedproject.adaptors.archive.ArchiveAdaptor;
 import org.comixedproject.adaptors.archive.ArchiveAdaptorException;
@@ -30,7 +29,6 @@ import org.comixedproject.model.archives.ArchiveType;
 import org.comixedproject.model.comic.Comic;
 import org.comixedproject.model.comic.Page;
 import org.comixedproject.model.comic.PageType;
-import org.comixedproject.model.library.DuplicatePage;
 import org.comixedproject.model.net.SetPageTypeRequest;
 import org.comixedproject.service.comic.ComicException;
 import org.comixedproject.service.comic.PageCacheService;
@@ -49,7 +47,6 @@ import org.springframework.http.ResponseEntity;
 @SpringBootTest
 public class PageControllerTest {
   private static final long TEST_PAGE_ID = 129;
-  private static final List<DuplicatePage> TEST_DUPLICATE_PAGES = new ArrayList<>();
   private static final int TEST_PAGE_INDEX = 7;
   private static final long TEST_COMIC_ID = 1002L;
   private static final byte[] TEST_PAGE_CONTENT = new byte[53253];
@@ -70,17 +67,12 @@ public class PageControllerTest {
   @Mock private FileTypeIdentifier fileTypeIdentifier;
   @Mock private ComicFileHandler comicFileHandler;
   @Mock private ArchiveAdaptor archiveAdaptor;
-  @Mock private List<String> pageHashList;
 
   @Captor private ArgumentCaptor<InputStream> inputStream;
   private ArchiveType archiveType = ArchiveType.CB7;
 
   @Before
   public void setUp() {
-    pageHashList.add("12345");
-    pageHashList.add("23456");
-    pageHashList.add("34567");
-
     Mockito.when(page.getHash()).thenReturn(TEST_PAGE_HASH);
   }
 
@@ -97,19 +89,6 @@ public class PageControllerTest {
 
     Mockito.verify(pageService, Mockito.times(1))
         .updateTypeForPage(TEST_PAGE_ID, TEST_PAGE_TYPE_NAME);
-  }
-
-  @Test
-  public void testGetDuplicatePages() {
-
-    Mockito.when(pageService.getDuplicatePages()).thenReturn(TEST_DUPLICATE_PAGES);
-
-    List<DuplicatePage> result = pageController.getDuplicatePages();
-
-    assertNotNull(result);
-    assertSame(TEST_DUPLICATE_PAGES, result);
-
-    Mockito.verify(pageService, Mockito.times(1)).getDuplicatePages();
   }
 
   @Test

--- a/comixed-rest-api/src/test/java/org/comixedproject/controller/library/DuplicatePageControllerTest.java
+++ b/comixed-rest-api/src/test/java/org/comixedproject/controller/library/DuplicatePageControllerTest.java
@@ -1,0 +1,53 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.controller.library;
+
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertSame;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.comixedproject.model.library.DuplicatePage;
+import org.comixedproject.service.comic.PageService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DuplicatePageControllerTest {
+  @InjectMocks private DuplicatePageController controller;
+  @Mock private PageService pageService;
+
+  private List<DuplicatePage> duplicatePageList = new ArrayList<>();
+
+  @Test
+  public void testGetDuplicatePageList() {
+    Mockito.when(pageService.getDuplicatePages()).thenReturn(duplicatePageList);
+
+    final List<DuplicatePage> result = controller.getDuplicatePageList();
+
+    assertNotNull(result);
+    assertSame(duplicatePageList, result);
+
+    Mockito.verify(pageService, Mockito.times(1)).getDuplicatePages();
+  }
+}

--- a/comixed-services/src/main/java/org/comixedproject/service/blockedpage/BlockedPageService.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/blockedpage/BlockedPageService.java
@@ -29,9 +29,11 @@ import org.comixedproject.adaptors.csv.CsvAdaptor;
 import org.comixedproject.messaging.PublishingException;
 import org.comixedproject.messaging.blockedpage.PublishBlockedPageRemovalAction;
 import org.comixedproject.messaging.blockedpage.PublishBlockedPageUpdateAction;
+import org.comixedproject.messaging.library.PublishDuplicatePageListUpdateAction;
 import org.comixedproject.model.blockedpage.BlockedPage;
 import org.comixedproject.model.net.DownloadDocument;
 import org.comixedproject.repositories.blockedpage.BlockedPageRepository;
+import org.comixedproject.service.comic.PageService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -52,6 +54,8 @@ public class BlockedPageService {
   @Autowired private CsvAdaptor csvAdaptor;
   @Autowired private PublishBlockedPageUpdateAction publishBlockedPageUpdateAction;
   @Autowired private PublishBlockedPageRemovalAction publishBlockedPageRemovalAction;
+  @Autowired private PageService pageService;
+  @Autowired private PublishDuplicatePageListUpdateAction publishDuplicatePageListUpdateAction;
 
   /**
    * Returns all blocked pages.
@@ -113,7 +117,17 @@ public class BlockedPageService {
     } catch (PublishingException error) {
       log.error("Failed to publish blocked page update", error);
     }
+    this.doPublishDuplicatePageUpdates();
     return result;
+  }
+
+  private void doPublishDuplicatePageUpdates() {
+    try {
+      log.trace("Publishing duplicate page list");
+      this.publishDuplicatePageListUpdateAction.publish(this.pageService.getDuplicatePages());
+    } catch (PublishingException error) {
+      log.error("Failed to publish duplicate page list", error);
+    }
   }
 
   /**
@@ -141,6 +155,7 @@ public class BlockedPageService {
     } catch (PublishingException error) {
       log.error("Failed to publish blocked page update", error);
     }
+    this.doPublishDuplicatePageUpdates();
     return result;
   }
 
@@ -164,6 +179,7 @@ public class BlockedPageService {
     } catch (PublishingException error) {
       log.error("Failed to publish blocked page remove", error);
     }
+    this.doPublishDuplicatePageUpdates();
     return result;
   }
 

--- a/comixed-services/src/main/java/org/comixedproject/service/comic/PageService.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/comic/PageService.java
@@ -198,24 +198,22 @@ public class PageService {
 
   @Transactional(isolation = Isolation.READ_UNCOMMITTED)
   public List<DuplicatePage> getDuplicatePages() {
-    log.debug("Getting pages from repository");
+    log.trace("Getting pages from repository");
     final List<Page> pages = this.pageRepository.getDuplicatePages();
-
-    log.debug("Build duplicate page list");
+    log.trace("Build duplicate page list");
     Map<String, DuplicatePage> mapped = new HashMap<>();
     for (Page page : pages) {
+      log.trace("Looking for existing entry");
       DuplicatePage entry = mapped.get(page.getHash());
-
       if (entry == null) {
-        entry = new DuplicatePage();
-
-        entry.setHash(page.getHash());
-        entry.setBlocked(page.isBlocked());
+        log.trace("Creating new entry");
+        entry = new DuplicatePage(page.getHash(), page.isBlocked());
         mapped.put(entry.getHash(), entry);
       }
-      entry.getPages().add(page);
+      log.trace("Loading comic into entry");
+      entry.getComics().add(page.getComic());
     }
-
+    log.trace("Returning duplicate page list");
     return new ArrayList<>(mapped.values());
   }
 

--- a/comixed-web/src/app/blocked-pages/actions/block-page.actions.ts
+++ b/comixed-web/src/app/blocked-pages/actions/block-page.actions.ts
@@ -21,7 +21,7 @@ import { Page } from '@app/comic-book/models/page';
 
 export const setBlockedState = createAction(
   '[Block Page] Sets the blocked state',
-  props<{ page: Page; blocked: boolean }>()
+  props<{ hash: string; blocked: boolean }>()
 );
 
 export const blockedStateSet = createAction(

--- a/comixed-web/src/app/blocked-pages/blocked-pages.routing.ts
+++ b/comixed-web/src/app/blocked-pages/blocked-pages.routing.ts
@@ -24,12 +24,12 @@ import { BlockedPageDetailPageComponent } from '@app/blocked-pages/pages/blocked
 
 const routes: Routes = [
   {
-    path: 'admin/pages/blocked',
+    path: 'library/pages/blocked',
     component: BlockedPageListPageComponent,
     canActivate: [AdminGuard]
   },
   {
-    path: 'admin/pages/blocked/:hash',
+    path: 'library/pages/blocked/:hash',
     component: BlockedPageDetailPageComponent,
     canActivate: [AdminGuard]
   }

--- a/comixed-web/src/app/blocked-pages/effects/block-page.effects.spec.ts
+++ b/comixed-web/src/app/blocked-pages/effects/block-page.effects.spec.ts
@@ -81,7 +81,7 @@ describe('BlockPageEffects', () => {
     it('fires an action on success', () => {
       const serviceResponse = new HttpResponse({ status: 200 });
       const action = setBlockedState({
-        page: PAGE,
+        hash: PAGE.hash,
         blocked: Math.random() > 0.5
       });
       const outcome = blockedStateSet();
@@ -98,7 +98,7 @@ describe('BlockPageEffects', () => {
     xit('fires an action on service failure', () => {
       const serviceResponse = new HttpErrorResponse({});
       const action = setBlockedState({
-        page: PAGE,
+        hash: PAGE.hash,
         blocked: Math.random() > 0.5
       });
       const outcome = setBlockedStateFailed();
@@ -115,7 +115,7 @@ describe('BlockPageEffects', () => {
 
     it('fires an action on general failure', () => {
       const action = setBlockedState({
-        page: PAGE,
+        hash: PAGE.hash,
         blocked: Math.random() > 0.5
       });
       const outcome = setBlockedStateFailed();

--- a/comixed-web/src/app/blocked-pages/effects/block-page.effects.ts
+++ b/comixed-web/src/app/blocked-pages/effects/block-page.effects.ts
@@ -38,7 +38,7 @@ export class BlockPageEffects {
       tap(action => this.logger.debug('Effect: set blocked state:', action)),
       switchMap(action =>
         this.blockedPageService
-          .setBlockedState({ page: action.page, blocked: action.blocked })
+          .setBlockedState({ hash: action.hash, blocked: action.blocked })
           .pipe(
             tap(() =>
               this.alertService.info(

--- a/comixed-web/src/app/blocked-pages/pages/blocked-page-detail-page/blocked-page-detail-page.component.spec.ts
+++ b/comixed-web/src/app/blocked-pages/pages/blocked-page-detail-page/blocked-page-detail-page.component.spec.ts
@@ -111,7 +111,9 @@ describe('BlockedPageDetailPageComponent', () => {
     });
 
     it('redirects to the blocked page list', () => {
-      expect(router.navigateByUrl).toHaveBeenCalledWith('/admin/pages/blocked');
+      expect(router.navigateByUrl).toHaveBeenCalledWith(
+        '/library/pages/blocked'
+      );
     });
   });
 
@@ -214,7 +216,9 @@ describe('BlockedPageDetailPageComponent', () => {
     });
 
     it('redirects the browsers', () => {
-      expect(router.navigateByUrl).toHaveBeenCalledWith('/admin/pages/blocked');
+      expect(router.navigateByUrl).toHaveBeenCalledWith(
+        '/library/pages/blocked'
+      );
     });
   });
 });

--- a/comixed-web/src/app/blocked-pages/pages/blocked-page-detail-page/blocked-page-detail-page.component.ts
+++ b/comixed-web/src/app/blocked-pages/pages/blocked-page-detail-page/blocked-page-detail-page.component.ts
@@ -78,7 +78,7 @@ export class BlockedPageDetailPageComponent implements OnInit, OnDestroy {
         this.store.dispatch(setBusyState({ enabled: state.loading }));
         if (!state.loading && state.notFound) {
           this.logger.debug('Blocked page not found');
-          this.router.navigateByUrl('/admin/pages/blocked');
+          this.router.navigateByUrl('/library/pages/blocked');
         }
       });
     this.blockedPageSubscription = this.store
@@ -149,7 +149,7 @@ export class BlockedPageDetailPageComponent implements OnInit, OnDestroy {
   }
 
   onGoBack(): void {
-    this.router.navigateByUrl('/admin/pages/blocked');
+    this.router.navigateByUrl('/library/pages/blocked');
   }
 
   encodeForm(): BlockedPage {

--- a/comixed-web/src/app/blocked-pages/reducers/block-page.reducer.spec.ts
+++ b/comixed-web/src/app/blocked-pages/reducers/block-page.reducer.spec.ts
@@ -47,7 +47,7 @@ describe('BlockPage Reducer', () => {
     beforeEach(() => {
       state = reducer(
         { ...state, saving: false },
-        setBlockedState({ page: PAGE, blocked: true })
+        setBlockedState({ hash: PAGE.hash, blocked: true })
       );
     });
 

--- a/comixed-web/src/app/blocked-pages/services/blocked-page.service.spec.ts
+++ b/comixed-web/src/app/blocked-pages/services/blocked-page.service.spec.ts
@@ -227,7 +227,7 @@ describe('BlockedPageService', () => {
 
   it('can block a page', () => {
     service
-      .setBlockedState({ page: PAGE, blocked: true })
+      .setBlockedState({ hash: PAGE.hash, blocked: true })
       .subscribe(response => expect(response.status).toEqual(200));
 
     const req = httpMock.expectOne(
@@ -240,7 +240,7 @@ describe('BlockedPageService', () => {
 
   it('can unblock a page', () => {
     service
-      .setBlockedState({ page: PAGE, blocked: false })
+      .setBlockedState({ hash: PAGE.hash, blocked: false })
       .subscribe(response => expect(response.status).toEqual(200));
 
     const req = httpMock.expectOne(

--- a/comixed-web/src/app/blocked-pages/services/blocked-page.service.ts
+++ b/comixed-web/src/app/blocked-pages/services/blocked-page.service.ts
@@ -134,17 +134,17 @@ export class BlockedPageService {
    * @param args.page the page
    * @param args.blocked the blocked state
    */
-  setBlockedState(args: { page: Page; blocked: boolean }): Observable<any> {
+  setBlockedState(args: { hash: string; blocked: boolean }): Observable<any> {
     if (args.blocked) {
       this.logger.debug('Service: blocking pages with hash:', args);
       return this.http.post(
-        interpolate(SET_BLOCKED_STATE_URL, { hash: args.page.hash }),
+        interpolate(SET_BLOCKED_STATE_URL, { hash: args.hash }),
         {}
       );
     } else {
       this.logger.debug('Service: unblocking pages with hash:', args);
       return this.http.delete(
-        interpolate(REMOVE_BLOCKED_STATE_URL, { hash: args.page.hash })
+        interpolate(REMOVE_BLOCKED_STATE_URL, { hash: args.hash })
       );
     }
   }

--- a/comixed-web/src/app/comic-book/comic-book.constants.ts
+++ b/comixed-web/src/app/comic-book/comic-book.constants.ts
@@ -22,5 +22,7 @@ export const LOAD_COMIC_FORMATS_URL = `${API_ROOT_URL}/comics/formats`;
 export const LOAD_SCAN_TYPES_URL = `${API_ROOT_URL}/comics/scantypes`;
 export const UPDATE_COMIC_INFO_URL = `${API_ROOT_URL}/comics/\${id}/comicinfo`;
 
+export const PAGE_URL_FROM_HASH = `${API_ROOT_URL}/pages/hashes/\${hash}/content`;
+
 export const COMICVINE_ISSUE_LINK =
   'https://comicvine.gamespot.com/issues/4000-${id}/';

--- a/comixed-web/src/app/comic-book/comic-book.module.ts
+++ b/comixed-web/src/app/comic-book/comic-book.module.ts
@@ -85,6 +85,7 @@ import { MatSortModule } from '@angular/material/sort';
 import { CoreModule } from '@app/core/core.module';
 import { MatGridListModule } from '@angular/material/grid-list';
 import { ComicvineIssueLinkPipe } from './pipes/comicvine-issue-link.pipe';
+import { PageHashUrlPipe } from './pipes/page-hash-url.pipe';
 
 @NgModule({
   declarations: [
@@ -101,7 +102,8 @@ import { ComicvineIssueLinkPipe } from './pipes/comicvine-issue-link.pipe';
     ComicPageUrlPipe,
     ComicTitlePipe,
     ScrapingIssueTitlePipe,
-    ComicvineIssueLinkPipe
+    ComicvineIssueLinkPipe,
+    PageHashUrlPipe
   ],
   imports: [
     CommonModule,
@@ -151,7 +153,8 @@ import { ComicvineIssueLinkPipe } from './pipes/comicvine-issue-link.pipe';
     ComicScrapingComponent,
     ComicDetailCardComponent,
     ComicTitlePipe,
-    ComicCoverUrlPipe
+    ComicCoverUrlPipe,
+    PageHashUrlPipe
   ]
 })
 export class ComicBookModule {

--- a/comixed-web/src/app/comic-book/components/comic-detail-card/comic-detail-card.component.html
+++ b/comixed-web/src/app/comic-book/components/comic-detail-card/comic-detail-card.component.html
@@ -84,7 +84,7 @@
         (click)="onCoverClicked()"
         (contextmenu)="onContextMenu($event)"
       />
-      <mat-chip-list>
+      <mat-chip-list *ngIf="showActions">
         <mat-chip
           *ngIf="detailLink"
           [routerLink]="detailLink"

--- a/comixed-web/src/app/comic-book/components/comic-detail-card/comic-detail-card.component.ts
+++ b/comixed-web/src/app/comic-book/components/comic-detail-card/comic-detail-card.component.ts
@@ -53,6 +53,7 @@ export class ComicDetailCardComponent implements OnInit, OnDestroy {
   @Input() selected = false;
   @Input() comicChanged = false;
   @Input() isAdmin = false;
+  @Input() showActions = true;
 
   @Output() selectionChanged = new EventEmitter<ComicSelectEvent>();
   @Output() showContextMenu = new EventEmitter<ComicContextMenuEvent>();

--- a/comixed-web/src/app/comic-book/components/comic-pages/comic-pages.component.spec.ts
+++ b/comixed-web/src/app/comic-book/components/comic-pages/comic-pages.component.spec.ts
@@ -110,7 +110,7 @@ describe('ComicPagesComponent', () => {
 
     it('fires an action', () => {
       expect(store.dispatch).toHaveBeenCalledWith(
-        setBlockedState({ page: PAGE, blocked: BLOCKED })
+        setBlockedState({ hash: PAGE.hash, blocked: BLOCKED })
       );
     });
   });

--- a/comixed-web/src/app/comic-book/components/comic-pages/comic-pages.component.ts
+++ b/comixed-web/src/app/comic-book/components/comic-pages/comic-pages.component.ts
@@ -53,6 +53,6 @@ export class ComicPagesComponent implements OnInit {
 
   onSetPageBlocked(page: Page, blocked: boolean): void {
     this.logger.debug('Updating page blocked state:', page, blocked);
-    this.store.dispatch(setBlockedState({ page, blocked }));
+    this.store.dispatch(setBlockedState({ hash: page.hash, blocked }));
   }
 }

--- a/comixed-web/src/app/comic-book/pipes/page-hash-url.pipe.spec.ts
+++ b/comixed-web/src/app/comic-book/pipes/page-hash-url.pipe.spec.ts
@@ -1,0 +1,44 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { PageHashUrlPipe } from './page-hash-url.pipe';
+import { PAGE_2 } from '@app/comic-book/comic-book.fixtures';
+import { PAGE_URL_FROM_HASH } from '@app/comic-book/comic-book.constants';
+import { interpolate } from '@app/core';
+
+describe('PageHashUrlPipe', () => {
+  const PAGE = PAGE_2;
+
+  let pipe: PageHashUrlPipe;
+
+  beforeEach(() => {
+    pipe = new PageHashUrlPipe();
+  });
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('returns a url', () => {
+    expect(pipe.transform(PAGE.hash)).toEqual(
+      interpolate(PAGE_URL_FROM_HASH, {
+        hash: PAGE.hash
+      })
+    );
+  });
+});

--- a/comixed-web/src/app/comic-book/pipes/page-hash-url.pipe.ts
+++ b/comixed-web/src/app/comic-book/pipes/page-hash-url.pipe.ts
@@ -1,0 +1,30 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { Pipe, PipeTransform } from '@angular/core';
+import { interpolate } from '@app/core';
+import { PAGE_URL_FROM_HASH } from '@app/comic-book/comic-book.constants';
+
+@Pipe({
+  name: 'pageHashUrl'
+})
+export class PageHashUrlPipe implements PipeTransform {
+  transform(hash: string): string {
+    return interpolate(PAGE_URL_FROM_HASH, { hash });
+  }
+}

--- a/comixed-web/src/app/components/side-navigation/side-navigation.component.html
+++ b/comixed-web/src/app/components/side-navigation/side-navigation.component.html
@@ -37,7 +37,15 @@
         {{ "navigation.option.unscraped-comics" | translate }}
       </a>
       <a
-        *ngIf="!!user"
+        *ngIf="isAdmin"
+        mat-list-item
+        routerLink="/library/import"
+        routerLinkActive="active"
+      >
+        {{ "navigation.option.import-comics" | translate }}
+      </a>
+      <a
+        *ngIf="isAdmin"
         mat-list-item
         routerLink="/library/deleted"
         routerLinkActive="active"
@@ -47,10 +55,18 @@
       <a
         *ngIf="isAdmin"
         mat-list-item
-        routerLink="/library/import"
+        routerLink="/library/pages/duplicates"
         routerLinkActive="active"
       >
-        {{ "navigation.option.import-comics" | translate }}
+        {{ "navigation.option.duplicate-pages" | translate }}
+      </a>
+      <a
+        *ngIf="isAdmin"
+        mat-list-item
+        routerLink="/library/pages/blocked"
+        routerLinkActive="active"
+      >
+        {{ "navigation.option.blocked-pages" | translate }}
       </a>
     </mat-nav-list>
 
@@ -155,14 +171,6 @@
       routerLinkActive="active"
     >
       {{ "navigation.option.configuration" | translate }}
-    </a>
-    <a
-      *ngIf="isAdmin"
-      mat-list-item
-      routerLink="/admin/pages/blocked"
-      routerLinkActive="active"
-    >
-      {{ "navigation.option.blocked-pages" | translate }}
     </a>
     <a
       *ngIf="isAdmin"

--- a/comixed-web/src/app/library/actions/duplicate-page-list.actions.ts
+++ b/comixed-web/src/app/library/actions/duplicate-page-list.actions.ts
@@ -1,0 +1,37 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { createAction, props } from '@ngrx/store';
+import { DuplicatePage } from '@app/library/models/duplicate-page';
+
+export const resetDuplicatePages = createAction(
+  '[Duplicate Page List] Resets the feature state'
+);
+
+export const loadDuplicatePages = createAction(
+  '[Duplicate Page List] Load all duplicate pages'
+);
+
+export const duplicatePagesLoaded = createAction(
+  '[Duplicate Page List] Duplicate pages loaded',
+  props<{ pages: DuplicatePage[] }>()
+);
+
+export const loadDuplicatePagesFailed = createAction(
+  '[Duplicate Page List] Failed to load all duplicate pages'
+);

--- a/comixed-web/src/app/library/components/comic-covers/comic-covers.component.html
+++ b/comixed-web/src/app/library/components/comic-covers/comic-covers.component.html
@@ -5,6 +5,7 @@
     [pagination]="pagination"
     [archiveType]="archiveType"
     (archiveTypeChanged)="onArchiveTypeChanged($event)"
+    [showActions]="showActions"
   ></cx-library-toolbar>
   <div
     id="cx-all-comics"
@@ -22,6 +23,7 @@
       [selected]="isSelected(comic)"
       [comicChanged]="isChanged(comic)"
       [isAdmin]="isAdmin"
+      [showActions]="showActions"
       (selectionChanged)="onSelectionChanged($event.comic, $event.selected)"
       (showContextMenu)="onShowContextMenu($event.comic, $event.x, $event.y)"
       (updateComicInfo)="onUpdateComicInfo($event.comic)"

--- a/comixed-web/src/app/library/components/comic-covers/comic-covers.component.ts
+++ b/comixed-web/src/app/library/components/comic-covers/comic-covers.component.ts
@@ -61,6 +61,7 @@ export class ComicCoversComponent implements OnInit, OnDestroy, AfterViewInit {
   @Input() selected: Comic[] = [];
   @Input() isAdmin = false;
   @Input() archiveType: ArchiveType;
+  @Input() showActions = true;
 
   @Output() archiveTypeChanged = new EventEmitter<ArchiveType>();
 

--- a/comixed-web/src/app/library/components/comics-with-duplicate-page/comics-with-duplicate-page.component.html
+++ b/comixed-web/src/app/library/components/comics-with-duplicate-page/comics-with-duplicate-page.component.html
@@ -1,0 +1,1 @@
+<cx-comic-covers [comics]="page.comics" [showActions]="false"></cx-comic-covers>

--- a/comixed-web/src/app/library/components/comics-with-duplicate-page/comics-with-duplicate-page.component.spec.ts
+++ b/comixed-web/src/app/library/components/comics-with-duplicate-page/comics-with-duplicate-page.component.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComicsWithDuplicatePageComponent } from './comics-with-duplicate-page.component';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+describe('ComicsWithDuplicatePageComponent', () => {
+  let component: ComicsWithDuplicatePageComponent;
+  let fixture: ComponentFixture<ComicsWithDuplicatePageComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ComicsWithDuplicatePageComponent],
+      providers: [
+        {
+          provide: MatDialogRef,
+          useValue: {}
+        },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: {}
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ComicsWithDuplicatePageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/comixed-web/src/app/library/components/comics-with-duplicate-page/comics-with-duplicate-page.component.ts
+++ b/comixed-web/src/app/library/components/comics-with-duplicate-page/comics-with-duplicate-page.component.ts
@@ -1,0 +1,30 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { DuplicatePage } from '@app/library/models/duplicate-page';
+
+@Component({
+  selector: 'cx-comics-with-duplicate-page',
+  templateUrl: './comics-with-duplicate-page.component.html',
+  styleUrls: ['./comics-with-duplicate-page.component.scss']
+})
+export class ComicsWithDuplicatePageComponent {
+  constructor(@Inject(MAT_DIALOG_DATA) public page: DuplicatePage) {}
+}

--- a/comixed-web/src/app/library/components/library-toolbar/library-toolbar.component.html
+++ b/comixed-web/src/app/library/components/library-toolbar/library-toolbar.component.html
@@ -23,6 +23,7 @@
   </mat-form-field>
   <button
     id="scrape-all-button"
+    *ngIf="showActions"
     mat-icon-button
     color="primary"
     class="cx-toolbar-button cx-margin-right-5"
@@ -34,6 +35,7 @@
   </button>
   <button
     id="select-all-button"
+    *ngIf="showActions"
     mat-icon-button
     color="primary"
     class="cx-toolbar-button cx-margin-right-5"
@@ -45,6 +47,7 @@
   </button>
   <button
     id="deselect-all-button"
+    *ngIf="showActions"
     mat-icon-button
     color="warn"
     class="cx-toolbar-button cx-margin-right-5"
@@ -55,7 +58,7 @@
     <mat-icon>check_box</mat-icon>
   </button>
   <button
-    *ngIf="isAdmin"
+    *ngIf="showActions && isAdmin"
     id="scrape-comics-button"
     mat-icon-button
     color="accent"

--- a/comixed-web/src/app/library/components/library-toolbar/library-toolbar.component.ts
+++ b/comixed-web/src/app/library/components/library-toolbar/library-toolbar.component.ts
@@ -61,6 +61,7 @@ export class LibraryToolbarComponent
   @Input() selected: Comic[] = [];
   @Input() isAdmin = false;
   @Input() archiveType: ArchiveType;
+  @Input() showActions = true;
 
   @Output() archiveTypeChanged = new EventEmitter<ArchiveType>();
 

--- a/comixed-web/src/app/library/effects/duplicate-page-list.effects.spec.ts
+++ b/comixed-web/src/app/library/effects/duplicate-page-list.effects.spec.ts
@@ -1,0 +1,124 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { Observable, of, throwError } from 'rxjs';
+import { DuplicatePageListEffects } from './duplicate-page-list.effects';
+import { LoggerModule } from '@angular-ru/logger';
+import { TranslateModule } from '@ngx-translate/core';
+import { DuplicatePageService } from '@app/library/services/duplicate-page.service';
+import { AlertService } from '@app/core/services/alert.service';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import {
+  duplicatePagesLoaded,
+  loadDuplicatePages,
+  loadDuplicatePagesFailed
+} from '@app/library/actions/duplicate-page-list.actions';
+import { hot } from 'jasmine-marbles';
+import { HttpErrorResponse } from '@angular/common/http';
+import {
+  DUPLICATE_PAGE_1,
+  DUPLICATE_PAGE_2,
+  DUPLICATE_PAGE_3
+} from '@app/library/library.fixtures';
+
+describe('DuplicatePageListEffects', () => {
+  const PAGES = [DUPLICATE_PAGE_1, DUPLICATE_PAGE_2, DUPLICATE_PAGE_3];
+
+  let actions$: Observable<any>;
+  let effects: DuplicatePageListEffects;
+  let duplicatePageService: jasmine.SpyObj<DuplicatePageService>;
+  let alertService: AlertService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        LoggerModule.forRoot(),
+        TranslateModule.forRoot(),
+        MatSnackBarModule
+      ],
+      providers: [
+        DuplicatePageListEffects,
+        provideMockActions(() => actions$),
+        {
+          provide: DuplicatePageService,
+          useValue: {
+            loadDuplicatePages: jasmine.createSpy(
+              'DuplicatePageService.loadDuplicatePages()'
+            )
+          }
+        }
+      ]
+    });
+
+    effects = TestBed.inject(DuplicatePageListEffects);
+    duplicatePageService = TestBed.inject(
+      DuplicatePageService
+    ) as jasmine.SpyObj<DuplicatePageService>;
+    alertService = TestBed.inject(AlertService);
+    spyOn(alertService, 'error');
+  });
+
+  it('should be created', () => {
+    expect(effects).toBeTruthy();
+  });
+
+  describe('loading comics with duplicate pages', () => {
+    it('fires an action on success', () => {
+      const serviceResponse = PAGES;
+      const action = loadDuplicatePages();
+      const outcome = duplicatePagesLoaded({ pages: PAGES });
+
+      actions$ = hot('-a', { a: action });
+      duplicatePageService.loadDuplicatePages.and.returnValue(
+        of(serviceResponse)
+      );
+
+      const expected = hot('-b', { b: outcome });
+      expect(effects.loadComicsWithDuplicatePages$).toBeObservable(expected);
+    });
+
+    it('fires an action on service failure', () => {
+      const serviceResponse = new HttpErrorResponse({});
+      const action = loadDuplicatePages();
+      const outcome = loadDuplicatePagesFailed();
+
+      actions$ = hot('-a', { a: action });
+      duplicatePageService.loadDuplicatePages.and.returnValue(
+        throwError(serviceResponse)
+      );
+
+      const expected = hot('-b', { b: outcome });
+      expect(effects.loadComicsWithDuplicatePages$).toBeObservable(expected);
+      expect(alertService.error).toHaveBeenCalledWith(jasmine.any(String));
+    });
+
+    it('fires an action on general failure', () => {
+      const action = loadDuplicatePages();
+      const outcome = loadDuplicatePagesFailed();
+
+      actions$ = hot('-a', { a: action });
+      duplicatePageService.loadDuplicatePages.and.throwError('expected');
+
+      const expected = hot('-(b|)', { b: outcome });
+      expect(effects.loadComicsWithDuplicatePages$).toBeObservable(expected);
+      expect(alertService.error).toHaveBeenCalledWith(jasmine.any(String));
+    });
+  });
+});

--- a/comixed-web/src/app/library/effects/duplicate-page-list.effects.ts
+++ b/comixed-web/src/app/library/effects/duplicate-page-list.effects.ts
@@ -1,0 +1,79 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { Injectable } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import {
+  duplicatePagesLoaded,
+  loadDuplicatePages,
+  loadDuplicatePagesFailed
+} from '@app/library/actions/duplicate-page-list.actions';
+import { DuplicatePageService } from '@app/library/services/duplicate-page.service';
+import { LoggerService } from '@angular-ru/logger';
+import { AlertService } from '@app/core/services/alert.service';
+import { TranslateService } from '@ngx-translate/core';
+import { catchError, map, switchMap, tap } from 'rxjs/operators';
+import { of } from 'rxjs';
+import { DuplicatePage } from '@app/library/models/duplicate-page';
+
+@Injectable()
+export class DuplicatePageListEffects {
+  loadComicsWithDuplicatePages$ = createEffect(() => {
+    return this.actions$.pipe(
+      ofType(loadDuplicatePages),
+      tap(action =>
+        this.logger.trace(
+          'Effect: loading all comics with duplicate pages:',
+          action
+        )
+      ),
+      switchMap(action =>
+        this.duplicatePageService.loadDuplicatePages().pipe(
+          tap(response => this.logger.trace('Response received:', response)),
+          map((response: DuplicatePage[]) =>
+            duplicatePagesLoaded({ pages: response })
+          ),
+          catchError(error => {
+            this.logger.error('Service failure:', error);
+            this.alertService.error(
+              this.translateService.instant(
+                'duplicate-pages.load-comics.effect-failure'
+              )
+            );
+            return of(loadDuplicatePagesFailed());
+          })
+        )
+      ),
+      catchError(error => {
+        this.logger.error('General failure:', error);
+        this.alertService.error(
+          this.translateService.instant('app.general-effect-failure')
+        );
+        return of(loadDuplicatePagesFailed());
+      })
+    );
+  });
+
+  constructor(
+    private logger: LoggerService,
+    private actions$: Actions,
+    private duplicatePageService: DuplicatePageService,
+    private alertService: AlertService,
+    private translateService: TranslateService
+  ) {}
+}

--- a/comixed-web/src/app/library/index.ts
+++ b/comixed-web/src/app/library/index.ts
@@ -34,6 +34,11 @@ import {
   DisplayState,
   reducer as displayReducer
 } from '@app/library/reducers/display.reducer';
+import {
+  DUPLICATE_PAGE_LIST_FEATURE_KEY,
+  DuplicatePageListState,
+  reducer as comicsWithDuplicatePagesReducer
+} from './reducers/duplicate-page-list.reducer';
 
 interface RouterStateUrl {
   url: string;
@@ -46,6 +51,7 @@ export interface LibraryModuleState {
   [DISPLAY_FEATURE_KEY]: DisplayState;
   [COMIC_IMPORT_FEATURE_KEY]: ComicImportState;
   [LIBRARY_FEATURE_KEY]: LibraryState;
+  [DUPLICATE_PAGE_LIST_FEATURE_KEY]: DuplicatePageListState;
 }
 
 export type ModuleState = LibraryModuleState;
@@ -54,5 +60,6 @@ export const reducers: ActionReducerMap<LibraryModuleState> = {
   router: routerReducer,
   [DISPLAY_FEATURE_KEY]: displayReducer,
   [COMIC_IMPORT_FEATURE_KEY]: libraryImportReducer,
-  [LIBRARY_FEATURE_KEY]: libraryReducer
+  [LIBRARY_FEATURE_KEY]: libraryReducer,
+  [DUPLICATE_PAGE_LIST_FEATURE_KEY]: comicsWithDuplicatePagesReducer
 };

--- a/comixed-web/src/app/library/library.constants.ts
+++ b/comixed-web/src/app/library/library.constants.ts
@@ -45,6 +45,8 @@ export const SCRAPE_COMIC_URL = `${API_ROOT_URL}/scraping/comics/\${comicId}`;
 
 export const SET_READ_STATE_URL = `${API_ROOT_URL}/library/read`;
 
+export const LOAD_COMICS_WITH_DUPLICATE_PAGES_URL = `${API_ROOT_URL}/library/pages/duplicates`;
+
 // import options
 export const IMPORT_ROOT_DIRECTORY_PREFERENCE =
   'preference.import.root-directory';
@@ -70,3 +72,4 @@ export const PAGINATION_DEFAULT = PAGINATION_OPTIONS[0];
 
 // messaging
 export const COMIC_LIST_UPDATE_TOPIC = '/topic/comic-list.update';
+export const DUPLICATE_PAGE_LIST_TOPIC = '/topic/duplicate-page-list.update';

--- a/comixed-web/src/app/library/library.fixtures.ts
+++ b/comixed-web/src/app/library/library.fixtures.ts
@@ -15,3 +15,31 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses>
  */
+
+import { DuplicatePage } from './models/duplicate-page';
+import {
+  COMIC_1,
+  COMIC_2,
+  COMIC_3,
+  PAGE_1,
+  PAGE_2,
+  PAGE_3
+} from '../comic-book/comic-book.fixtures';
+
+export const DUPLICATE_PAGE_1: DuplicatePage = {
+  hash: PAGE_1.hash,
+  blocked: false,
+  comics: [COMIC_1]
+};
+
+export const DUPLICATE_PAGE_2: DuplicatePage = {
+  hash: PAGE_2.hash,
+  blocked: false,
+  comics: [COMIC_2]
+};
+
+export const DUPLICATE_PAGE_3: DuplicatePage = {
+  hash: PAGE_3.hash,
+  blocked: false,
+  comics: [COMIC_3]
+};

--- a/comixed-web/src/app/library/library.module.ts
+++ b/comixed-web/src/app/library/library.module.ts
@@ -66,6 +66,13 @@ import { ScrapingPageComponent } from '@app/library/pages/scraping-page/scraping
 import { ComicBookModule } from '@app/comic-book/comic-book.module';
 import { ArchiveTypePipe } from './pipes/archive-type.pipe';
 import { UnreadComicsPipe } from './pipes/unread-comics.pipe';
+import {
+  DUPLICATE_PAGE_LIST_FEATURE_KEY,
+  reducer as comicsWithDuplicatePagesReducer
+} from '@app/library/reducers/duplicate-page-list.reducer';
+import { DuplicatePageListEffects } from '@app/library/effects/duplicate-page-list.effects';
+import { DuplicatePageListPageComponent } from './pages/duplicate-page-list-page/duplicate-page-list-page.component';
+import { ComicsWithDuplicatePageComponent } from './components/comics-with-duplicate-page/comics-with-duplicate-page.component';
 
 @NgModule({
   declarations: [
@@ -78,7 +85,9 @@ import { UnreadComicsPipe } from './pipes/unread-comics.pipe';
     ScrapingPageComponent,
     ComicCoversComponent,
     ArchiveTypePipe,
-    UnreadComicsPipe
+    UnreadComicsPipe,
+    DuplicatePageListPageComponent,
+    ComicsWithDuplicatePageComponent
   ],
   providers: [],
   imports: [
@@ -90,7 +99,15 @@ import { UnreadComicsPipe } from './pipes/unread-comics.pipe';
     TranslateModule.forRoot(),
     StoreModule.forFeature(DISPLAY_FEATURE_KEY, displayReducer),
     StoreModule.forFeature(LIBRARY_FEATURE_KEY, libraryReducer),
-    EffectsModule.forFeature([DisplayEffects, LibraryEffects]),
+    StoreModule.forFeature(
+      DUPLICATE_PAGE_LIST_FEATURE_KEY,
+      comicsWithDuplicatePagesReducer
+    ),
+    EffectsModule.forFeature([
+      DisplayEffects,
+      LibraryEffects,
+      DuplicatePageListEffects
+    ]),
     MatInputModule,
     MatSelectModule,
     MatButtonModule,

--- a/comixed-web/src/app/library/library.routing.ts
+++ b/comixed-web/src/app/library/library.routing.ts
@@ -21,6 +21,7 @@ import { NgModule } from '@angular/core';
 import { AdminGuard, ReaderGuard } from '@app/user';
 import { LibraryPageComponent } from '@app/library/pages/library-page/library-page.component';
 import { ScrapingPageComponent } from '@app/library/pages/scraping-page/scraping-page.component';
+import { DuplicatePageListPageComponent } from '@app/library/pages/duplicate-page-list-page/duplicate-page-list-page.component';
 
 const routes: Routes = [
   {
@@ -49,6 +50,11 @@ const routes: Routes = [
   {
     path: 'library/scrape',
     component: ScrapingPageComponent,
+    canActivate: [AdminGuard]
+  },
+  {
+    path: 'library/pages/duplicates',
+    component: DuplicatePageListPageComponent,
     canActivate: [AdminGuard]
   }
 ];

--- a/comixed-web/src/app/library/models/duplicate-page.ts
+++ b/comixed-web/src/app/library/models/duplicate-page.ts
@@ -1,0 +1,25 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { Comic } from '../../comic-book/models/comic';
+
+export interface DuplicatePage {
+  hash: string;
+  blocked: boolean;
+  comics: Comic[];
+}

--- a/comixed-web/src/app/library/pages/duplicate-page-list-page/duplicate-page-list-page.component.html
+++ b/comixed-web/src/app/library/pages/duplicate-page-list-page/duplicate-page-list-page.component.html
@@ -1,0 +1,120 @@
+<mat-toolbar class="cx-primary-light-background">
+  <mat-paginator
+    class="cx-primary-light-background cx-height-100"
+    [pageSizeOptions]="[5, 10, 20]"
+    showFirstLastButtons
+  ></mat-paginator>
+  <div class="cx-spacer"></div>
+  <button
+    id="block-selections-button"
+    mat-icon-button
+    color="warn"
+    [disabled]="!anySelected"
+    [matTooltip]="'duplicate-pages.tooltip.block-selections' | translate"
+    (click)="onBlockSelected()"
+  >
+    <mat-icon>thumb_down</mat-icon>
+  </button>
+  <button
+    id="unblock-selections-button"
+    mat-icon-button
+    color="warn"
+    [disabled]="!anySelected"
+    [matTooltip]="'duplicate-pages.tooltip.unblock-selections' | translate"
+    (click)="onUnblockSelected()"
+  >
+    <mat-icon>thumb_up</mat-icon>
+  </button>
+</mat-toolbar>
+
+<mat-table [dataSource]="dataSource" matSort>
+  <ng-container matColumnDef="selection">
+    <mat-header-cell mat-sort-header *matHeaderCellDef>
+      <mat-checkbox
+        [checked]="allSelected"
+        (change)="onSelectAll($event.checked)"
+        (click)="$event.stopPropagation()"
+      ></mat-checkbox>
+    </mat-header-cell>
+    <mat-cell *matCellDef="let row">
+      <mat-checkbox
+        [checked]="row.selected"
+        (change)="onSelectOne(row, $event.checked)"
+        (click)="$event.stopPropagation()"
+      ></mat-checkbox>
+    </mat-cell>
+  </ng-container>
+
+  <ng-container matColumnDef="hash">
+    <mat-header-cell mat-sort-header mat-sort-header *matHeaderCellDef>
+      {{ "duplicate-pages.header.hash" | translate }}
+    </mat-header-cell>
+    <mat-cell *matCellDef="let row">
+      <span class="cx-text-nowrap">{{ row.item.hash }}</span>
+    </mat-cell>
+  </ng-container>
+
+  <ng-container matColumnDef="thumbnail">
+    <mat-header-cell *matHeaderCellDef>
+      {{ "duplicate-pages.header.thumbnail" | translate }}
+    </mat-header-cell>
+    <mat-cell *matCellDef="let row">
+      <div class="cx-text-nowrap cx-table-thumbnail cx-width-100">
+        <img
+          [src]="row.item.hash | pageHashUrl"
+          alt="thumbnail"
+          width="100%"
+          height="auto"
+          (click)="onShowComicsWithPage(row)"
+        />
+      </div>
+    </mat-cell>
+  </ng-container>
+
+  <ng-container matColumnDef="comic-count">
+    <mat-header-cell mat-sort-header *matHeaderCellDef>
+      {{ "duplicate-pages.header.comic-count" | translate }}
+    </mat-header-cell>
+    <mat-cell *matCellDef="let row">
+      <span class="cx-text-nowrap">{{ row.item.comics.length }}</span>
+    </mat-cell>
+  </ng-container>
+
+  <ng-container matColumnDef="blocked">
+    <mat-header-cell mat-sort-header *matHeaderCellDef>
+      {{ "duplicate-pages.header.blocked" | translate }}
+    </mat-header-cell>
+    <mat-cell *matCellDef="let row">
+      <span class="cx-text-nowrap">
+        {{ row.item.blocked | yesNo | translate }}
+      </span>
+    </mat-cell>
+  </ng-container>
+
+  <ng-container matColumnDef="actions">
+    <mat-header-cell *matHeaderCellDef></mat-header-cell>
+    <mat-cell *matCellDef="let row">
+      <button
+        *ngIf="!row.item.blocked"
+        mat-icon-button
+        color="warn"
+        [matTooltip]="'duplicate-pages.tooltip.block-page' | translate"
+        (click)="onBlockPage(row)"
+      >
+        <mat-icon>thumb_down</mat-icon>
+      </button>
+      <button
+        *ngIf="row.item.blocked"
+        mat-icon-button
+        color="primary"
+        [matTooltip]="'duplicate-pages.tooltip.unblock-page' | translate"
+        (click)="onUnblockPage(row)"
+      >
+        <mat-icon>thumb_up</mat-icon>
+      </button>
+    </mat-cell>
+  </ng-container>
+
+  <mat-header-row *matHeaderRowDef="displayColumns"></mat-header-row>
+  <mat-row *matRowDef="let row; columns: displayColumns"></mat-row>
+</mat-table>

--- a/comixed-web/src/app/library/pages/duplicate-page-list-page/duplicate-page-list-page.component.scss
+++ b/comixed-web/src/app/library/pages/duplicate-page-list-page/duplicate-page-list-page.component.scss
@@ -1,0 +1,34 @@
+@import '~styles';
+
+.mat-column-selection {
+  width: $cx-column-small;
+  max-width: $cx-column-small;
+  resize: none;
+}
+
+.mat-column-thumbnail {
+  width: $cx-column-medium;
+  max-width: $cx-column-medium;
+  resize: none;
+}
+
+.mat-column-hash {
+}
+
+.mat-column-comic-count {
+  width: $cx-column-medium;
+  max-width: $cx-column-medium;
+  resize: none;
+}
+
+.mat-column-blocked {
+  width: $cx-column-medium;
+  max-width: $cx-column-medium;
+  resize: none;
+}
+
+.mat-column-actions {
+  width: $cx-column-small;
+  max-width: $cx-column-small;
+  resize: none;
+}

--- a/comixed-web/src/app/library/pages/duplicate-page-list-page/duplicate-page-list-page.component.spec.ts
+++ b/comixed-web/src/app/library/pages/duplicate-page-list-page/duplicate-page-list-page.component.spec.ts
@@ -1,0 +1,414 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { DuplicatePageListPageComponent } from './duplicate-page-list-page.component';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { LoggerModule } from '@angular-ru/logger';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import {
+  DUPLICATE_PAGE_LIST_FEATURE_KEY,
+  initialState as initialDuplicatePageListState
+} from '@app/library/reducers/duplicate-page-list.reducer';
+import {
+  initialState as initialMessagingState,
+  MESSAGING_FEATURE_KEY
+} from '@app/messaging/reducers/messaging.reducer';
+import { WebSocketService } from '@app/messaging';
+import { Subscription } from 'webstomp-client';
+import {
+  DUPLICATE_PAGE_1,
+  DUPLICATE_PAGE_2,
+  DUPLICATE_PAGE_3
+} from '@app/library/library.fixtures';
+import { DUPLICATE_PAGE_LIST_TOPIC } from '@app/library/library.constants';
+import { duplicatePagesLoaded } from '@app/library/actions/duplicate-page-list.actions';
+import { TitleService } from '@app/core/services/title.service';
+import { SelectableListItem } from '@app/core/models/ui/selectable-list-item';
+import { DuplicatePage } from '@app/library/models/duplicate-page';
+import { ComicsWithDuplicatePageComponent } from '@app/library/components/comics-with-duplicate-page/comics-with-duplicate-page.component';
+import { setBlockedState } from '@app/blocked-pages/actions/block-page.actions';
+import { ConfirmationService } from '@app/core/services/confirmation.service';
+import { Confirmation } from '@app/core/models/confirmation';
+
+describe('DuplicatePageListPageComponent', () => {
+  const DUPLICATE_PAGES = [
+    DUPLICATE_PAGE_1,
+    DUPLICATE_PAGE_2,
+    DUPLICATE_PAGE_3
+  ];
+  const initialState = {
+    [DUPLICATE_PAGE_LIST_FEATURE_KEY]: initialDuplicatePageListState,
+    [MESSAGING_FEATURE_KEY]: initialMessagingState
+  };
+
+  let component: DuplicatePageListPageComponent;
+  let fixture: ComponentFixture<DuplicatePageListPageComponent>;
+  let store: MockStore<any>;
+  let webSocketService: jasmine.SpyObj<WebSocketService>;
+  let titleService: TitleService;
+  let setTitleSpy: jasmine.Spy<any>;
+  let translateService: TranslateService;
+  let dialog: MatDialog;
+  let confirmationService: ConfirmationService;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [DuplicatePageListPageComponent],
+      imports: [
+        LoggerModule.forRoot(),
+        TranslateModule.forRoot(),
+        MatDialogModule
+      ],
+      providers: [
+        provideMockStore({ initialState }),
+        {
+          provide: WebSocketService,
+          useValue: {
+            subscribe: jasmine.createSpy('WebSocketService.subscribe()'),
+            send: jasmine.createSpy('WebSocketService.send()'),
+            requestResponse: jasmine.createSpy(
+              'WebSocketService.requestResponse()'
+            )
+          }
+        },
+        ConfirmationService
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DuplicatePageListPageComponent);
+    component = fixture.componentInstance;
+    store = TestBed.inject(MockStore);
+    spyOn(store, 'dispatch');
+    webSocketService = TestBed.inject(
+      WebSocketService
+    ) as jasmine.SpyObj<WebSocketService>;
+    titleService = TestBed.inject(TitleService);
+    setTitleSpy = spyOn(titleService, 'setTitle');
+    translateService = TestBed.inject(TranslateService);
+    dialog = TestBed.inject(MatDialog);
+    spyOn(dialog, 'open');
+    confirmationService = TestBed.inject(ConfirmationService);
+    component.pageUpdatesSubscription = null;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('when duplicate page updates are subscribed', () => {
+    let subscription: any;
+
+    beforeEach(() => {
+      subscription = jasmine.createSpyObj(['unsubscribe']);
+      component.pageUpdatesSubscription = subscription;
+      component.ngOnDestroy();
+    });
+
+    it('unsubscribes from duplicate page updates', () => {
+      expect(subscription.unsubscribe).toHaveBeenCalled();
+    });
+
+    it('clears the reference', () => {
+      expect(component.pageUpdatesSubscription).toBeNull();
+    });
+  });
+
+  it('loads the page title', () => {
+    expect(titleService.setTitle).toHaveBeenCalledWith(jasmine.any(String));
+  });
+
+  describe('when the language changes', () => {
+    beforeEach(() => {
+      translateService.use('fr');
+    });
+
+    it('reloads the page title', () => {
+      expect(titleService.setTitle).toHaveBeenCalledWith(jasmine.any(String));
+    });
+  });
+
+  describe('when messaging starts', () => {
+    beforeEach(() => {
+      component.pageUpdatesSubscription = null;
+      webSocketService.subscribe
+        .withArgs(DUPLICATE_PAGE_LIST_TOPIC, jasmine.anything())
+        .and.callFake((topic, callback) => {
+          callback(DUPLICATE_PAGES);
+          return {} as Subscription;
+        });
+      store.setState({
+        ...initialState,
+        [MESSAGING_FEATURE_KEY]: { ...initialMessagingState, started: true }
+      });
+    });
+
+    it('subscribes to duplicate page list updates', () => {
+      expect(webSocketService.subscribe).toHaveBeenCalledWith(
+        DUPLICATE_PAGE_LIST_TOPIC,
+        jasmine.anything()
+      );
+    });
+
+    it('processes duplicate page list updates', () => {
+      expect(store.dispatch).toHaveBeenCalledWith(
+        duplicatePagesLoaded({ pages: DUPLICATE_PAGES })
+      );
+    });
+  });
+
+  describe('loading duplicate pages', () => {
+    beforeEach(() => {
+      component.dataSource.data = [
+        { selected: true, item: DUPLICATE_PAGES[0] }
+      ];
+      component.duplicatePages = DUPLICATE_PAGES;
+    });
+
+    it('maintains existing selectsion', () => {
+      expect(component.dataSource.data[0].selected).toBeTrue();
+    });
+  });
+
+  describe('sorting data', () => {
+    const ENTRY = {
+      item: DUPLICATE_PAGES[0],
+      selected: Math.random() > 0.5
+    } as SelectableListItem<DuplicatePage>;
+
+    it('sorts by selection status', () => {
+      expect(
+        component.dataSource.sortingDataAccessor(ENTRY, 'selection')
+      ).toEqual(`${ENTRY.selected}`);
+    });
+
+    it('sorts by hash', () => {
+      expect(component.dataSource.sortingDataAccessor(ENTRY, 'hash')).toEqual(
+        ENTRY.item.hash
+      );
+    });
+
+    it('sorts by comic count', () => {
+      expect(
+        component.dataSource.sortingDataAccessor(ENTRY, 'comic-count')
+      ).toEqual(ENTRY.item.comics.length);
+    });
+
+    it('sorts by blocked state', () => {
+      expect(
+        component.dataSource.sortingDataAccessor(ENTRY, 'blocked')
+      ).toEqual(`${ENTRY.item.blocked}`);
+    });
+  });
+
+  describe('showing comics for a duplicate page', () => {
+    const ENTRY = {
+      item: DUPLICATE_PAGES[0],
+      selected: Math.random() > 0.5
+    } as SelectableListItem<DuplicatePage>;
+
+    beforeEach(() => {
+      component.onShowComicsWithPage(ENTRY);
+    });
+
+    it('opens a dialog', () => {
+      expect(dialog.open).toHaveBeenCalledWith(
+        ComicsWithDuplicatePageComponent,
+        { data: ENTRY.item }
+      );
+    });
+  });
+
+  describe('blocking a duplicate page', () => {
+    const ENTRY = {
+      item: DUPLICATE_PAGES[0],
+      selected: Math.random() > 0.5
+    } as SelectableListItem<DuplicatePage>;
+
+    beforeEach(() => {
+      spyOn(confirmationService, 'confirm').and.callFake(
+        (confirmation: Confirmation) => confirmation.confirm()
+      );
+      component.onBlockPage(ENTRY);
+    });
+
+    it('confirms with the user', () => {
+      expect(confirmationService.confirm).toHaveBeenCalled();
+    });
+
+    it('fires an action', () => {
+      expect(store.dispatch).toHaveBeenCalledWith(
+        setBlockedState({ hash: ENTRY.item.hash, blocked: true })
+      );
+    });
+  });
+
+  describe('unblocking a duplicate page', () => {
+    const ENTRY = {
+      item: DUPLICATE_PAGES[0],
+      selected: Math.random() > 0.5
+    } as SelectableListItem<DuplicatePage>;
+
+    beforeEach(() => {
+      spyOn(confirmationService, 'confirm').and.callFake(
+        (confirmation: Confirmation) => confirmation.confirm()
+      );
+      component.onUnblockPage(ENTRY);
+    });
+
+    it('confirms with the user', () => {
+      expect(confirmationService.confirm).toHaveBeenCalled();
+    });
+
+    it('fires an action', () => {
+      expect(store.dispatch).toHaveBeenCalledWith(
+        setBlockedState({ hash: ENTRY.item.hash, blocked: false })
+      );
+    });
+  });
+
+  describe('selections', () => {
+    beforeEach(() => {
+      component.duplicatePages = DUPLICATE_PAGES;
+    });
+
+    describe('selecting an element', () => {
+      beforeEach(() => {
+        component.anySelected = false;
+        component.dataSource.data[0].selected = false;
+        component.onSelectOne(component.dataSource.data[0], true);
+      });
+
+      it('sets the selection state', () => {
+        expect(component.dataSource.data[0].selected).toBeTrue();
+      });
+
+      it('sets the any selected flag', () => {
+        expect(component.anySelected).toBeTrue();
+      });
+    });
+
+    describe('deselecting an element', () => {
+      beforeEach(() => {
+        component.anySelected = true;
+        component.dataSource.data[0].selected = true;
+        component.onSelectOne(component.dataSource.data[0], false);
+      });
+
+      it('clears the selection state', () => {
+        expect(component.dataSource.data[0].selected).toBeFalse();
+      });
+
+      it('clears the any selected flag', () => {
+        expect(component.anySelected).toBeFalse();
+      });
+    });
+
+    describe('selecting all elements', () => {
+      beforeEach(() => {
+        component.anySelected = false;
+        component.anySelected = false;
+        component.dataSource.data.forEach(entry => (entry.selected = false));
+        component.onSelectAll(true);
+      });
+
+      it('marks all as selected', () => {
+        expect(
+          component.dataSource.data.every(entry => entry.selected)
+        ).toBeTrue();
+      });
+
+      it('sets the any selected flag', () => {
+        expect(component.anySelected).toBeTrue();
+      });
+
+      it('sets the any selected flag', () => {
+        expect(component.allSelected).toBeTrue();
+      });
+
+      describe('deselecting one item', () => {
+        beforeEach(() => {
+          component.onSelectOne(component.dataSource.data[0], false);
+        });
+
+        it('marks the element as unselected', () => {
+          expect(component.dataSource.data[0].selected).toBeFalse();
+        });
+
+        it('clears the any selected flag', () => {
+          expect(component.allSelected).toBeFalse();
+        });
+      });
+    });
+
+    describe('deselecting all elements', () => {
+      beforeEach(() => {
+        component.anySelected = true;
+        component.anySelected = true;
+        component.dataSource.data.forEach(entry => (entry.selected = true));
+        component.onSelectAll(false);
+      });
+
+      it('unmarks all as selected', () => {
+        expect(
+          component.dataSource.data.every(entry => entry.selected)
+        ).toBeFalse();
+      });
+
+      it('clears the any selected flag', () => {
+        expect(component.anySelected).toBeFalse();
+      });
+
+      it('clears the any selected flag', () => {
+        expect(component.allSelected).toBeFalse();
+      });
+    });
+  });
+
+  describe('processing all selected items', () => {
+    beforeEach(() => {
+      component.duplicatePages = DUPLICATE_PAGES;
+      component.dataSource.data[0].selected = true;
+      spyOn(confirmationService, 'confirm').and.callFake(
+        (confirmation: Confirmation) => confirmation.confirm()
+      );
+    });
+
+    describe('blocking selected items', () => {
+      beforeEach(() => {
+        component.onBlockSelected();
+      });
+
+      it('confirms with the user', () => {
+        expect(confirmationService.confirm).toHaveBeenCalled();
+      });
+    });
+
+    describe('unblocking selected items', () => {
+      beforeEach(() => {
+        component.onUnblockSelected();
+      });
+
+      it('confirms with the user', () => {
+        expect(confirmationService.confirm).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/comixed-web/src/app/library/pages/duplicate-page-list-page/duplicate-page-list-page.component.ts
+++ b/comixed-web/src/app/library/pages/duplicate-page-list-page/duplicate-page-list-page.component.ts
@@ -1,0 +1,276 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import {
+  AfterViewInit,
+  Component,
+  OnDestroy,
+  OnInit,
+  ViewChild
+} from '@angular/core';
+import { Subscription } from 'rxjs';
+import { LoggerService } from '@angular-ru/logger';
+import { Store } from '@ngrx/store';
+import { TitleService } from '@app/core/services/title.service';
+import { TranslateService } from '@ngx-translate/core';
+import {
+  selectDuplicatePageList,
+  selectDuplicatePageListState
+} from '@app/library/selectors/duplicate-page-list.selectors';
+import { setBusyState } from '@app/core/actions/busy.actions';
+import {
+  duplicatePagesLoaded,
+  loadDuplicatePages
+} from '@app/library/actions/duplicate-page-list.actions';
+import { DuplicatePage } from '@app/library/models/duplicate-page';
+import { MatTableDataSource } from '@angular/material/table';
+import { SelectableListItem } from '@app/core/models/ui/selectable-list-item';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatDialog } from '@angular/material/dialog';
+import { ComicsWithDuplicatePageComponent } from '@app/library/components/comics-with-duplicate-page/comics-with-duplicate-page.component';
+import { MatSort } from '@angular/material/sort';
+import { ConfirmationService } from '@app/core/services/confirmation.service';
+import { setBlockedState } from '@app/blocked-pages/actions/block-page.actions';
+import { MessagingSubscription, WebSocketService } from '@app/messaging';
+import { DUPLICATE_PAGE_LIST_TOPIC } from '@app/library/library.constants';
+import { selectMessagingState } from '@app/messaging/selectors/messaging.selectors';
+
+@Component({
+  selector: 'cx-duplicate-page-list-page',
+  templateUrl: './duplicate-page-list-page.component.html',
+  styleUrls: ['./duplicate-page-list-page.component.scss']
+})
+export class DuplicatePageListPageComponent
+  implements OnInit, OnDestroy, AfterViewInit
+{
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+  @ViewChild(MatSort) sort: MatSort;
+
+  dataSource = new MatTableDataSource<SelectableListItem<DuplicatePage>>([]);
+  langChangeSubscription: Subscription;
+  duplicatePageSubscription: Subscription;
+  duplicatePageStateSubscription: Subscription;
+  messagingStateSubscription: Subscription;
+  pageUpdatesSubscription: MessagingSubscription;
+  allSelected = false;
+  anySelected = false;
+
+  readonly displayColumns = [
+    'selection',
+    'thumbnail',
+    'hash',
+    'comic-count',
+    'blocked',
+    'actions'
+  ];
+
+  constructor(
+    private logger: LoggerService,
+    private store: Store<any>,
+    private titleService: TitleService,
+    private translateService: TranslateService,
+    private dialog: MatDialog,
+    private confirmationService: ConfirmationService,
+    private webSocketService: WebSocketService
+  ) {
+    this.logger.trace('Subscribing to duplicate page list changes');
+    this.duplicatePageSubscription = this.store
+      .select(selectDuplicatePageList)
+      .subscribe(pages => (this.duplicatePages = pages));
+    this.logger.trace('Subscribing to duplicate page state changes');
+    this.duplicatePageStateSubscription = this.store
+      .select(selectDuplicatePageListState)
+      .subscribe(state => {
+        this.store.dispatch(setBusyState({ enabled: state.loading }));
+      });
+    this.logger.trace('Subscribing to language changes');
+    this.langChangeSubscription = this.translateService.onLangChange.subscribe(
+      () => this.loadTranslations()
+    );
+    this.messagingStateSubscription = this.store
+      .select(selectMessagingState)
+      .subscribe(state => {
+        if (state.started && !this.pageUpdatesSubscription) {
+          this.logger.trace('Subscribing to duplicate page list updates');
+          this.pageUpdatesSubscription = this.webSocketService.subscribe(
+            DUPLICATE_PAGE_LIST_TOPIC,
+            (pages: DuplicatePage[]) => {
+              this.logger.trace('Duplicate page update received:', pages);
+              this.store.dispatch(duplicatePagesLoaded({ pages }));
+            }
+          );
+        }
+      });
+  }
+
+  set duplicatePages(pages: DuplicatePage[]) {
+    this.logger.trace('Loading duplicate pages');
+    const oldData = this.dataSource.data;
+    this.dataSource.data = pages.map(page => {
+      const existingPage = oldData.find(
+        oldPage => oldPage.item.hash === page.hash
+      );
+
+      return {
+        item: page,
+        selected: existingPage?.selected || false
+      };
+    });
+  }
+
+  ngOnInit(): void {
+    this.store.dispatch(loadDuplicatePages());
+  }
+
+  ngAfterViewInit(): void {
+    this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
+    this.dataSource.sortingDataAccessor = (data, sortHeaderId) => {
+      switch (sortHeaderId) {
+        case 'selection':
+          return `${data.selected}`;
+        case 'hash':
+          return data.item.hash;
+        case 'comic-count':
+          return data.item.comics.length;
+        case 'blocked':
+          return `${data.item.blocked}`;
+      }
+    };
+    this.loadTranslations();
+  }
+
+  ngOnDestroy(): void {
+    this.duplicatePageSubscription.unsubscribe();
+    this.duplicatePageStateSubscription.unsubscribe();
+    this.langChangeSubscription.unsubscribe();
+    this.pageUpdatesSubscription.unsubscribe();
+    if (!!this.pageUpdatesSubscription) {
+      this.logger.trace('Unsubscribing from duplicate page list updates');
+      this.pageUpdatesSubscription.unsubscribe();
+      this.pageUpdatesSubscription = null;
+    }
+  }
+
+  onShowComicsWithPage(row: SelectableListItem<DuplicatePage>): void {
+    this.logger.trace('Displaying dialog of affected comics');
+    this.dialog.open(ComicsWithDuplicatePageComponent, { data: row.item });
+  }
+
+  onBlockPage(row: SelectableListItem<DuplicatePage>): void {
+    const hash = row.item.hash;
+    this.logger.trace('Prompting to block page:', hash);
+    this.confirmationService.confirm({
+      title: this.translateService.instant(
+        'blocked-page.add-page-hash.confirmation-title'
+      ),
+      message: this.translateService.instant(
+        'blocked-page.add-page-hash.confirmation-message',
+        { hash }
+      ),
+      confirm: () => {
+        this.logger.trace('Blocking all pages with hash:', hash);
+        this.store.dispatch(setBlockedState({ hash, blocked: true }));
+      }
+    });
+  }
+
+  onUnblockPage(row: SelectableListItem<DuplicatePage>): void {
+    const hash = row.item.hash;
+    this.logger.trace('Prompting to unblock page hash:', hash);
+    this.confirmationService.confirm({
+      title: this.translateService.instant(
+        'blocked-page.remove-page-hash.confirmation-title'
+      ),
+      message: this.translateService.instant(
+        'blocked-page.remove-page-hash.confirmation-message',
+        { hash }
+      ),
+      confirm: () => {
+        this.logger.trace('Unblocking all pages with hash:', hash);
+        this.store.dispatch(setBlockedState({ hash, blocked: false }));
+      }
+    });
+  }
+
+  onSelectAll(checked: boolean): void {
+    this.logger.trace('Selecting all duplicate pages');
+    this.dataSource.data.forEach(entry => (entry.selected = checked));
+    this.updateSelectionState();
+  }
+
+  onSelectOne(row: SelectableListItem<DuplicatePage>, checked: boolean): void {
+    this.logger.trace('Toggling selected state for row:', row, checked);
+    row.selected = checked;
+    this.updateSelectionState();
+  }
+
+  onBlockSelected(): void {
+    this.logger.trace('Confirming blocking selected items');
+    const selection = this.dataSource.data
+      .filter(entry => entry.selected)
+      .map(entry => entry.item);
+    this.confirmationService.confirm({
+      title: this.translateService.instant(
+        'duplicate-pages.block-selection.confirmation-title'
+      ),
+      message: this.translateService.instant(
+        'duplicate-pages.block-selection.confirmation-message',
+        { count: selection.length }
+      ),
+      confirm: () => {
+        this.logger.trace('Blocking selected page hashes');
+        // TODO block selected pages
+      }
+    });
+  }
+
+  onUnblockSelected(): void {
+    this.logger.trace('Confirming unblocking selected items');
+    const selection = this.dataSource.data
+      .filter(entry => entry.selected)
+      .map(entry => entry.item);
+    this.confirmationService.confirm({
+      title: this.translateService.instant(
+        'duplicate-pages.unblock-selection.confirmation-title'
+      ),
+      message: this.translateService.instant(
+        'duplicate-pages.unblock-selection.confirmation-message',
+        { count: selection.length }
+      ),
+      confirm: () => {
+        this.logger.trace('Unblocking selected page hashes');
+        // TODO block selected pages
+      }
+    });
+  }
+
+  private loadTranslations(): void {
+    this.titleService.setTitle(
+      this.translateService.instant('duplicate-pages.list-page.tab-title')
+    );
+  }
+
+  private updateSelectionState(): void {
+    this.allSelected =
+      this.dataSource.data.length > 0 &&
+      this.dataSource.data.every(entry => entry.selected);
+    this.anySelected =
+      this.allSelected || this.dataSource.data.some(entry => entry.selected);
+  }
+}

--- a/comixed-web/src/app/library/reducers/duplicate-page-list.reducer.spec.ts
+++ b/comixed-web/src/app/library/reducers/duplicate-page-list.reducer.spec.ts
@@ -1,0 +1,112 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import {
+  DuplicatePageListState,
+  initialState,
+  reducer
+} from './duplicate-page-list.reducer';
+import {
+  duplicatePagesLoaded,
+  loadDuplicatePages,
+  loadDuplicatePagesFailed,
+  resetDuplicatePages
+} from '@app/library/actions/duplicate-page-list.actions';
+import {
+  DUPLICATE_PAGE_1,
+  DUPLICATE_PAGE_2,
+  DUPLICATE_PAGE_3
+} from '@app/library/library.fixtures';
+
+describe('DuplicatePageList Reducer', () => {
+  const PAGES = [DUPLICATE_PAGE_1, DUPLICATE_PAGE_2, DUPLICATE_PAGE_3];
+
+  let state: DuplicatePageListState;
+
+  beforeEach(() => {
+    state = { ...initialState };
+  });
+
+  describe('the initial state', () => {
+    beforeEach(() => {
+      state = reducer({ ...state }, {} as any);
+    });
+
+    it('clears the loading flag', () => {
+      expect(state.loading).toBeFalse();
+    });
+
+    it('has no pages', () => {
+      expect(state.pages).toEqual([]);
+    });
+  });
+
+  describe('resetting the feature state', () => {
+    beforeEach(() => {
+      state = reducer(
+        { ...state, loading: true, pages: PAGES },
+        resetDuplicatePages()
+      );
+    });
+
+    it('clears the loading flag', () => {
+      expect(state.loading).toBeFalse();
+    });
+
+    it('clears the pages', () => {
+      expect(state.pages).toEqual([]);
+    });
+  });
+
+  describe('loading the pages', () => {
+    beforeEach(() => {
+      state = reducer({ ...state, loading: false }, loadDuplicatePages());
+    });
+
+    it('sets the loading flag', () => {
+      expect(state.loading).toBeTruthy();
+    });
+  });
+
+  describe('success loading the pages', () => {
+    beforeEach(() => {
+      state = reducer(
+        { ...state, loading: true, pages: [] },
+        duplicatePagesLoaded({ pages: PAGES })
+      );
+    });
+
+    it('clears the loading flag', () => {
+      expect(state.loading).toBeFalse();
+    });
+
+    it('loads the pages', () => {
+      expect(state.pages).toEqual(PAGES);
+    });
+  });
+
+  describe('failure loading the pages', () => {
+    beforeEach(() => {
+      state = reducer({ ...state, loading: true }, loadDuplicatePagesFailed());
+    });
+
+    it('clears the loading flag', () => {
+      expect(state.loading).toBeFalse();
+    });
+  });
+});

--- a/comixed-web/src/app/library/reducers/duplicate-page-list.reducer.ts
+++ b/comixed-web/src/app/library/reducers/duplicate-page-list.reducer.ts
@@ -1,0 +1,58 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { createReducer, on } from '@ngrx/store';
+import {
+  duplicatePagesLoaded,
+  loadDuplicatePages,
+  loadDuplicatePagesFailed,
+  resetDuplicatePages
+} from '@app/library/actions/duplicate-page-list.actions';
+import { DuplicatePage } from '@app/library/models/duplicate-page';
+
+export const DUPLICATE_PAGE_LIST_FEATURE_KEY = 'duplicate_page_list_state';
+
+export interface DuplicatePageListState {
+  loading: boolean;
+  pages: DuplicatePage[];
+}
+
+export const initialState: DuplicatePageListState = {
+  loading: false,
+  pages: []
+};
+
+export const reducer = createReducer(
+  initialState,
+
+  on(resetDuplicatePages, state => ({
+    ...state,
+    loading: false,
+    pages: []
+  })),
+  on(loadDuplicatePages, state => ({ ...state, loading: true })),
+  on(duplicatePagesLoaded, (state, action) => ({
+    ...state,
+    loading: false,
+    pages: action.pages
+  })),
+  on(loadDuplicatePagesFailed, state => ({
+    ...state,
+    loading: false
+  }))
+);

--- a/comixed-web/src/app/library/selectors/duplicate-page-list.selectors.spec.ts
+++ b/comixed-web/src/app/library/selectors/duplicate-page-list.selectors.spec.ts
@@ -1,0 +1,57 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import {
+  DUPLICATE_PAGE_LIST_FEATURE_KEY,
+  DuplicatePageListState
+} from '../reducers/duplicate-page-list.reducer';
+import {
+  selectDuplicatePageList,
+  selectDuplicatePageListState
+} from './duplicate-page-list.selectors';
+import {
+  DUPLICATE_PAGE_1,
+  DUPLICATE_PAGE_2,
+  DUPLICATE_PAGE_3
+} from '@app/library/library.fixtures';
+
+describe('DuplicatePageList Selectors', () => {
+  const PAGES = [DUPLICATE_PAGE_1, DUPLICATE_PAGE_2, DUPLICATE_PAGE_3];
+
+  let state: DuplicatePageListState;
+
+  beforeEach(() => {
+    state = { loading: Math.random() > 0.5, pages: PAGES };
+  });
+
+  it('should select the feature state', () => {
+    expect(
+      selectDuplicatePageListState({
+        [DUPLICATE_PAGE_LIST_FEATURE_KEY]: state
+      })
+    ).toEqual(state);
+  });
+
+  it('should select the page list', () => {
+    expect(
+      selectDuplicatePageList({
+        [DUPLICATE_PAGE_LIST_FEATURE_KEY]: state
+      })
+    ).toEqual(state.pages);
+  });
+});

--- a/comixed-web/src/app/library/selectors/duplicate-page-list.selectors.ts
+++ b/comixed-web/src/app/library/selectors/duplicate-page-list.selectors.ts
@@ -1,0 +1,33 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import {
+  DUPLICATE_PAGE_LIST_FEATURE_KEY,
+  DuplicatePageListState
+} from '../reducers/duplicate-page-list.reducer';
+
+export const selectDuplicatePageListState =
+  createFeatureSelector<DuplicatePageListState>(
+    DUPLICATE_PAGE_LIST_FEATURE_KEY
+  );
+
+export const selectDuplicatePageList = createSelector(
+  selectDuplicatePageListState,
+  state => state.pages
+);

--- a/comixed-web/src/app/library/services/duplicate-page.service.spec.ts
+++ b/comixed-web/src/app/library/services/duplicate-page.service.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { DuplicatePageService } from './duplicate-page.service';
+import {
+  HttpClientTestingModule,
+  HttpTestingController
+} from '@angular/common/http/testing';
+import { LoggerModule } from '@angular-ru/logger';
+import { interpolate } from '@app/core';
+import { LOAD_COMICS_WITH_DUPLICATE_PAGES_URL } from '@app/library/library.constants';
+import {
+  DUPLICATE_PAGE_1,
+  DUPLICATE_PAGE_2,
+  DUPLICATE_PAGE_3
+} from '@app/library/library.fixtures';
+
+describe('DuplicatePageService', () => {
+  const PAGES = [DUPLICATE_PAGE_1, DUPLICATE_PAGE_2, DUPLICATE_PAGE_3];
+
+  let service: DuplicatePageService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, LoggerModule.forRoot()]
+    });
+
+    service = TestBed.inject(DuplicatePageService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('can load duplicate pages', () => {
+    service
+      .loadDuplicatePages()
+      .subscribe(response => expect(response).toEqual(PAGES));
+
+    const req = httpMock.expectOne(
+      interpolate(LOAD_COMICS_WITH_DUPLICATE_PAGES_URL)
+    );
+    expect(req.request.method).toEqual('GET');
+    req.flush(PAGES);
+  });
+});

--- a/comixed-web/src/app/library/services/duplicate-page.service.ts
+++ b/comixed-web/src/app/library/services/duplicate-page.service.ts
@@ -1,0 +1,36 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { LoggerService } from '@angular-ru/logger';
+import { Observable } from 'rxjs';
+import { interpolate } from '@app/core';
+import { LOAD_COMICS_WITH_DUPLICATE_PAGES_URL } from '@app/library/library.constants';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DuplicatePageService {
+  constructor(private logger: LoggerService, private http: HttpClient) {}
+
+  loadDuplicatePages(): Observable<any> {
+    this.logger.trace('Service: Load duplicate pages');
+    return this.http.get(interpolate(LOAD_COMICS_WITH_DUPLICATE_PAGES_URL));
+  }
+}

--- a/comixed-web/src/app/messaging/index.ts
+++ b/comixed-web/src/app/messaging/index.ts
@@ -24,6 +24,7 @@ import {
   reducer as messagingReducer
 } from '@app/messaging/reducers/messaging.reducer';
 import { ActionReducerMap } from '@ngrx/store';
+import { Subscription } from 'webstomp-client';
 
 export { WebSocketService } from './services/web-socket.service';
 
@@ -39,6 +40,7 @@ export interface MessagingModuleState {
 }
 
 export type ModuleState = MessagingModuleState;
+export type MessagingSubscription = Subscription;
 
 export const reducers: ActionReducerMap<MessagingModuleState> = {
   router: routerReducer,

--- a/comixed-web/src/assets/i18n/de/app.json
+++ b/comixed-web/src/assets/i18n/de/app.json
@@ -93,6 +93,7 @@
       "character-collection": "Characters",
       "configuration": "Configuration",
       "deleted-comics": "Deleted comics",
+      "duplicate-pages": "Duplicate pages",
       "import-comics": "Import Comics",
       "location-collection": "Locations",
       "publisher-collection": "Publishers",

--- a/comixed-web/src/assets/i18n/de/blocked-pages.json
+++ b/comixed-web/src/assets/i18n/de/blocked-pages.json
@@ -1,5 +1,9 @@
 {
   "blocked-page": {
+    "add-page-hash": {
+      "confirmation-message": "Are you sure you want to block all pages with the hash \"{hash}\"?",
+      "confirmation-title": "Block Page Hash"
+    },
     "editing": {
       "reset-message": "Discard your changes to this blocked page type?",
       "reset-title": "Reset Blocked Page",
@@ -14,6 +18,10 @@
     },
     "load-by-hash-effect-error": "Failed to load blocked page for hash: {hash}",
     "page-title": "Blocked Page Details: {hash}",
+    "remove-page-hash": {
+      "confirmation-message": "Are you sure you want to unblock ll pages with the hash \"{hash}\"?",
+      "confirmation-title": "Unblock Page Hash"
+    },
     "set-state": {
       "effect-failure": "Failed to {block,select,true{block} other{unblock}} page hash.",
       "effect-success": "Successfully {block, select, true{blocked} other{unblocked}} page hash."

--- a/comixed-web/src/assets/i18n/de/library.json
+++ b/comixed-web/src/assets/i18n/de/library.json
@@ -1,4 +1,32 @@
 {
+  "duplicate-pages": {
+    "block-selection": {
+      "confirmation-message": "Are you sure you want to block the {count} selected {count, plural, =1{page} other{pages}}.",
+      "confirmation-title": "Block Selected Page Hashes"
+    },
+    "header": {
+      "blocked": "Is Page Blocked?",
+      "comic-count": "Comics Affected",
+      "hash": "Hash Value",
+      "thumbnail": "Thumbnail"
+    },
+    "list-page": {
+      "tab-title": "Duplicate Pages"
+    },
+    "load-comics": {
+      "effect-failure": "Failed to load comics with duplicate pages."
+    },
+    "tooltip": {
+      "block-page": "Block pages like this.",
+      "block-selections": "Block selected page hashes",
+      "unblock-page": "Unblock pages like this.",
+      "unblock-selections": "Unblock selected page hashes"
+    },
+    "unblock-selection": {
+      "confirmation-message": "Are you sure you want to unblock the {count} selected {count, plural, =1{page} other{pages}}.",
+      "confirmation-title": "Unblock Selected Page Hashes"
+    }
+  },
   "library": {
     "all-comics": {
       "tab-title": "All Comics",

--- a/comixed-web/src/assets/i18n/en/app.json
+++ b/comixed-web/src/assets/i18n/en/app.json
@@ -93,6 +93,7 @@
       "character-collection": "Characters",
       "configuration": "Configuration",
       "deleted-comics": "Deleted comics",
+      "duplicate-pages": "Duplicate pages",
       "import-comics": "Import Comics",
       "location-collection": "Locations",
       "publisher-collection": "Publishers",

--- a/comixed-web/src/assets/i18n/en/blocked-pages.json
+++ b/comixed-web/src/assets/i18n/en/blocked-pages.json
@@ -1,5 +1,9 @@
 {
   "blocked-page": {
+    "add-page-hash": {
+      "confirmation-message": "Are you sure you want to block all pages with the hash \"{hash}\"?",
+      "confirmation-title": "Block Page With Hash"
+    },
     "editing": {
       "reset-message": "Discard your changes to this blocked page type?",
       "reset-title": "Reset Blocked Page",
@@ -14,6 +18,10 @@
     },
     "load-by-hash-effect-error": "Failed to load blocked page for hash: {hash}",
     "page-title": "Blocked Page Details: {hash}",
+    "remove-page-hash": {
+      "confirmation-message": "Are you sure you want to unblock ll pages with the hash \"{hash}\"?",
+      "confirmation-title": "Unblock Page Hash"
+    },
     "set-state": {
       "effect-failure": "Failed to {block,select,true{block} other{unblock}} page hash.",
       "effect-success": "Successfully {block, select, true{blocked} other{unblocked}} page hash."

--- a/comixed-web/src/assets/i18n/en/library.json
+++ b/comixed-web/src/assets/i18n/en/library.json
@@ -1,4 +1,32 @@
 {
+  "duplicate-pages": {
+    "block-selection": {
+      "confirmation-message": "Are you sure you want to block the {count} selected {count, plural, =1{page} other{pages}}.",
+      "confirmation-title": "Block Selected Page Hashes"
+    },
+    "header": {
+      "blocked": "Is Page Blocked?",
+      "comic-count": "Comics Affected",
+      "hash": "Hash Value",
+      "thumbnail": "Thumbnail"
+    },
+    "list-page": {
+      "tab-title": "Duplicate Pages"
+    },
+    "load-comics": {
+      "effect-failure": "Failed to load comics with duplicate pages."
+    },
+    "tooltip": {
+      "block-page": "Block pages like this.",
+      "block-selections": "Block selected page hashes",
+      "unblock-page": "Unblock pages like this.",
+      "unblock-selections": "Unblock selected page hashes"
+    },
+    "unblock-selection": {
+      "confirmation-message": "Are you sure you want to unblock the {count} selected {count, plural, =1{page} other{pages}}.",
+      "confirmation-title": "Unblock Selected Page Hashes"
+    }
+  },
   "library": {
     "all-comics": {
       "tab-title": "All Comics",

--- a/comixed-web/src/assets/i18n/es/app.json
+++ b/comixed-web/src/assets/i18n/es/app.json
@@ -93,6 +93,7 @@
       "character-collection": "Personajes",
       "configuration": "Configuration",
       "deleted-comics": "Cómics eliminados",
+      "duplicate-pages": "Duplicate pages",
       "import-comics": "Importar cómics",
       "location-collection": "Ubicaciónes",
       "publisher-collection": "Editores",

--- a/comixed-web/src/assets/i18n/es/blocked-pages.json
+++ b/comixed-web/src/assets/i18n/es/blocked-pages.json
@@ -1,5 +1,9 @@
 {
   "blocked-page": {
+    "add-page-hash": {
+      "confirmation-message": "Are you sure you want to block all pages with the hash \"{hash}\"?",
+      "confirmation-title": "Block Page With Hash"
+    },
     "editing": {
       "reset-message": "¿Descartar los cambios en este tipo de página bloqueada?",
       "reset-title": "Restablecer página bloqueada",
@@ -14,6 +18,10 @@
     },
     "load-by-hash-effect-error": "No se pudo cargar la página bloqueada para hash: {hash}",
     "page-title": "Detalles de la página bloqueada: {hash}",
+    "remove-page-hash": {
+      "confirmation-message": "Are you sure you want to unblock ll pages with the hash \"{hash}\"?",
+      "confirmation-title": "Unblock Page Hash"
+    },
     "set-state": {
       "effect-failure": "No se pudo {block,select,true{block} other{unblock}} el hash de página.",
       "effect-success": "El hash de página {block, select, true{blocked} other{unblocked}} correctamente."

--- a/comixed-web/src/assets/i18n/es/library.json
+++ b/comixed-web/src/assets/i18n/es/library.json
@@ -1,4 +1,32 @@
 {
+  "duplicate-pages": {
+    "block-selection": {
+      "confirmation-message": "Are you sure you want to block the {count} selected {count, plural, =1{page} other{pages}}.",
+      "confirmation-title": "Block Selected Page Hashes"
+    },
+    "header": {
+      "blocked": "Is Page Blocked?",
+      "comic-count": "Comics Affected",
+      "hash": "Hash Value",
+      "thumbnail": "Thumbnail"
+    },
+    "list-page": {
+      "tab-title": "Duplicate Pages"
+    },
+    "load-comics": {
+      "effect-failure": "Failed to load comics with duplicate pages."
+    },
+    "tooltip": {
+      "block-page": "Block pages like this.",
+      "block-selections": "Block selected page hashes",
+      "unblock-page": "Unblock pages like this.",
+      "unblock-selections": "Unblock selected page hashes"
+    },
+    "unblock-selection": {
+      "confirmation-message": "Are you sure you want to unblock the {count} selected {count, plural, =1{page} other{pages}}.",
+      "confirmation-title": "Unblock Selected Page Hashes"
+    }
+  },
   "library": {
     "all-comics": {
       "tab-title": "Todos los cómics",

--- a/comixed-web/src/assets/i18n/fr/app.json
+++ b/comixed-web/src/assets/i18n/fr/app.json
@@ -108,6 +108,7 @@
       "character-collection": "Personnages",
       "configuration": "Configuration",
       "deleted-comics": "Bandes Dessinées supprimées",
+      "duplicate-pages": "Duplicate pages",
       "import-comics": "Bandes Dessinées importées",
       "location-collection": "Lieux",
       "publisher-collection": "Éditeurs",

--- a/comixed-web/src/assets/i18n/fr/blocked-pages.json
+++ b/comixed-web/src/assets/i18n/fr/blocked-pages.json
@@ -1,5 +1,9 @@
 {
   "blocked-page": {
+    "add-page-hash": {
+      "confirmation-message": "Are you sure you want to block all pages with the hash \"{hash}\"?",
+      "confirmation-title": "Block Page With Hash"
+    },
     "editing": {
       "reset-message": "Annuler les modifications apportées à ce type de page bloquée ?",
       "reset-title": "Rétablir la page bloquée",
@@ -14,6 +18,10 @@
     },
     "load-by-hash-effect-error": "Impossible de charger la page bloquée pour le hash : {hash}",
     "page-title": "Détails de la page bloquée : {hash}",
+    "remove-page-hash": {
+      "confirmation-message": "Are you sure you want to unblock ll pages with the hash \"{hash}\"?",
+      "confirmation-title": "Unblock Page Hash"
+    },
     "set-state": {
       "effect-failure": "Échec du hash de la page {block,select,true{bloquée} other{débloquée}}.",
       "effect-success": "Succès du hash de la page {block, select, true{bloquée} other{débloquée}}."

--- a/comixed-web/src/assets/i18n/fr/library.json
+++ b/comixed-web/src/assets/i18n/fr/library.json
@@ -1,4 +1,32 @@
 {
+  "duplicate-pages": {
+    "block-selection": {
+      "confirmation-message": "Are you sure you want to block the {count} selected {count, plural, =1{page} other{pages}}.",
+      "confirmation-title": "Block Selected Page Hashes"
+    },
+    "header": {
+      "blocked": "Is Page Blocked?",
+      "comic-count": "Comics Affected",
+      "hash": "Hash Value",
+      "thumbnail": "Thumbnail"
+    },
+    "list-page": {
+      "tab-title": "Duplicate Pages"
+    },
+    "load-comics": {
+      "effect-failure": "Failed to load comics with duplicate pages."
+    },
+    "tooltip": {
+      "block-page": "Block pages like this.",
+      "block-selections": "Block selected page hashes",
+      "unblock-page": "Unblock pages like this.",
+      "unblock-selections": "Unblock selected page hashes"
+    },
+    "unblock-selection": {
+      "confirmation-message": "Are you sure you want to unblock the {count} selected {count, plural, =1{page} other{pages}}.",
+      "confirmation-title": "Unblock Selected Page Hashes"
+    }
+  },
   "library": {
     "all-comics": {
       "tab-title": "Toutes les Bandes Dessinées",

--- a/comixed-web/src/assets/i18n/pt/app.json
+++ b/comixed-web/src/assets/i18n/pt/app.json
@@ -93,6 +93,7 @@
       "character-collection": "Characters",
       "configuration": "Configuration",
       "deleted-comics": "Deleted comics",
+      "duplicate-pages": "Duplicate pages",
       "import-comics": "Import Comics",
       "location-collection": "Locations",
       "publisher-collection": "Publishers",

--- a/comixed-web/src/assets/i18n/pt/blocked-pages.json
+++ b/comixed-web/src/assets/i18n/pt/blocked-pages.json
@@ -1,5 +1,9 @@
 {
   "blocked-page": {
+    "add-page-hash": {
+      "confirmation-message": "Are you sure you want to block all pages with the hash \"{hash}\"?",
+      "confirmation-title": "Block Page With Hash"
+    },
     "editing": {
       "reset-message": "Discard your changes to this blocked page type?",
       "reset-title": "Reset Blocked Page",
@@ -14,6 +18,10 @@
     },
     "load-by-hash-effect-error": "Failed to load blocked page for hash: {hash}",
     "page-title": "Blocked Page Details: {hash}",
+    "remove-page-hash": {
+      "confirmation-message": "Are you sure you want to unblock ll pages with the hash \"{hash}\"?",
+      "confirmation-title": "Unblock Page Hash"
+    },
     "set-state": {
       "effect-failure": "Failed to {block,select,true{block} other{unblock}} page hash.",
       "effect-success": "Successfully {block, select, true{blocked} other{unblocked}} page hash."

--- a/comixed-web/src/assets/i18n/pt/library.json
+++ b/comixed-web/src/assets/i18n/pt/library.json
@@ -1,4 +1,32 @@
 {
+  "duplicate-pages": {
+    "block-selection": {
+      "confirmation-message": "Are you sure you want to block the {count} selected {count, plural, =1{page} other{pages}}.",
+      "confirmation-title": "Block Selected Page Hashes"
+    },
+    "header": {
+      "blocked": "Is Page Blocked?",
+      "comic-count": "Comics Affected",
+      "hash": "Hash Value",
+      "thumbnail": "Thumbnail"
+    },
+    "list-page": {
+      "tab-title": "Duplicate Pages"
+    },
+    "load-comics": {
+      "effect-failure": "Failed to load comics with duplicate pages."
+    },
+    "tooltip": {
+      "block-page": "Block pages like this.",
+      "block-selections": "Block selected page hashes",
+      "unblock-page": "Unblock pages like this.",
+      "unblock-selections": "Unblock selected page hashes"
+    },
+    "unblock-selection": {
+      "confirmation-message": "Are you sure you want to unblock the {count} selected {count, plural, =1{page} other{pages}}.",
+      "confirmation-title": "Unblock Selected Page Hashes"
+    }
+  },
   "library": {
     "all-comics": {
       "tab-title": "All Comics",

--- a/comixed-web/src/styles.scss
+++ b/comixed-web/src/styles.scss
@@ -186,6 +186,11 @@ $cx-column-large: 325px;
   text-overflow: ellipsis;
 }
 
+.cx-table-thumbnail {
+  height: 100%;
+  overflow-y: hidden;
+}
+
 // component position
 
 .cx-centered {


### PR DESCRIPTION
 * Added a feature for loading the list of comics.
 * Moved duplicate page REST API to its own controller.
 * Added a publishing action for duplicate page list updates.

Also moved the blocked pages sidenav entry to be after the duplicate
pages entry, and modified its URL to be similar to duplicate pages.

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [X] Have you announced your PR on the comixed-dev mailing list?
- [X] New feature (non-breaking change which adds functionality)
- [X] My code follows the code style of this project.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

