### PR TITLE
Added a workflow to enforce pull request message conventions [#879]

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -1,0 +1,56 @@
+name: 'Commit Message Check'
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  check-commit-message:
+    name: Check Commit Message
+    runs-on: ubuntu-latest
+    steps:
+      - name: Load PR commits
+        id: 'get-pr-commits'
+        uses: tim-actions/get-pr-commits@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Subject line length
+        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
+          pattern: '^.{0,75}(\n.*)*$'
+          error: 'Subject too long (max 75)'
+
+      - name: Subject must be an imperative statement
+        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
+          pattern: '^(Added|Changed|Deprecated|Removed|Fixed|Security).+'
+          error: 'Subject must start with one of: Added, Changed, Deprecated, Removed, Fixed or Security'
+
+      - name: Subject must reference an issue number
+        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
+          pattern: '^.+ \[\#[\d]+\]$'
+          error: 'Subject must end with the issue number being addressed'
+
+      - name: Subject must not end with a sentence
+        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
+          pattern: '^.+[^.][ ]+\[\#[\d]+\]$'
+          error: 'Subject must not end with a period'
+
+      - name: Check Body Line Length
+        if: ${{ success() || failure() }}
+        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
+          pattern: '^.+(\n.{0,79})*$'
+          error: 'Body line too long (max 79)'


### PR DESCRIPTION
## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [X] New feature (non-breaking change which adds functionality)