### PR TITLE
Removed some options when  importing files [#855]

### DIFF
--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/AddComicsConfiguration.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/AddComicsConfiguration.java
@@ -46,6 +46,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @Log4j2
 public class AddComicsConfiguration {
+  public static final String PARAM_ADD_COMICS_STARTED = "job.add-comics.started";
+
   @Value("${batch.chunk-size}")
   private int batchChunkSize = 10;
 

--- a/comixed-model/src/main/java/org/comixedproject/model/net/ImportComicFilesRequest.java
+++ b/comixed-model/src/main/java/org/comixedproject/model/net/ImportComicFilesRequest.java
@@ -39,14 +39,4 @@ public class ImportComicFilesRequest {
   @Getter
   @Setter
   private List<String> filenames = new ArrayList<>();
-
-  @JsonProperty("ignoreMetadata")
-  @Getter
-  @Setter
-  private boolean ignoreMetadata;
-
-  @JsonProperty("deleteBlockedPages")
-  @Getter
-  @Setter
-  private boolean deleteBlockedPages;
 }

--- a/comixed-rest/src/main/java/org/comixedproject/rest/comicfiles/ComicFileController.java
+++ b/comixed-rest/src/main/java/org/comixedproject/rest/comicfiles/ComicFileController.java
@@ -26,6 +26,7 @@ import org.apache.commons.io.IOUtils;
 import org.comixedproject.adaptors.archive.ArchiveAdaptorException;
 import org.comixedproject.adaptors.handlers.ComicFileHandlerException;
 import org.comixedproject.auditlog.AuditableEndpoint;
+import org.comixedproject.batch.comicbooks.AddComicsConfiguration;
 import org.comixedproject.model.net.GetAllComicsUnderRequest;
 import org.comixedproject.model.net.ImportComicFilesRequest;
 import org.comixedproject.model.net.comicfiles.LoadComicFilesResponse;
@@ -54,7 +55,6 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/files")
 @Log4j2
 public class ComicFileController {
-  private static final String KEY_ADD_COMICS_STARTED = "key.add-comics.started";
 
   @Autowired private ComicFileService comicFileService;
 
@@ -147,8 +147,6 @@ public class ComicFileController {
       throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException,
           JobParametersInvalidException, JobRestartException {
     final List<String> filenames = request.getFilenames();
-    final boolean deleteBlockedPages = request.isDeleteBlockedPages();
-    final boolean ignoreMetadata = request.isIgnoreMetadata();
 
     log.info("Importing comic files");
     this.comicFileService.importComicFiles(filenames);
@@ -156,7 +154,7 @@ public class ComicFileController {
     this.jobLauncher.run(
         addComicsToLibraryJob,
         new JobParametersBuilder()
-            .addLong(KEY_ADD_COMICS_STARTED, System.currentTimeMillis())
+            .addLong(AddComicsConfiguration.PARAM_ADD_COMICS_STARTED, System.currentTimeMillis())
             .toJobParameters());
   }
 }

--- a/comixed-rest/src/test/java/org/comixedproject/rest/comicfiles/ComicFileControllerTest.java
+++ b/comixed-rest/src/test/java/org/comixedproject/rest/comicfiles/ComicFileControllerTest.java
@@ -50,8 +50,6 @@ public class ComicFileControllerTest {
   private static final String TEST_DIRECTORY = "src/test";
   private static final Integer TEST_LIMIT = RANDOM.nextInt();
   private static final Integer TEST_NO_LIMIT = -1;
-  private static final boolean TEST_DELETE_BLOCKED_PAGES = RANDOM.nextBoolean();
-  private static final boolean TEST_IGNORE_METADATA = RANDOM.nextBoolean();
 
   @InjectMocks private ComicFileController controller;
   @Mock private ComicFileService comicFileService;
@@ -124,8 +122,7 @@ public class ComicFileControllerTest {
     Mockito.when(jobLauncher.run(Mockito.any(Job.class), jobParametersArgumentCaptor.capture()))
         .thenReturn(jobExecution);
 
-    controller.importComicFiles(
-        new ImportComicFilesRequest(filenameList, TEST_IGNORE_METADATA, TEST_DELETE_BLOCKED_PAGES));
+    controller.importComicFiles(new ImportComicFilesRequest(filenameList));
 
     final JobParameters jobParameters = jobParametersArgumentCaptor.getValue();
 

--- a/comixed-webui/src/app/comic-file/actions/import-comic-files.actions.ts
+++ b/comixed-webui/src/app/comic-file/actions/import-comic-files.actions.ts
@@ -23,8 +23,6 @@ export const sendComicFiles = createAction(
   '[Import Comic Files] Begin importing the selected comic files',
   props<{
     files: ComicFile[];
-    ignoreMetadata: boolean;
-    deleteBlockedPages: boolean;
   }>()
 );
 

--- a/comixed-webui/src/app/comic-file/components/comic-file-toolbar/comic-file-toolbar.component.html
+++ b/comixed-webui/src/app/comic-file/components/comic-file-toolbar/comic-file-toolbar.component.html
@@ -33,50 +33,6 @@
     <mat-icon>check_box_outline_blank</mat-icon>
   </button>
   <button
-    *ngIf="ignoreMetadata"
-    id="ignore-metadata-button"
-    class="cx-margin-right-5"
-    mat-icon-button
-    color="primary"
-    [matTooltip]="'comic-files.tooltip.ignore-metadata-on' | translate"
-    (click)="onToggleIgnoreMetadata()"
-  >
-    <mat-icon>block</mat-icon>
-  </button>
-  <button
-    *ngIf="!ignoreMetadata"
-    id="use-metadata-button"
-    class="cx-margin-right-5"
-    mat-icon-button
-    color="primary"
-    [matTooltip]="'comic-files.tooltip.ignore-metadata-off' | translate"
-    (click)="onToggleIgnoreMetadata()"
-  >
-    <mat-icon>remove_circle_outline</mat-icon>
-  </button>
-  <button
-    *ngIf="deleteBlockedPages"
-    id="cx-delete-blocked-pages-button"
-    class="cx-margin-right-5"
-    mat-icon-button
-    color="primary"
-    [matTooltip]="'comic-files.tooltip.delete-blocked-pages-on' | translate"
-    (click)="onToggleDeleteBlockedPages()"
-  >
-    <mat-icon>delete</mat-icon>
-  </button>
-  <button
-    *ngIf="!deleteBlockedPages"
-    id="cx-ignore-blocked-pages-button"
-    class="cx-margin-right-5"
-    mat-icon-button
-    color="primary"
-    [matTooltip]="'comic-files.tooltip.delete-blocked-pages-off' | translate"
-    (click)="onToggleDeleteBlockedPages()"
-  >
-    <mat-icon>clear</mat-icon>
-  </button>
-  <button
     id="start-import-button"
     class="cx-margin-right-5"
     mat-icon-button

--- a/comixed-webui/src/app/comic-file/components/comic-file-toolbar/comic-file-toolbar.component.spec.ts
+++ b/comixed-webui/src/app/comic-file/components/comic-file-toolbar/comic-file-toolbar.component.spec.ts
@@ -147,39 +147,8 @@ describe('ComicFileToolbarComponent', () => {
     });
   });
 
-  describe('toggling the ignore metadata flag', () => {
-    const IGNORED = Math.random() > 0.5;
-
-    beforeEach(() => {
-      component.ignoreMetadata = IGNORED;
-      component.onToggleIgnoreMetadata();
-    });
-
-    it('flips the flag', () => {
-      expect(component.ignoreMetadata).not.toEqual(IGNORED);
-    });
-  });
-
-  describe('marking blocked pages for deletion', () => {
-    const MARKED = Math.random() > 0.5;
-
-    beforeEach(() => {
-      component.deleteBlockedPages = MARKED;
-      component.onToggleDeleteBlockedPages();
-    });
-
-    it('flips the flag', () => {
-      expect(component.deleteBlockedPages).not.toEqual(MARKED);
-    });
-  });
-
   describe('starting the import process', () => {
-    const IGNORED = Math.random() > 0.5;
-    const MARKED = Math.random() > 0.5;
-
     beforeEach(() => {
-      component.ignoreMetadata = IGNORED;
-      component.deleteBlockedPages = MARKED;
       component.selectedComicFiles = COMIC_FILES;
       component.onStartImport();
     });
@@ -187,9 +156,7 @@ describe('ComicFileToolbarComponent', () => {
     it('fires an action', () => {
       expect(store.dispatch).toHaveBeenCalledWith(
         sendComicFiles({
-          files: COMIC_FILES,
-          ignoreMetadata: IGNORED,
-          deleteBlockedPages: MARKED
+          files: COMIC_FILES
         })
       );
     });

--- a/comixed-webui/src/app/comic-file/components/comic-file-toolbar/comic-file-toolbar.component.ts
+++ b/comixed-webui/src/app/comic-file/components/comic-file-toolbar/comic-file-toolbar.component.ts
@@ -42,8 +42,6 @@ import { User } from '@app/user/models/user';
   styleUrls: ['./comic-file-toolbar.component.scss']
 })
 export class ComicFileToolbarComponent {
-  @Input() ignoreMetadata = false;
-  @Input() deleteBlockedPages = false;
   @Input() comicFiles: ComicFile[] = [];
   @Input() selectedComicFiles: ComicFile[] = [];
 
@@ -111,26 +109,11 @@ export class ComicFileToolbarComponent {
     this.store.dispatch(clearComicFileSelections());
   }
 
-  onToggleIgnoreMetadata(): void {
-    this.logger.trace('Setting ignoring metadata to', !this.ignoreMetadata);
-    this.ignoreMetadata = this.ignoreMetadata === false;
-  }
-
-  onToggleDeleteBlockedPages(): void {
-    this.logger.trace(
-      'Setting deleting blocked pages to',
-      !this.deleteBlockedPages
-    );
-    this.deleteBlockedPages = this.deleteBlockedPages === false;
-  }
-
   onStartImport(): void {
     this.logger.trace('Starting the import process');
     this.store.dispatch(
       sendComicFiles({
-        files: this.selectedComicFiles,
-        ignoreMetadata: this.ignoreMetadata,
-        deleteBlockedPages: this.deleteBlockedPages
+        files: this.selectedComicFiles
       })
     );
   }

--- a/comixed-webui/src/app/comic-file/effects/import-comic-files.effects.ts
+++ b/comixed-webui/src/app/comic-file/effects/import-comic-files.effects.ts
@@ -26,11 +26,6 @@ import {
   sendComicFiles,
   sendComicFilesFailed
 } from '@app/comic-file/actions/import-comic-files.actions';
-import { saveUserPreference } from '@app/user/actions/user.actions';
-import {
-  DELETE_BLOCKED_PAGES_PREFERENCE,
-  IGNORE_METADATA_PREFERENCE
-} from '@app/library/library.constants';
 import { LoggerService } from '@angular-ru/logger';
 import { ComicImportService } from '@app/comic-file/services/comic-import.service';
 import { AlertService } from '@app/core/services/alert.service';
@@ -46,9 +41,7 @@ export class ImportComicFilesEffects {
       switchMap(action =>
         this.comicImportService
           .sendComicFiles({
-            files: action.files,
-            ignoreMetadata: action.ignoreMetadata,
-            deleteBlockedPages: action.deleteBlockedPages
+            files: action.files
           })
           .pipe(
             tap(response => this.logger.debug('Response received:', response)),
@@ -60,18 +53,7 @@ export class ImportComicFilesEffects {
                 )
               )
             ),
-            mergeMap(() => [
-              comicFilesSent(),
-              clearComicFileSelections(),
-              saveUserPreference({
-                name: IGNORE_METADATA_PREFERENCE,
-                value: `${action.ignoreMetadata}`
-              }),
-              saveUserPreference({
-                name: DELETE_BLOCKED_PAGES_PREFERENCE,
-                value: `${action.deleteBlockedPages}`
-              })
-            ]),
+            mergeMap(() => [comicFilesSent(), clearComicFileSelections()]),
             catchError(error => {
               this.logger.error('Service failure:', error);
               this.alertService.error(

--- a/comixed-webui/src/app/comic-file/pages/import-comics-page/import-comics-page.component.spec.ts
+++ b/comixed-webui/src/app/comic-file/pages/import-comics-page/import-comics-page.component.spec.ts
@@ -55,10 +55,7 @@ import { ComicFileCoverUrlPipe } from '@app/comic-file/pipes/comic-file-cover-ur
 import { MatCardModule } from '@angular/material/card';
 import { ComicPageComponent } from '@app/comic-book/components/comic-page/comic-page.component';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import {
-  DELETE_BLOCKED_PAGES_PREFERENCE,
-  IGNORE_METADATA_PREFERENCE
-} from '@app/library/library.constants';
+import { PAGE_SIZE_PREFERENCE } from '@app/library/library.constants';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import {
@@ -154,20 +151,13 @@ describe('ImportComicsPageComponent', () => {
   });
 
   describe('loading user preferences', () => {
-    const IGNORE_METADATA = Math.random() > 0.5;
-    const DELETE_BLOCKED_PAGES = Math.random() > 0.5;
-
     beforeEach(() => {
       const user = {
         ...USER_ADMIN,
         preferences: [
           {
-            name: IGNORE_METADATA_PREFERENCE,
-            value: `${IGNORE_METADATA}`
-          },
-          {
-            name: DELETE_BLOCKED_PAGES_PREFERENCE,
-            value: `${DELETE_BLOCKED_PAGES}`
+            name: PAGE_SIZE_PREFERENCE,
+            value: `${PAGE_SIZE}`
           }
         ]
       } as User;
@@ -181,11 +171,7 @@ describe('ImportComicsPageComponent', () => {
     });
 
     it('sets the ignore metadata flag', () => {
-      expect(component.ignoreMetadata).toEqual(IGNORE_METADATA);
-    });
-
-    it('sets the delete blocked pages flag', () => {
-      expect(component.deleteBlockedPages).toEqual(DELETE_BLOCKED_PAGES);
+      expect(component.pageSize).toEqual(PAGE_SIZE);
     });
   });
 
@@ -290,14 +276,9 @@ describe('ImportComicsPageComponent', () => {
   });
 
   describe('starting the import process', () => {
-    const IGNORE_METADATA = Math.random() > 0.5;
-    const DELETE_BLOCKED_PAGES = Math.random() > 0.5;
-
     beforeEach(() => {
       component.files = FILES;
       component.selectedFiles = FILES;
-      component.ignoreMetadata = IGNORE_METADATA;
-      component.deleteBlockedPages = DELETE_BLOCKED_PAGES;
 
       spyOn(confirmationService, 'confirm').and.callFake(
         (confirm: Confirmation) => confirm.confirm()
@@ -312,9 +293,7 @@ describe('ImportComicsPageComponent', () => {
     it('fires an action', () => {
       expect(store.dispatch).toHaveBeenCalledWith(
         sendComicFiles({
-          files: FILES,
-          ignoreMetadata: IGNORE_METADATA,
-          deleteBlockedPages: DELETE_BLOCKED_PAGES
+          files: FILES
         })
       );
     });

--- a/comixed-webui/src/app/comic-file/pages/import-comics-page/import-comics-page.component.ts
+++ b/comixed-webui/src/app/comic-file/pages/import-comics-page/import-comics-page.component.ts
@@ -27,10 +27,6 @@ import { filter } from 'rxjs/operators';
 import { getUserPreference } from '@app/user';
 import { Title } from '@angular/platform-browser';
 import {
-  DELETE_BLOCKED_PAGES_DEFAULT,
-  DELETE_BLOCKED_PAGES_PREFERENCE,
-  IGNORE_METADATA_DEFAULT,
-  IGNORE_METADATA_PREFERENCE,
   PAGE_SIZE_DEFAULT,
   PAGE_SIZE_PREFERENCE
 } from '@app/library/library.constants';
@@ -68,8 +64,6 @@ export class ImportComicsPageComponent implements OnInit, OnDestroy {
   selectedFilesSubscription: Subscription;
   selectedFiles: ComicFile[];
   pageSize = PAGE_SIZE_DEFAULT;
-  ignoreMetadata = false;
-  deleteBlockedPages = false;
   importing = false;
   private sending = false;
   private loading = false;
@@ -92,18 +86,6 @@ export class ImportComicsPageComponent implements OnInit, OnDestroy {
       .subscribe(user => {
         this.user = user;
         this.logger.debug('User updated:', user);
-        this.ignoreMetadata =
-          getUserPreference(
-            user.preferences,
-            IGNORE_METADATA_PREFERENCE,
-            IGNORE_METADATA_DEFAULT
-          ) === 'true';
-        this.deleteBlockedPages =
-          getUserPreference(
-            user.preferences,
-            DELETE_BLOCKED_PAGES_PREFERENCE,
-            DELETE_BLOCKED_PAGES_DEFAULT
-          ) === 'true';
         this.pageSize = parseInt(
           getUserPreference(
             user.preferences,
@@ -171,9 +153,7 @@ export class ImportComicsPageComponent implements OnInit, OnDestroy {
         this.logger.debug('Starting import');
         this.store.dispatch(
           sendComicFiles({
-            files: this.selectedFiles,
-            ignoreMetadata: this.ignoreMetadata,
-            deleteBlockedPages: this.deleteBlockedPages
+            files: this.selectedFiles
           })
         );
       }

--- a/comixed-webui/src/app/comic-file/reducers/import-comic-files.reducer.spec.ts
+++ b/comixed-webui/src/app/comic-file/reducers/import-comic-files.reducer.spec.ts
@@ -56,9 +56,7 @@ describe('ImportComicFiles Reducer', () => {
       state = reducer(
         { ...state, sending: false },
         sendComicFiles({
-          files: FILES,
-          ignoreMetadata: true,
-          deleteBlockedPages: true
+          files: FILES
         })
       );
     });

--- a/comixed-webui/src/app/comic-file/services/comic-import.service.spec.ts
+++ b/comixed-webui/src/app/comic-file/services/comic-import.service.spec.ts
@@ -29,11 +29,11 @@ import { LoadComicFilesRequest } from '@app/library/models/net/load-comic-files-
 import { SendComicFilesRequest } from '@app/library/models/net/send-comic-files-request';
 import { HttpResponse } from '@angular/common/http';
 import {
-  ROOT_DIRECTORY,
   COMIC_FILE_1,
   COMIC_FILE_2,
   COMIC_FILE_3,
-  COMIC_FILE_4
+  COMIC_FILE_4,
+  ROOT_DIRECTORY
 } from '@app/comic-file/comic-file.fixtures';
 import {
   LOAD_COMIC_FILES_URL,
@@ -43,8 +43,6 @@ import {
 describe('ComicImportService', () => {
   const FILES = [COMIC_FILE_1, COMIC_FILE_2, COMIC_FILE_3, COMIC_FILE_4];
   const MAXIMUM = 100;
-  const IGNORE_METADATA = Math.random() > 0.5;
-  const DELETE_BLOCKED_PAGES = Math.random() > 0.5;
 
   let service: ComicImportService;
   let httpMock: HttpTestingController;
@@ -83,18 +81,14 @@ describe('ComicImportService', () => {
     const serviceResponse = new HttpResponse({ status: 200 });
     service
       .sendComicFiles({
-        files: FILES,
-        ignoreMetadata: IGNORE_METADATA,
-        deleteBlockedPages: DELETE_BLOCKED_PAGES
+        files: FILES
       })
       .subscribe(response => expect(response).toEqual(serviceResponse));
 
     const req = httpMock.expectOne(interpolate(SEND_COMIC_FILES_URL));
     expect(req.request.method).toEqual('POST');
     expect(req.request.body).toEqual({
-      filenames: FILES.map(file => file.filename),
-      ignoreMetadata: IGNORE_METADATA,
-      deleteBlockedPages: DELETE_BLOCKED_PAGES
+      filenames: FILES.map(file => file.filename)
     } as SendComicFilesRequest);
     req.flush(serviceResponse);
   });

--- a/comixed-webui/src/app/comic-file/services/comic-import.service.ts
+++ b/comixed-webui/src/app/comic-file/services/comic-import.service.ts
@@ -57,16 +57,10 @@ export class ComicImportService {
    * @param args.ignoreMetadata flag to ignore metadata
    * @param args.deleteBlockedPages flag to mark blocked pages as deleted
    */
-  sendComicFiles(args: {
-    files: ComicFile[];
-    ignoreMetadata: boolean;
-    deleteBlockedPages: boolean;
-  }): Observable<any> {
+  sendComicFiles(args: { files: ComicFile[] }): Observable<any> {
     this.logger.debug('Service: sending comic files:', args);
     return this.http.post(interpolate(SEND_COMIC_FILES_URL), {
-      filenames: args.files.map(file => file.filename),
-      ignoreMetadata: args.ignoreMetadata,
-      deleteBlockedPages: args.deleteBlockedPages
+      filenames: args.files.map(file => file.filename)
     } as SendComicFilesRequest);
   }
 }

--- a/comixed-webui/src/app/library/library.constants.ts
+++ b/comixed-webui/src/app/library/library.constants.ts
@@ -59,11 +59,6 @@ export const IMPORT_ROOT_DIRECTORY_DEFAULT = '';
 export const IMPORT_MAXIMUM_RESULTS_PREFERENCE =
   'preference.import.maximum-results';
 export const IMPORT_MAXIMUM_RESULTS_DEFAULT = 0;
-export const IGNORE_METADATA_PREFERENCE = 'preference.import.ignore-metadata';
-export const IGNORE_METADATA_DEFAULT = `${false}`;
-export const DELETE_BLOCKED_PAGES_PREFERENCE =
-  'preference.import.delete-blocked-pages';
-export const DELETE_BLOCKED_PAGES_DEFAULT = `${false}`;
 export const API_KEY_PREFERENCE = 'preference.scraping.api-key';
 export const SKIP_CACHE_PREFERENCE = 'preference.scraping.skip-cache';
 export const MAXIMUM_RECORDS_PREFERENCE = 'preference.scraping.maximum-records';

--- a/comixed-webui/src/app/library/models/net/send-comic-files-request.ts
+++ b/comixed-webui/src/app/library/models/net/send-comic-files-request.ts
@@ -18,6 +18,4 @@
 
 export interface SendComicFilesRequest {
   filenames: string[];
-  ignoreMetadata: boolean;
-  deleteBlockedPages: boolean;
 }

--- a/comixed-webui/src/assets/i18n/de/comic-file.json
+++ b/comixed-webui/src/assets/i18n/de/comic-file.json
@@ -33,11 +33,7 @@
       "selected-for-import": "This file will be imported."
     },
     "tooltip": {
-      "delete-blocked-pages-off": "Blocked pages will not be marked for deletion.",
-      "delete-blocked-pages-on": "Blocked pages will be marked for deletion.",
       "deselect-all": "Clear the comic file selections.",
-      "ignore-metadata-on": "Metadata will not be used.",
-      "ignore-metadata-off": "Metadata will be used.",
       "select-all": "Select all comic files for import.",
       "start-import": "Start importing the selected comic files.",
       "toggle-file-lookup-form": "Toggle the comic file lookup form."

--- a/comixed-webui/src/assets/i18n/en/comic-file.json
+++ b/comixed-webui/src/assets/i18n/en/comic-file.json
@@ -33,11 +33,7 @@
       "selected-for-import": "This file will be imported."
     },
     "tooltip": {
-      "delete-blocked-pages-off": "Blocked pages will not be marked for deletion.",
-      "delete-blocked-pages-on": "Blocked pages will be marked for deletion.",
       "deselect-all": "Clear the comic file selections.",
-      "ignore-metadata-on": "Metadata will not be used.",
-      "ignore-metadata-off": "Metadata will be used.",
       "select-all": "Select all comic files for import.",
       "start-import": "Start importing the selected comic files.",
       "toggle-file-lookup-form": "Toggle the comic file lookup form."

--- a/comixed-webui/src/assets/i18n/es/comic-file.json
+++ b/comixed-webui/src/assets/i18n/es/comic-file.json
@@ -33,11 +33,7 @@
       "selected-for-import": "Este archivo se importará."
     },
     "tooltip": {
-      "delete-blocked-pages-off": "Las páginas bloqueadas no se marcarán para su eliminación.",
-      "delete-blocked-pages-on": "Las páginas bloqueadas se marcarán para su eliminación.",
       "deselect-all": "Borrar las selecciones de archivos de cómic.",
-      "ignore-metadata-on": "No se utilizarán metadatos.",
-      "ignore-metadata-off": "Se utilizarán metadatos.",
       "select-all": "Seleccione todos los archivos de cómic para importarlos.",
       "start-import": "Empezar a importar los archivos de cómic seleccionados.",
       "toggle-file-lookup-form": "Alternar el formulario de búsqueda de archivos de cómic."

--- a/comixed-webui/src/assets/i18n/fr/comic-file.json
+++ b/comixed-webui/src/assets/i18n/fr/comic-file.json
@@ -33,11 +33,7 @@
       "selected-for-import": "Ce fichier sera importé."
     },
     "tooltip": {
-      "delete-blocked-pages-off": "Les pages bloquées ne seront pas marquées pour suppression.",
-      "delete-blocked-pages-on": "Les pages bloquées seront marquées pour suppression.",
       "deselect-all": "Annuler la sélection des fichiers de Bandes Dessinées.",
-      "ignore-metadata-on": "Les métadonnées ne seront pas utilisées.",
-      "ignore-metadata-off": "Les métadonnées seront utilisées.",
       "select-all": "Sélectionner tous les fichiers de Bandes Dessinées pour import.",
       "start-import": "Commencez l'import des fichiers sélectionnés de Bandes Dessinées.",
       "toggle-file-lookup-form": "Afficher le formulaire de recherche de fichiers de bande dessinée."

--- a/comixed-webui/src/assets/i18n/pt/comic-file.json
+++ b/comixed-webui/src/assets/i18n/pt/comic-file.json
@@ -33,11 +33,7 @@
       "selected-for-import": "This file will be imported."
     },
     "tooltip": {
-      "delete-blocked-pages-off": "Blocked pages will not be marked for deletion.",
-      "delete-blocked-pages-on": "Blocked pages will be marked for deletion.",
       "deselect-all": "Clear the comic file selections.",
-      "ignore-metadata-on": "Metadata will not be used.",
-      "ignore-metadata-off": "Metadata will be used.",
       "select-all": "Select all comic files for import.",
       "start-import": "Start importing the selected comic files.",
       "toggle-file-lookup-form": "Toggle the comic file lookup form."


### PR DESCRIPTION
Removed the buttons for toggling ignoring metadata and marking blocked
pages as deleted. Instead imports willd efault to performing those
actions since that's their purpose.

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [X] Refactors existing code (code changes for efficiency or maintainability)
- [X] All new and existing tests passed.

