### PR TITLE
Added marking individual pages for deletion [#980]

### DIFF
--- a/comixed-model/src/main/java/org/comixedproject/model/messaging/Constants.java
+++ b/comixed-model/src/main/java/org/comixedproject/model/messaging/Constants.java
@@ -28,7 +28,7 @@ public interface Constants {
   String COMIC_LIST_UPDATE_TOPIC = "/topic/comic-list.update";
 
   /** Topic which receives individual comic updates in real time. */
-  String COMIC_BOOK_UPDATE_TOPIC = "/topic/comic-books.%d.update";
+  String COMIC_BOOK_UPDATE_TOPIC = "/topic/comic-book.%d.update";
 
   /** Topic which receives blocked page updates in real time. */
   String BLOCKED_HASH_LIST_UPDATE_TOPIC = "/topic/blocked-hash-list.update";

--- a/comixed-model/src/main/java/org/comixedproject/model/net/comicpages/UpdatePageDeletionRequest.java
+++ b/comixed-model/src/main/java/org/comixedproject/model/net/comicpages/UpdatePageDeletionRequest.java
@@ -1,0 +1,39 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.model.net.comicpages;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * <code>UpdatePageDeletionRequest</code> represents the request body when updating the deleted
+ * state for individual pages.
+ *
+ * @author Darryl L. Pierce
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdatePageDeletionRequest {
+  @JsonProperty("ids")
+  @Getter
+  private List<Long> ids;
+}

--- a/comixed-repositories/src/main/java/org/comixedproject/repositories/comicpages/PageRepository.java
+++ b/comixed-repositories/src/main/java/org/comixedproject/repositories/comicpages/PageRepository.java
@@ -23,6 +23,7 @@ import org.comixedproject.model.comicpages.Page;
 import org.comixedproject.model.comicpages.PageState;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -32,6 +33,15 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface PageRepository extends CrudRepository<Page, Long> {
+  /**
+   * Fetches a single page by record id.
+   *
+   * @param id the record id
+   * @return the page
+   */
+  @Query("SELECT p FROM Page p WHERE p.id = :id")
+  Page getById(@Param("id") long id);
+
   /**
    * Finds a single page with a given hash.
    *

--- a/comixed-webui/src/app/comic-books/actions/comic.actions.ts
+++ b/comixed-webui/src/app/comic-books/actions/comic.actions.ts
@@ -18,6 +18,7 @@
 
 import { createAction, props } from '@ngrx/store';
 import { Comic } from '@app/comic-books/models/comic';
+import { Page } from '@app/comic-books/models/page';
 
 export const loadComic = createAction(
   '[Comic] Loads a single comic',
@@ -45,4 +46,17 @@ export const comicUpdated = createAction(
 
 export const updateComicFailed = createAction(
   '[Comic] Failed to update a comic'
+);
+
+export const updatePageDeletion = createAction(
+  '[Comic] Update page deletion state',
+  props<{ pages: Page[]; deleted: boolean }>()
+);
+
+export const pageDeletionUpdated = createAction(
+  '[Comic] Page deletion was updated'
+);
+
+export const updatePageDeletionFailed = createAction(
+  '[Comic] Failed to update page deletion state'
 );

--- a/comixed-webui/src/app/comic-books/components/comic-page/comic-page.component.html
+++ b/comixed-webui/src/app/comic-books/components/comic-page/comic-page.component.html
@@ -14,11 +14,13 @@
     </div>
   </mat-card-content>
   <mat-card-footer *ngIf="page?.blocked">
-    <mat-icon
-      *ngIf="page?.blocked"
-      [matTooltip]="'comic-book.tooltip.blocked-hash' | translate"
-    >
+    <mat-icon [matTooltip]="'comic-book.tooltip.blocked-hash' | translate">
       block
+    </mat-icon>
+    <mat-icon *ngIf="page?.deleted">
+      <mat-icon [matTooltip]="'comic-book.tooltip.deleted-page' | translate">
+        deleted
+      </mat-icon>
     </mat-icon>
   </mat-card-footer>
 </mat-card>

--- a/comixed-webui/src/app/comic-books/components/comic-pages/comic-pages.component.html
+++ b/comixed-webui/src/app/comic-books/components/comic-pages/comic-pages.component.html
@@ -26,7 +26,27 @@
 <mat-menu #contextMenu="matMenu">
   <ng-template matMenuContent>
     <button
-      *ngIf="page.blocked"
+      *ngIf="isAdmin && page.deleted"
+      mat-menu-item
+      (click)="onSetPageDeleted(page, false)"
+    >
+      <mat-icon>delete</mat-icon>
+      <mat-label>
+        {{ "library.context-menu.set-page-undeleted" | translate }}
+      </mat-label>
+    </button>
+    <button
+      *ngIf="isAdmin && !page.deleted"
+      mat-menu-item
+      (click)="onSetPageDeleted(page, true)"
+    >
+      <mat-icon>delete</mat-icon>
+      <mat-label>
+        {{ "library.context-menu.set-page-deleted" | translate }}
+      </mat-label>
+    </button>
+    <button
+      *ngIf="isAdmin && page.blocked"
       mat-menu-item
       (click)="onSetPageBlocked(page, false)"
     >
@@ -36,7 +56,7 @@
       </mat-label>
     </button>
     <button
-      *ngIf="!page.blocked"
+      *ngIf="isAdmin && !page.blocked"
       mat-menu-item
       (click)="onSetPageBlocked(page, true)"
     >

--- a/comixed-webui/src/app/comic-books/models/network/mark-pages-deleted-request.ts
+++ b/comixed-webui/src/app/comic-books/models/network/mark-pages-deleted-request.ts
@@ -16,18 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses>
  */
 
-import { API_ROOT_URL } from '../core';
-
-export const UPDATE_COMIC_INFO_URL = `${API_ROOT_URL}/comics/\${id}/metadata`;
-export const MARK_COMICS_DELETED_URL = `${API_ROOT_URL}/comics/mark/deleted`;
-export const MARK_COMICS_UNDELETED_URL = `${API_ROOT_URL}/comics/mark/undeleted`;
-export const GET_IMPRINTS_URL = `${API_ROOT_URL}/comics/imprints`;
-
-export const PAGE_URL_FROM_HASH = `${API_ROOT_URL}/pages/hashes/\${hash}/content`;
-export const MARK_PAGES_DELETED_URL = `${API_ROOT_URL}/pages/deleted`;
-export const MARK_PAGES_UNDELETED_URL = `${API_ROOT_URL}/pages/undeleted`;
-
-export const COMICVINE_ISSUE_LINK =
-  'https://comicvine.gamespot.com/issues/4000-${id}/';
-
-export const COMIC_BOOK_UPDATE_TOPIC = `/topic/comic-book.\${id}.update`;
+export interface MarkPagesDeletedRequest {
+  ids: number[];
+  deleted: boolean;
+}

--- a/comixed-webui/src/app/comic-books/pages/comic-book-page/comic-book-page.component.html
+++ b/comixed-webui/src/app/comic-books/pages/comic-book-page/comic-book-page.component.html
@@ -147,6 +147,7 @@
           *ngIf="showPages"
           [comic]="comic"
           [pageSize]="pageSize"
+          [isAdmin]="isAdmin"
         ></cx-comic-pages>
       </mat-tab>
       <mat-tab

--- a/comixed-webui/src/app/comic-books/pages/comic-book-page/comic-book-page.component.spec.ts
+++ b/comixed-webui/src/app/comic-books/pages/comic-book-page/comic-book-page.component.spec.ts
@@ -411,4 +411,22 @@ describe('ComicBookPageComponent', () => {
       );
     });
   });
+
+  describe('unsubscribing from comic updates', () => {
+    const subscription = jasmine.createSpyObj(['unsubscribe']);
+
+    beforeEach(() => {
+      component.comicUpdateSubscription = subscription;
+      component.messagingStarted = true;
+      component.unsubscribeFromUpdates();
+    });
+
+    it('unsubscribes from updates', () => {
+      expect(subscription.unsubscribe).toHaveBeenCalled();
+    });
+
+    it('clears the subscription', () => {
+      expect(component.comicUpdateSubscription).toBeNull();
+    });
+  });
 });

--- a/comixed-webui/src/app/comic-books/reducers/comic.reducer.spec.ts
+++ b/comixed-webui/src/app/comic-books/reducers/comic.reducer.spec.ts
@@ -23,12 +23,18 @@ import {
   comicUpdated,
   loadComic,
   loadComicFailed,
+  pageDeletionUpdated,
   updateComic,
-  updateComicFailed
+  updateComicFailed,
+  updatePageDeletion,
+  updatePageDeletionFailed
 } from '@app/comic-books/actions/comic.actions';
+import { PAGE_1 } from '@app/comic-pages/comic-pages.fixtures';
 
 describe('Comic Reducer', () => {
   const COMIC = COMIC_2;
+  const PAGE = PAGE_1;
+  const DELETED = Math.random() > 0.5;
 
   let state: ComicState;
 
@@ -176,6 +182,39 @@ describe('Comic Reducer', () => {
 
     it('clears the saved flag', () => {
       expect(state.saved).toBeFalse();
+    });
+  });
+
+  describe('setting the deleted state for pages', () => {
+    beforeEach(() => {
+      state = reducer(
+        { ...state, saving: false },
+        updatePageDeletion({ pages: [PAGE], deleted: DELETED })
+      );
+    });
+
+    it('sets the saving flag', () => {
+      expect(state.saving).toBeTrue();
+    });
+  });
+
+  describe('success setting the deleted state', () => {
+    beforeEach(() => {
+      state = reducer({ ...state, saving: true }, pageDeletionUpdated());
+    });
+
+    it('clears the saving flag', () => {
+      expect(state.saving).toBeFalse();
+    });
+  });
+
+  describe('failure setting the deleted state', () => {
+    beforeEach(() => {
+      state = reducer({ ...state, saving: true }, updatePageDeletionFailed());
+    });
+
+    it('clears the saving flag', () => {
+      expect(state.saving).toBeFalse();
     });
   });
 });

--- a/comixed-webui/src/app/comic-books/reducers/comic.reducer.ts
+++ b/comixed-webui/src/app/comic-books/reducers/comic.reducer.ts
@@ -22,8 +22,11 @@ import {
   comicUpdated,
   loadComic,
   loadComicFailed,
+  pageDeletionUpdated,
   updateComic,
-  updateComicFailed
+  updateComicFailed,
+  updatePageDeletion,
+  updatePageDeletionFailed
 } from '../actions/comic.actions';
 import { Comic } from '@app/comic-books/models/comic';
 
@@ -66,5 +69,8 @@ export const reducer = createReducer(
       return state;
     }
   }),
-  on(updateComicFailed, state => ({ ...state, saving: false, saved: false }))
+  on(updateComicFailed, state => ({ ...state, saving: false, saved: false })),
+  on(updatePageDeletion, state => ({ ...state, saving: true })),
+  on(pageDeletionUpdated, state => ({ ...state, saving: false })),
+  on(updatePageDeletionFailed, state => ({ ...state, saving: false }))
 );

--- a/comixed-webui/src/app/comic-books/services/comic.service.spec.ts
+++ b/comixed-webui/src/app/comic-books/services/comic.service.spec.ts
@@ -41,17 +41,21 @@ import { LoadComicsRequest } from '@app/comic-books/models/net/load-comics-reque
 import {
   MARK_COMICS_DELETED_URL,
   MARK_COMICS_UNDELETED_URL,
-  UPDATE_COMIC_INFO_URL
+  MARK_PAGES_DELETED_URL,
+  MARK_PAGES_UNDELETED_URL
 } from '@app/comic-books/comic-books.constants';
 import { MarkComicsDeletedRequest } from '@app/comic-books/models/net/mark-comics-deleted-request';
 import { HttpResponse } from '@angular/common/http';
 import { MarkComicsUndeletedRequest } from '@app/comic-books/models/net/mark-comics-undeleted-request';
+import { PAGE_1 } from '@app/comic-pages/comic-pages.fixtures';
+import { MarkPagesDeletedRequest } from '@app/comic-books/models/network/mark-pages-deleted-request';
 
 describe('ComicService', () => {
   const COMIC = COMIC_2;
   const COMICS = [COMIC_1, COMIC_3, COMIC_5];
   const LAST_ID = Math.floor(Math.abs(Math.random() * 1000));
   const LAST_PAGE = Math.random() > 0.5;
+  const PAGE = PAGE_1;
 
   let service: ComicService;
   let httpMock: HttpTestingController;
@@ -142,6 +146,40 @@ describe('ComicService', () => {
     expect(req.request.body).toEqual({
       ids: COMICS.map(comic => comic.id)
     } as MarkComicsUndeletedRequest);
+    req.flush(new HttpResponse({ status: 200 }));
+  });
+
+  it('it can mark pages for deletion', () => {
+    service
+      .updatePageDeletion({
+        pages: [PAGE],
+        deleted: true
+      })
+      .subscribe(response => expect(response.status).toEqual(200));
+
+    const req = httpMock.expectOne(interpolate(MARK_PAGES_DELETED_URL));
+    expect(req.request.method).toEqual('POST');
+    expect(req.request.body).toEqual({
+      ids: [PAGE.id],
+      deleted: true
+    } as MarkPagesDeletedRequest);
+    req.flush(new HttpResponse({ status: 200 }));
+  });
+
+  it('it can unmark pages for deletion', () => {
+    service
+      .updatePageDeletion({
+        pages: [PAGE],
+        deleted: false
+      })
+      .subscribe(response => expect(response.status).toEqual(200));
+
+    const req = httpMock.expectOne(interpolate(MARK_PAGES_UNDELETED_URL));
+    expect(req.request.method).toEqual('POST');
+    expect(req.request.body).toEqual({
+      ids: [PAGE.id],
+      deleted: false
+    } as MarkPagesDeletedRequest);
     req.flush(new HttpResponse({ status: 200 }));
   });
 });

--- a/comixed-webui/src/app/comic-books/services/comic.service.ts
+++ b/comixed-webui/src/app/comic-books/services/comic.service.ts
@@ -31,9 +31,12 @@ import { LoadComicsRequest } from '@app/comic-books/models/net/load-comics-reque
 import {
   MARK_COMICS_DELETED_URL,
   MARK_COMICS_UNDELETED_URL,
-  UPDATE_COMIC_INFO_URL
+  MARK_PAGES_DELETED_URL,
+  MARK_PAGES_UNDELETED_URL
 } from '@app/comic-books/comic-books.constants';
 import { MarkComicsDeletedRequest } from '@app/comic-books/models/net/mark-comics-deleted-request';
+import { Page } from '@app/comic-books/models/page';
+import { MarkPagesDeletedRequest } from '@app/comic-books/models/network/mark-pages-deleted-request';
 
 @Injectable({
   providedIn: 'root'
@@ -97,6 +100,25 @@ export class ComicService {
       return this.http.post(interpolate(MARK_COMICS_UNDELETED_URL), {
         ids
       } as MarkComicsDeletedRequest);
+    }
+  }
+
+  updatePageDeletion(args: {
+    pages: Page[];
+    deleted: boolean;
+  }): Observable<any> {
+    if (args.deleted) {
+      this.logger.trace('Marking pages for deletion');
+      return this.http.post(interpolate(MARK_PAGES_DELETED_URL), {
+        ids: args.pages.map(page => page.id),
+        deleted: true
+      } as MarkPagesDeletedRequest);
+    } else {
+      this.logger.trace('Unmarking pages for deletion');
+      return this.http.post(interpolate(MARK_PAGES_UNDELETED_URL), {
+        ids: args.pages.map(page => page.id),
+        deleted: false
+      } as MarkPagesDeletedRequest);
     }
   }
 }

--- a/comixed-webui/src/assets/i18n/de/comic-books.json
+++ b/comixed-webui/src/assets/i18n/de/comic-books.json
@@ -121,6 +121,14 @@
       "effect-failure": "Failed to load comic formats."
     }
   },
+  "comic-page": {
+    "update-page-deletion": {
+      "confirmation-message": "Are you sure you want to {deleted, select, true{mark} other{unmark}} this page?",
+      "confirmation-title": "{deleted, select, true{Mark} other{Unmark}} Page",
+      "effect-failure": "Failed to mark {count, plural, =1{one page} other{# pages}} as {deleted, select, true{deleted} other{not deleted}}.",
+      "effect-success": "Marked {count, plural, =1{one page} other{# pages}} as {deleted, select, true{deleted} other{not deleted}}."
+    }
+  },
   "imprint": {
     "load-all": {
       "effect-failure": "Failed to load imprints."

--- a/comixed-webui/src/assets/i18n/de/library.json
+++ b/comixed-webui/src/assets/i18n/de/library.json
@@ -79,7 +79,9 @@
       "mark-selected-as-unread": "Selected Comics As Unread",
       "reading-lists": "Add to list...",
       "set-page-blocked": "Block Pages Like This",
+      "set-page-deleted": "Delete This Page",
       "set-page-unblocked": "Don't Block Pages Like This",
+      "set-page-undeleted": "Don't Delete This Page",
       "undelete-one": "This Comic As Undeleted",
       "undelete-selected": "Selected Comics As Undeleted"
     },

--- a/comixed-webui/src/assets/i18n/en/comic-books.json
+++ b/comixed-webui/src/assets/i18n/en/comic-books.json
@@ -121,6 +121,14 @@
       "effect-failure": "Failed to load comic formats."
     }
   },
+  "comic-page": {
+    "update-page-deletion": {
+      "confirmation-message": "Are you sure you want to {deleted, select, true{mark} other{unmark}} this page?",
+      "confirmation-title": "{deleted, select, true{Mark} other{Unmark}} Page",
+      "effect-failure": "Failed to mark {count, plural, =1{one page} other{# pages}} as {deleted, select, true{deleted} other{not deleted}}.",
+      "effect-success": "Marked {count, plural, =1{one page} other{# pages}} as {deleted, select, true{deleted} other{not deleted}}."
+    }
+  },
   "imprint": {
     "load-all": {
       "effect-failure": "Failed to load imprints."

--- a/comixed-webui/src/assets/i18n/en/library.json
+++ b/comixed-webui/src/assets/i18n/en/library.json
@@ -79,7 +79,9 @@
       "mark-selected-as-unread": "Selected Comics As Unread",
       "reading-lists": "Add to list...",
       "set-page-blocked": "Block Pages Like This",
+      "set-page-deleted": "Delete This Page",
       "set-page-unblocked": "Don't Block Pages Like This",
+      "set-page-undeleted": "Don't Delete This Page",
       "undelete-one": "This Comic As Undeleted",
       "undelete-selected": "Selected Comics As Undeleted"
     },

--- a/comixed-webui/src/assets/i18n/es/comic-books.json
+++ b/comixed-webui/src/assets/i18n/es/comic-books.json
@@ -121,6 +121,14 @@
       "effect-failure": "No se pudieron cargar los formatos de cómic."
     }
   },
+  "comic-page": {
+    "update-page-deletion": {
+      "confirmation-message": "Are you sure you want to {deleted, select, true{mark} other{unmark}} this page?",
+      "confirmation-title": "{deleted, select, true{Mark} other{Unmark}} Page",
+      "effect-failure": "Failed to mark {count, plural, =1{one page} other{# pages}} as {deleted, select, true{deleted} other{not deleted}}.",
+      "effect-success": "Marked {count, plural, =1{one page} other{# pages}} as {deleted, select, true{deleted} other{not deleted}}."
+    }
+  },
   "imprint": {
     "load-all": {
       "effect-failure": "Failed to load imprints."

--- a/comixed-webui/src/assets/i18n/es/library.json
+++ b/comixed-webui/src/assets/i18n/es/library.json
@@ -79,7 +79,9 @@
       "mark-selected-as-unread": "Cómics seleccionados como no leídos",
       "reading-lists": "Add to list...",
       "set-page-blocked": "Bloquear páginas como esta",
+      "set-page-deleted": "Delete This Page",
       "set-page-unblocked": "No bloquee páginas como esta",
+      "set-page-undeleted": "Don't Delete This Page",
       "undelete-one": "This Comic As Undeleted",
       "undelete-selected": "Selected Comics As Undeleted"
     },

--- a/comixed-webui/src/assets/i18n/fr/comic-books.json
+++ b/comixed-webui/src/assets/i18n/fr/comic-books.json
@@ -121,6 +121,14 @@
       "effect-failure": "Échec du chargement des formats de bande dessinée."
     }
   },
+  "comic-page": {
+    "update-page-deletion": {
+      "confirmation-message": "Are you sure you want to {deleted, select, true{mark} other{unmark}} this page?",
+      "confirmation-title": "{deleted, select, true{Mark} other{Unmark}} Page",
+      "effect-failure": "Failed to mark {count, plural, =1{one page} other{# pages}} as {deleted, select, true{deleted} other{not deleted}}.",
+      "effect-success": "Marked {count, plural, =1{one page} other{# pages}} as {deleted, select, true{deleted} other{not deleted}}."
+    }
+  },
   "imprint": {
     "load-all": {
       "effect-failure": "Failed to load imprints."

--- a/comixed-webui/src/assets/i18n/fr/library.json
+++ b/comixed-webui/src/assets/i18n/fr/library.json
@@ -79,7 +79,9 @@
       "mark-selected-as-unread": "Les Bandes Dessinées sélectionnées comme Non lues",
       "reading-lists": "Ajouter à la liste...",
       "set-page-blocked": "Bloquer des pages comme celle-ci",
+      "set-page-deleted": "Delete This Page",
       "set-page-unblocked": "Ne pas bloquer des pages comme celle-ci",
+      "set-page-undeleted": "Don't Delete This Page",
       "undelete-one": "Cette bande dessinée comme non supprimée",
       "undelete-selected": "Bandes dessinées sélectionnées comme non supprimées"
     },

--- a/comixed-webui/src/assets/i18n/pt/comic-books.json
+++ b/comixed-webui/src/assets/i18n/pt/comic-books.json
@@ -121,6 +121,14 @@
       "effect-failure": "Failed to load comic formats."
     }
   },
+  "comic-page": {
+    "update-page-deletion": {
+      "confirmation-message": "Are you sure you want to {deleted, select, true{mark} other{unmark}} this page?",
+      "confirmation-title": "{deleted, select, true{Mark} other{Unmark}} Page",
+      "effect-failure": "Failed to mark {count, plural, =1{one page} other{# pages}} as {deleted, select, true{deleted} other{not deleted}}.",
+      "effect-success": "Marked {count, plural, =1{one page} other{# pages}} as {deleted, select, true{deleted} other{not deleted}}."
+    }
+  },
   "imprint": {
     "load-all": {
       "effect-failure": "Failed to load imprints."

--- a/comixed-webui/src/assets/i18n/pt/library.json
+++ b/comixed-webui/src/assets/i18n/pt/library.json
@@ -79,7 +79,9 @@
       "mark-selected-as-unread": "Selected Comics As Unread",
       "reading-lists": "Add to list...",
       "set-page-blocked": "Block Pages Like This",
+      "set-page-deleted": "Delete This Page",
       "set-page-unblocked": "Don't Block Pages Like This",
+      "set-page-undeleted": "Don't Delete This Page",
       "undelete-one": "This Comic As Undeleted",
       "undelete-selected": "Selected Comics As Undeleted"
     },


### PR DESCRIPTION
 * Added a new feature to set the deleted state on pages.
 * Added REST APIs for marking and unmarking pages.

 Also paid some technical debut by boosting the unit test converage
 for PageController.

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [X] Have you announced your PR on the comixed-dev mailing list?
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

