### PR TITLE
Added a rule to use when renaming pages in a comic file [#516]

### DIFF
--- a/comixed-adaptors/src/main/java/org/comixedproject/adaptors/comicbooks/ComicPageAdaptor.java
+++ b/comixed-adaptors/src/main/java/org/comixedproject/adaptors/comicbooks/ComicPageAdaptor.java
@@ -1,0 +1,63 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2021, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.adaptors.comicbooks;
+
+import lombok.extern.log4j.Log4j2;
+import org.codehaus.plexus.util.FileUtils;
+import org.comixedproject.model.comicpages.Page;
+import org.springframework.stereotype.Component;
+
+/**
+ * <code>ComicPageAdaptor</code> provides a set of utility methods for naming comic pages.
+ *
+ * @author Darryl L. Pierce
+ */
+@Component
+@Log4j2
+public class ComicPageAdaptor {
+  private static final String FORBIDDEN_RULE_CHARACTERS = "[\"':\\\\*?|<>]";
+
+  /**
+   * Generates a new filename for the given page.
+   *
+   * @param page the page
+   * @param renamingRule the renaming rule
+   * @param pageIndex the page index in the comic
+   * @return the page name
+   */
+  public String createFilenameFromRule(
+      final Page page, final String renamingRule, final int pageIndex) {
+    log.debug("Scrubbing renaming rule: {}", renamingRule);
+    final String rule = this.scrub(renamingRule, FORBIDDEN_RULE_CHARACTERS);
+
+    log.debug("Generating relative filename based on renaming rule: {}", rule);
+    final String index = String.valueOf(pageIndex + 1);
+
+    String result = rule.replace("$INDEX", index);
+
+    log.debug("Relative page name: {}", result);
+
+    return String.format("%s.%s", result, FileUtils.getExtension(page.getFilename()));
+  }
+
+  private String scrub(final String text, final String forbidden) {
+    log.trace("Pre-sanitized text: {}", text);
+    return text.replaceAll(forbidden, "_");
+  }
+}

--- a/comixed-adaptors/src/test/java/org/comixedproject/adaptors/comicbooks/ComicPageAdaptorTest.java
+++ b/comixed-adaptors/src/test/java/org/comixedproject/adaptors/comicbooks/ComicPageAdaptorTest.java
@@ -16,14 +16,12 @@
  * along with this program. If not, see <http://www.gnu.org/licenses>
  */
 
-package org.comixedproject.batch.comicbooks.processors;
+package org.comixedproject.adaptors.comicbooks;
 
+import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertSame;
 
-import org.comixedproject.adaptors.comicbooks.ComicBookAdaptor;
-import org.comixedproject.model.archives.ArchiveType;
-import org.comixedproject.model.comicbooks.Comic;
+import org.comixedproject.model.comicpages.Page;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,35 +31,25 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class UpdateMetadataProcessorTest {
-  private static final ArchiveType TEST_ARCHIVE_TYPE = ArchiveType.CB7;
+public class ComicPageAdaptorTest {
+  private static final String TEST_RENAMING_RULE = "page-$INDEX";
+  private static final int TEST_PAGE_INDEX = 3;
+  private static final String TEST_FILENAME = "oldname3.png";
+  private static final String TEST_EXPECTED_PAGE_NAME = "page-4.png";
 
-  @InjectMocks private UpdateMetadataProcessor processor;
-  @Mock private ComicBookAdaptor comicBookAdaptor;
-  @Mock private Comic comic;
+  @InjectMocks private ComicPageAdaptor adaptor;
+  @Mock private Page page;
 
   @Before
   public void setUp() {
-    Mockito.when(comic.getArchiveType()).thenReturn(TEST_ARCHIVE_TYPE);
+    Mockito.when(page.getFilename()).thenReturn(TEST_FILENAME);
   }
 
   @Test
-  public void testProcessUpdateException() throws Exception {
-    final Comic result = processor.process(comic);
+  public void testCreateFilenameFromRule() {
+    final String result = adaptor.createFilenameFromRule(page, TEST_RENAMING_RULE, TEST_PAGE_INDEX);
 
     assertNotNull(result);
-    assertSame(comic, result);
-
-    Mockito.verify(comicBookAdaptor, Mockito.times(1)).save(comic, TEST_ARCHIVE_TYPE, false, "");
-  }
-
-  @Test
-  public void testProcess() throws Exception {
-    final Comic result = processor.process(comic);
-
-    assertNotNull(result);
-    assertSame(comic, result);
-
-    Mockito.verify(comicBookAdaptor, Mockito.times(1)).save(comic, TEST_ARCHIVE_TYPE, false, "");
+    assertEquals(TEST_EXPECTED_PAGE_NAME, result);
   }
 }

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/RecreateComicFilesConfiguration.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/RecreateComicFilesConfiguration.java
@@ -44,7 +44,6 @@ public class RecreateComicFilesConfiguration {
   public static final String JOB_RECREATE_COMICS_STARTED = "job.recreate-comic.started";
   public static final String JOB_TARGET_ARCHIVE = "job.recreate-comic.target-archive";
   public static final String JOB_DELETE_MARKED_PAGES = "job.recreate-comic.delete-blocked-pages";
-  public static final String JOB_RENAME_PAGES = "job.recreate-comic.rename-pages";
 
   @Value("${batch.chunk-size}")
   private int batchChunkSize = 10;

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/processors/RecreateComicFileProcessor.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/processors/RecreateComicFileProcessor.java
@@ -18,12 +18,15 @@
 
 package org.comixedproject.batch.comicbooks.processors;
 
-import static org.comixedproject.batch.comicbooks.RecreateComicFilesConfiguration.*;
+import static org.comixedproject.batch.comicbooks.RecreateComicFilesConfiguration.JOB_DELETE_MARKED_PAGES;
+import static org.comixedproject.batch.comicbooks.RecreateComicFilesConfiguration.JOB_TARGET_ARCHIVE;
+import static org.comixedproject.service.admin.ConfigurationService.CFG_LIBRARY_PAGE_RENAMING_RULE;
 
 import lombok.extern.log4j.Log4j2;
 import org.comixedproject.adaptors.comicbooks.ComicBookAdaptor;
 import org.comixedproject.model.archives.ArchiveType;
 import org.comixedproject.model.comicbooks.Comic;
+import org.comixedproject.service.admin.ConfigurationService;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.StepExecution;
@@ -42,6 +45,7 @@ import org.springframework.stereotype.Component;
 public class RecreateComicFileProcessor
     implements ItemProcessor<Comic, Comic>, StepExecutionListener {
   @Autowired private ComicBookAdaptor comicBookAdaptor;
+  @Autowired private ConfigurationService configurationService;
 
   private JobParameters jobParameters;
 
@@ -52,10 +56,12 @@ public class RecreateComicFileProcessor
         ArchiveType.forValue(this.jobParameters.getString(JOB_TARGET_ARCHIVE));
     final boolean removeDeletedPages =
         Boolean.parseBoolean(this.jobParameters.getString(JOB_DELETE_MARKED_PAGES));
-    final boolean renamePages =
-        Boolean.parseBoolean(this.jobParameters.getString(JOB_RENAME_PAGES));
-    log.trace("Recreating comic file{}", renamePages ? ", renaming pages" : "");
-    this.comicBookAdaptor.save(comic, archiveType, removeDeletedPages, renamePages);
+    log.trace("Recreating comic files");
+    this.comicBookAdaptor.save(
+        comic,
+        archiveType,
+        removeDeletedPages,
+        this.configurationService.getOptionValue(CFG_LIBRARY_PAGE_RENAMING_RULE, ""));
     return comic;
   }
 

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/processors/UpdateMetadataProcessor.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/processors/UpdateMetadataProcessor.java
@@ -40,7 +40,7 @@ public class UpdateMetadataProcessor implements ItemProcessor<Comic, Comic> {
   public Comic process(final Comic comic) {
     try {
       log.debug("Updating comic metadata: id={}", comic.getId());
-      this.comicBookAdaptor.save(comic, comic.getArchiveType(), false, false);
+      this.comicBookAdaptor.save(comic, comic.getArchiveType(), false, "");
     } catch (AdaptorException error) {
       log.error("Failed to update metadata for comic", error);
     }

--- a/comixed-model/src/main/resources/db/migrations/0.11.0/010_516_add_page_renaming_rule_option.xml
+++ b/comixed-model/src/main/resources/db/migrations/0.11.0/010_516_add_page_renaming_rule_option.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="010_516_add_page_renaming_rule_option.xml"
+             author="mcpierce">
+
+    <insert tableName="ConfigurationOptions">
+      <column name="Name"
+              value="library.comic-page.renaming-rule"/>
+      <column name="Value"
+              value="index-$INDEX"/>
+      <column name="LastModifiedOn"
+              value="NOW()"/>
+    </insert>
+
+    <update tableName="ConfigurationOptions">
+      <column name="Name"
+              value="library.comic-book.renaming-rule"/>
+      <where>Name='library.renaming-rule'</where>
+    </update>
+
+  </changeSet>
+</databaseChangeLog>

--- a/comixed-model/src/main/resources/db/migrations/0.11.0/changelog-0.11.0.xml
+++ b/comixed-model/src/main/resources/db/migrations/0.11.0/changelog-0.11.0.xml
@@ -15,5 +15,6 @@
   <include file="/db/migrations/0.11.0/007_1046_make_comicvineid_a_number.xml"/>
   <include file="/db/migrations/0.11.0/008_1053_remove_comic_file_entries.xml"/>
   <include file="/db/migrations/0.11.0/009_1059_removed_dates_from_last_read.xml"/>
+  <include file="/db/migrations/0.11.0/010_516_add_page_renaming_rule_option.xml"/>
 
 </databaseChangeLog>

--- a/comixed-rest/src/main/java/org/comixedproject/rest/library/LibraryController.java
+++ b/comixed-rest/src/main/java/org/comixedproject/rest/library/LibraryController.java
@@ -118,7 +118,6 @@ public class LibraryController {
             .addLong(JOB_RECREATE_COMICS_STARTED, System.currentTimeMillis())
             .addString(JOB_TARGET_ARCHIVE, archiveType.getName())
             .addString(JOB_DELETE_MARKED_PAGES, String.valueOf(deletePages))
-            .addString(JOB_RENAME_PAGES, String.valueOf(renamePages))
             .toJobParameters());
   }
 
@@ -143,7 +142,8 @@ public class LibraryController {
         this.configurationService.getOptionValue(ConfigurationService.CFG_LIBRARY_ROOT_DIRECTORY);
     log.trace("Loading renaming rule");
     final String renamingRule =
-        this.configurationService.getOptionValue(ConfigurationService.CFG_LIBRARY_RENAMING_RULE);
+        this.configurationService.getOptionValue(
+            ConfigurationService.CFG_LIBRARY_COMIC_RENAMING_RULE);
     this.libraryService.prepareForConsolidation(
         targetDirectory, renamingRule, deleteRemovedComicFiles);
     log.trace("Launch consolidation batch process");

--- a/comixed-rest/src/test/java/org/comixedproject/rest/library/LibraryControllerTest.java
+++ b/comixed-rest/src/test/java/org/comixedproject/rest/library/LibraryControllerTest.java
@@ -22,7 +22,7 @@ import static junit.framework.TestCase.*;
 import static org.comixedproject.batch.comicbooks.ConsolidationConfiguration.*;
 import static org.comixedproject.batch.comicbooks.RecreateComicFilesConfiguration.*;
 import static org.comixedproject.rest.library.LibraryController.MAXIMUM_RECORDS;
-import static org.comixedproject.service.admin.ConfigurationService.CFG_LIBRARY_RENAMING_RULE;
+import static org.comixedproject.service.admin.ConfigurationService.CFG_LIBRARY_COMIC_RENAMING_RULE;
 import static org.comixedproject.service.admin.ConfigurationService.CFG_LIBRARY_ROOT_DIRECTORY;
 
 import java.util.ArrayList;
@@ -112,7 +112,6 @@ public class LibraryControllerTest {
     assertEquals(TEST_ARCHIVE_TYPE.getName(), jobParameters.getString(JOB_TARGET_ARCHIVE));
     assertEquals(
         String.valueOf(TEST_DELETE_MARKED_PAGES), jobParameters.getString(JOB_DELETE_MARKED_PAGES));
-    assertEquals(String.valueOf(TEST_RENAME_PAGES), jobParameters.getString(JOB_RENAME_PAGES));
 
     Mockito.verify(libraryService, Mockito.times(1)).prepareToRecreateComics(idList);
     Mockito.verify(jobLauncher, Mockito.times(1)).run(recreateComicFilesJob, jobParameters);
@@ -122,7 +121,7 @@ public class LibraryControllerTest {
   public void testConsolidateServiceThrowsException() throws Exception {
     Mockito.when(configurationService.getOptionValue(CFG_LIBRARY_ROOT_DIRECTORY))
         .thenReturn(TEST_DESTINATION_DIRECTORY);
-    Mockito.when(configurationService.getOptionValue(CFG_LIBRARY_RENAMING_RULE))
+    Mockito.when(configurationService.getOptionValue(CFG_LIBRARY_COMIC_RENAMING_RULE))
         .thenReturn(TEST_RENAMING_RULE);
     Mockito.doThrow(LibraryException.class)
         .when(libraryService)
@@ -140,7 +139,7 @@ public class LibraryControllerTest {
   public void testConsolidate() throws Exception {
     Mockito.when(configurationService.getOptionValue(CFG_LIBRARY_ROOT_DIRECTORY))
         .thenReturn(TEST_DESTINATION_DIRECTORY);
-    Mockito.when(configurationService.getOptionValue(CFG_LIBRARY_RENAMING_RULE))
+    Mockito.when(configurationService.getOptionValue(CFG_LIBRARY_COMIC_RENAMING_RULE))
         .thenReturn(TEST_RENAMING_RULE);
     Mockito.when(jobLauncher.run(Mockito.any(Job.class), jobParametersArgumentCaptor.capture()))
         .thenReturn(jobExecution);

--- a/comixed-services/src/main/java/org/comixedproject/service/admin/ConfigurationService.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/admin/ConfigurationService.java
@@ -21,6 +21,7 @@ package org.comixedproject.service.admin;
 import java.util.List;
 import javax.transaction.Transactional;
 import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang.StringUtils;
 import org.comixedproject.model.admin.ConfigurationOption;
 import org.comixedproject.repositories.admin.ConfigurationRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +37,8 @@ import org.springframework.stereotype.Service;
 @Log4j2
 public class ConfigurationService {
   public static final String CFG_LIBRARY_ROOT_DIRECTORY = "library.root-directory";
-  public static final String CFG_LIBRARY_RENAMING_RULE = "library.renaming-rule";
+  public static final String CFG_LIBRARY_COMIC_RENAMING_RULE = "library.comic-book.renaming-rule";
+  public static final String CFG_LIBRARY_PAGE_RENAMING_RULE = "library.comic-page.renaming-rule";
 
   @Autowired private ConfigurationRepository configurationRepository;
 
@@ -70,7 +72,7 @@ public class ConfigurationService {
         throw new ConfigurationOptionException(
             "No such configuration option: name=" + option.getName());
       log.trace("Updating existing record: value={}", option.getValue());
-      existing.setValue(option.getValue());
+      existing.setValue(option.getValue().trim());
       log.trace("Updating existing record");
       this.configurationRepository.save(existing);
     }
@@ -88,5 +90,10 @@ public class ConfigurationService {
     log.trace("Loading option");
     final ConfigurationOption option = this.configurationRepository.findByName(name);
     return option != null ? option.getValue() : null;
+  }
+
+  public String getOptionValue(final String name, final String defaultValue) {
+    final String result = this.getOptionValue(name);
+    return StringUtils.isNotEmpty(result) ? result : defaultValue;
   }
 }

--- a/comixed-webui/src/app/admin/admin.constants.ts
+++ b/comixed-webui/src/app/admin/admin.constants.ts
@@ -20,7 +20,8 @@ import { API_ROOT_URL } from '../core';
 
 export const COMICVINE_API_KEY = 'comicvine.api-key';
 export const LIBRARY_ROOT_DIRECTORY = 'library.root-directory';
-export const LIBRARY_RENAMING_RULE = 'library.renaming-rule';
+export const LIBRARY_COMIC_RENAMING_RULE = 'library.comic-book.renaming-rule';
+export const LIBRARY_PAGE_RENAMING_RULE = 'library.comic-page.renaming-rule';
 
 export const LOAD_CONFIGURATION_OPTIONS_URL = `${API_ROOT_URL}/admin/config`;
 export const SAVE_CONFIGURATION_OPTIONS_URL = `${API_ROOT_URL}/admin/config`;

--- a/comixed-webui/src/app/admin/components/library-configuration/library-configuration.component.html
+++ b/comixed-webui/src/app/admin/components/library-configuration/library-configuration.component.html
@@ -26,13 +26,13 @@
     <mat-expansion-panel>
       <mat-expansion-panel-header>
         <mat-panel-title>
-          {{ "configuration.label.renaming-variables" | translate }}
+          {{ "configuration.label.comic-renaming-variables" | translate }}
         </mat-panel-title>
       </mat-expansion-panel-header>
 
       <table class="cx-width-100 cx-border-primary-1 cx-padding-5">
         <caption>
-          {{ "configuration.text.variable-caption" | translate }}
+          {{ "configuration.text.comic-variable-caption" | translate }}
         </caption>
         <colgroup>
           <col class="cx-table-column-medium" />
@@ -40,14 +40,14 @@
         </colgroup>
         <thead>
           <th scope="col">
-            {{ "configuration.label.variable-name" | translate }}
+            {{ "configuration.label.comic-variable-name" | translate }}
           </th>
           <th scope="col">
-            {{ "configuration.label.variable-description" | translate }}
+            {{ "configuration.label.comic-variable-description" | translate }}
           </th>
         </thead>
         <tbody>
-          <tr *ngFor="let option of variableOptions">
+          <tr *ngFor="let option of comicVariableOptions">
             <td>{{ option.label }}</td>
             <td>{{ option.value | translate }}</td>
           </tr>
@@ -57,9 +57,60 @@
   </div>
   <mat-form-field class="cx-width-100" appearance="fill">
     <mat-label>
-      {{ "configuration.label.renaming-rule" | translate }}
+      {{ "configuration.label.comic-renaming-rule" | translate }}
     </mat-label>
-    <input id="renaming-rule-input" matInput formControlName="renamingRule" />
+    <input
+      id="comic-renaming-rule-input"
+      matInput
+      formControlName="comicRenamingRule"
+    />
+    <mat-error>
+      {{ "validation.field-required" | translate }}
+    </mat-error>
+  </mat-form-field>
+
+  <div class="cx-width-100">
+    <mat-expansion-panel>
+      <mat-expansion-panel-header>
+        <mat-panel-title>
+          {{ "configuration.label.page-renaming-variables" | translate }}
+        </mat-panel-title>
+      </mat-expansion-panel-header>
+
+      <table class="cx-width-100 cx-border-primary-1 cx-padding-5">
+        <caption>
+          {{ "configuration.text.page-variable-caption" | translate }}
+        </caption>
+        <colgroup>
+          <col class="cx-table-column-medium" />
+          <col />
+        </colgroup>
+        <thead>
+          <th scope="col">
+            {{ "configuration.label.page-variable-name" | translate }}
+          </th>
+          <th scope="col">
+            {{ "configuration.label.page-variable-description" | translate }}
+          </th>
+        </thead>
+        <tbody>
+          <tr *ngFor="let option of pageVariableOptions">
+            <td>{{ option.label }}</td>
+            <td>{{ option.value | translate }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </mat-expansion-panel>
+  </div>
+  <mat-form-field class="cx-width-100" appearance="fill">
+    <mat-label>
+      {{ "configuration.label.page-renaming-rule" | translate }}
+    </mat-label>
+    <input
+      id="page-renaming-rule-input"
+      matInput
+      formControlName="pageRenamingRule"
+    />
     <mat-error>
       {{ "validation.field-required" | translate }}
     </mat-error>

--- a/comixed-webui/src/app/admin/components/library-configuration/library-configuration.component.spec.ts
+++ b/comixed-webui/src/app/admin/components/library-configuration/library-configuration.component.spec.ts
@@ -28,7 +28,8 @@ import { LoggerModule } from '@angular-ru/logger';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import {
-  LIBRARY_RENAMING_RULE,
+  LIBRARY_COMIC_RENAMING_RULE,
+  LIBRARY_PAGE_RENAMING_RULE,
   LIBRARY_ROOT_DIRECTORY
 } from '@app/admin/admin.constants';
 import { Confirmation } from '@app/core/models/confirmation';
@@ -37,15 +38,20 @@ import { ConfirmationService } from '@app/core/services/confirmation.service';
 
 describe('LibraryConfigurationComponent', () => {
   const LIBRARY_ROOT = 'The library root';
-  const RENAMING_RULE = 'The renaming rule';
+  const COMIC_RENAMING_RULE = 'The comic renaming rule';
+  const PAGE_RENAMING_RULE = 'The page renaming rule';
   const OPTIONS = [
     {
       name: LIBRARY_ROOT_DIRECTORY,
       value: LIBRARY_ROOT
     },
     {
-      name: LIBRARY_RENAMING_RULE,
-      value: RENAMING_RULE
+      name: LIBRARY_COMIC_RENAMING_RULE,
+      value: COMIC_RENAMING_RULE
+    },
+    {
+      name: LIBRARY_PAGE_RENAMING_RULE,
+      value: PAGE_RENAMING_RULE
     }
   ];
   const initialState = {};
@@ -95,10 +101,16 @@ describe('LibraryConfigurationComponent', () => {
       ).toEqual(LIBRARY_ROOT);
     });
 
-    it('sets the renaming rule value', () => {
+    it('sets the comic renaming rule value', () => {
       expect(
-        component.libraryConfigurationForm.controls.renamingRule.value
-      ).toEqual(RENAMING_RULE);
+        component.libraryConfigurationForm.controls.comicRenamingRule.value
+      ).toEqual(COMIC_RENAMING_RULE);
+    });
+
+    it('sets the page renaming rule value', () => {
+      expect(
+        component.libraryConfigurationForm.controls.pageRenamingRule.value
+      ).toEqual(PAGE_RENAMING_RULE);
     });
   });
 
@@ -120,7 +132,8 @@ describe('LibraryConfigurationComponent', () => {
         saveConfigurationOptions({
           options: [
             { name: LIBRARY_ROOT_DIRECTORY, value: LIBRARY_ROOT },
-            { name: LIBRARY_RENAMING_RULE, value: RENAMING_RULE }
+            { name: LIBRARY_COMIC_RENAMING_RULE, value: COMIC_RENAMING_RULE },
+            { name: LIBRARY_PAGE_RENAMING_RULE, value: PAGE_RENAMING_RULE }
           ]
         })
       );

--- a/comixed-webui/src/app/admin/components/library-configuration/library-configuration.component.ts
+++ b/comixed-webui/src/app/admin/components/library-configuration/library-configuration.component.ts
@@ -26,7 +26,8 @@ import { LoggerService } from '@angular-ru/logger';
 import { ConfigurationOption } from '@app/admin/models/configuration-option';
 import { getConfigurationOption } from '@app/admin';
 import {
-  LIBRARY_RENAMING_RULE,
+  LIBRARY_COMIC_RENAMING_RULE,
+  LIBRARY_PAGE_RENAMING_RULE,
   LIBRARY_ROOT_DIRECTORY
 } from '@app/admin/admin.constants';
 import { saveConfigurationOptions } from '@app/admin/actions/save-configuration-options.actions';
@@ -39,25 +40,34 @@ import { saveConfigurationOptions } from '@app/admin/actions/save-configuration-
 export class LibraryConfigurationComponent implements OnInit {
   @Input() libraryConfigurationForm: FormGroup;
 
-  readonly variableOptions: ListItem<string>[] = [
+  readonly comicVariableOptions: ListItem<string>[] = [
     {
       label: '$PUBLISHER',
-      value: 'configuration.text.renaming-rule-publisher'
+      value: 'configuration.text.comic-renaming-rule-publisher'
     },
-    { label: '$SERIES', value: 'configuration.text.renaming-rule-series' },
-    { label: '$VOLUME', value: 'configuration.text.renaming-rule-volume' },
+    {
+      label: '$SERIES',
+      value: 'configuration.text.comic-renaming-rule-series'
+    },
+    {
+      label: '$VOLUME',
+      value: 'configuration.text.comic-renaming-rule-volume'
+    },
     {
       label: '$ISSUE',
-      value: 'configuration.text.renaming-rule-issue-number'
+      value: 'configuration.text.comic-renaming-rule-issue-number'
     },
     {
       label: '$COVERDATE',
-      value: 'configuration.text.renaming-rule-cover-date'
+      value: 'configuration.text.comic-renaming-rule-cover-date'
     },
     {
       label: '$PUBYEAR',
-      value: 'configuration.text.renaming-rule-published-year'
+      value: 'configuration.text.comic-renaming-rule-published-year'
     }
+  ];
+  readonly pageVariableOptions: ListItem<string>[] = [
+    { label: '$INDEX', value: 'configuration.text.page-renaming-rule-index' }
   ];
 
   constructor(
@@ -69,7 +79,8 @@ export class LibraryConfigurationComponent implements OnInit {
   ) {
     this.libraryConfigurationForm = this.formBuilder.group({
       rootDirectory: ['', [Validators.required]],
-      renamingRule: ['', []]
+      comicRenamingRule: ['', []],
+      pageRenamingRule: ['', []]
     });
   }
 
@@ -78,8 +89,11 @@ export class LibraryConfigurationComponent implements OnInit {
     this.libraryConfigurationForm.controls.rootDirectory.setValue(
       getConfigurationOption(options, LIBRARY_ROOT_DIRECTORY, '')
     );
-    this.libraryConfigurationForm.controls.renamingRule.setValue(
-      getConfigurationOption(options, LIBRARY_RENAMING_RULE, '')
+    this.libraryConfigurationForm.controls.comicRenamingRule.setValue(
+      getConfigurationOption(options, LIBRARY_COMIC_RENAMING_RULE, '')
+    );
+    this.libraryConfigurationForm.controls.pageRenamingRule.setValue(
+      getConfigurationOption(options, LIBRARY_PAGE_RENAMING_RULE, '')
     );
   }
 
@@ -110,8 +124,12 @@ export class LibraryConfigurationComponent implements OnInit {
         value: this.libraryConfigurationForm.controls.rootDirectory.value
       },
       {
-        name: LIBRARY_RENAMING_RULE,
-        value: this.libraryConfigurationForm.controls.renamingRule.value
+        name: LIBRARY_COMIC_RENAMING_RULE,
+        value: this.libraryConfigurationForm.controls.comicRenamingRule.value
+      },
+      {
+        name: LIBRARY_PAGE_RENAMING_RULE,
+        value: this.libraryConfigurationForm.controls.pageRenamingRule.value
       }
     ];
   }

--- a/comixed-webui/src/app/admin/pages/configuration-page/configuration-page.component.spec.ts
+++ b/comixed-webui/src/app/admin/pages/configuration-page/configuration-page.component.spec.ts
@@ -44,7 +44,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatDialogModule } from '@angular/material/dialog';
 import {
   COMICVINE_API_KEY,
-  LIBRARY_RENAMING_RULE
+  LIBRARY_COMIC_RENAMING_RULE
 } from '@app/admin/admin.constants';
 import { LibraryConfigurationComponent } from '@app/admin/components/library-configuration/library-configuration.component';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -61,7 +61,7 @@ import { MatCardModule } from '@angular/material/card';
 describe('ConfigurationPageComponent', () => {
   const OPTIONS = [
     { ...CONFIGURATION_OPTION_1, name: COMICVINE_API_KEY },
-    { ...CONFIGURATION_OPTION_2, name: LIBRARY_RENAMING_RULE },
+    { ...CONFIGURATION_OPTION_2, name: LIBRARY_COMIC_RENAMING_RULE },
     CONFIGURATION_OPTION_3,
     CONFIGURATION_OPTION_4,
     CONFIGURATION_OPTION_5

--- a/comixed-webui/src/assets/i18n/de/admin.json
+++ b/comixed-webui/src/assets/i18n/de/admin.json
@@ -1,12 +1,16 @@
 {
   "configuration": {
     "label": {
+      "comic-renaming-rule": "Comic Renaming Rule",
+      "comic-renaming-variables": "Comic Renaming Variables",
+      "comic-variable-description": "Description",
+      "comic-variable-name": "Variable",
       "comicvine-api-key": "ComicVine API Key",
-      "renaming-rule": "Comic Renaming Rule",
-      "renaming-variables": "Available Renaming Variables",
+      "page-renaming-rule": "Page Renaming Rule",
+      "page-renaming-variables": "Page Renaming Variables",
       "root-directory": "Library Root Directory",
-      "variable-description": "Description Of The Output",
-      "variable-name": "Variable Name"
+      "page-variable-description": "Description Of The Output",
+      "page-variable-name": "Variable Name"
     },
     "load-all": {
       "effect-failure": "Failed to load configuration options."
@@ -19,14 +23,16 @@
     },
     "tab-title": "Configuration",
     "text": {
-      "renaming-rule-cover-date": "The cover date",
-      "renaming-rule-issue-number": "The issue number",
-      "renaming-rule-published-month": "The month published",
-      "renaming-rule-published-year": "The year published",
-      "renaming-rule-publisher": "The name of the publisher",
-      "renaming-rule-series": "The name of the series",
-      "renaming-rule-volume": "The volume",
-      "variable-caption": "These are the available variables that can be used for renaming comics."
+      "comic-renaming-rule-cover-date": "The cover date",
+      "comic-renaming-rule-issue-number": "The issue number",
+      "comic-renaming-rule-published-month": "The month published",
+      "comic-renaming-rule-published-year": "The year published",
+      "comic-renaming-rule-publisher": "The name of the publisher",
+      "comic-renaming-rule-series": "The name of the series",
+      "comic-renaming-rule-volume": "The volume",
+      "comic-variable-caption": "These are the available variables that can be used for renaming comics.",
+      "page-renaming-rule-index": "The page index (1-based)",
+      "page-variable-caption": "These are the available variables that can be used for renaming pages."
     }
   },
   "filename-scraping-rules": {

--- a/comixed-webui/src/assets/i18n/en/admin.json
+++ b/comixed-webui/src/assets/i18n/en/admin.json
@@ -1,12 +1,16 @@
 {
   "configuration": {
     "label": {
+      "comic-renaming-rule": "Comic Renaming Rule",
+      "comic-renaming-variables": "Comic Renaming Variables",
+      "comic-variable-description": "Description",
+      "comic-variable-name": "Variable",
       "comicvine-api-key": "ComicVine API Key",
-      "renaming-rule": "Comic Renaming Rule",
-      "renaming-variables": "Available Renaming Variables",
+      "page-renaming-rule": "Page Renaming Rule",
+      "page-renaming-variables": "Page Renaming Variables",
       "root-directory": "Library Root Directory",
-      "variable-description": "Description Of The Output",
-      "variable-name": "Variable Name"
+      "page-variable-description": "Description Of The Output",
+      "page-variable-name": "Variable Name"
     },
     "load-all": {
       "effect-failure": "Failed to load configuration options."
@@ -19,14 +23,16 @@
     },
     "tab-title": "Configuration",
     "text": {
-      "renaming-rule-cover-date": "The cover date",
-      "renaming-rule-issue-number": "The issue number",
-      "renaming-rule-published-month": "The month published",
-      "renaming-rule-published-year": "The year published",
-      "renaming-rule-publisher": "The name of the publisher",
-      "renaming-rule-series": "The name of the series",
-      "renaming-rule-volume": "The volume",
-      "variable-caption": "These are the available variables that can be used for renaming comics."
+      "comic-renaming-rule-cover-date": "The cover date",
+      "comic-renaming-rule-issue-number": "The issue number",
+      "comic-renaming-rule-published-month": "The month published",
+      "comic-renaming-rule-published-year": "The year published",
+      "comic-renaming-rule-publisher": "The name of the publisher",
+      "comic-renaming-rule-series": "The name of the series",
+      "comic-renaming-rule-volume": "The volume",
+      "comic-variable-caption": "These are the available variables that can be used for renaming comics.",
+      "page-renaming-rule-index": "The page index (1-based)",
+      "page-variable-caption": "These are the available variables that can be used for renaming pages."
     }
   },
   "filename-scraping-rules": {

--- a/comixed-webui/src/assets/i18n/es/admin.json
+++ b/comixed-webui/src/assets/i18n/es/admin.json
@@ -1,12 +1,16 @@
 {
   "configuration": {
     "label": {
+      "comic-renaming-rule": "Comic Renaming Rule",
+      "comic-renaming-variables": "Comic Renaming Variables",
+      "comic-variable-description": "Description",
+      "comic-variable-name": "Variable",
       "comicvine-api-key": "ComicVine API Key",
-      "renaming-rule": "Comic Renaming Rule",
-      "renaming-variables": "Available Renaming Variables",
+      "page-renaming-rule": "Page Renaming Rule",
+      "page-renaming-variables": "Page Renaming Variables",
       "root-directory": "Library Root Directory",
-      "variable-description": "Description Of The Output",
-      "variable-name": "Variable Name"
+      "page-variable-description": "Description Of The Output",
+      "page-variable-name": "Variable Name"
     },
     "load-all": {
       "effect-failure": "Failed to load configuration options."
@@ -19,14 +23,16 @@
     },
     "tab-title": "Configuration",
     "text": {
-      "renaming-rule-cover-date": "The cover date",
-      "renaming-rule-issue-number": "The issue number",
-      "renaming-rule-published-month": "The month published",
-      "renaming-rule-published-year": "The year published",
-      "renaming-rule-publisher": "The name of the publisher",
-      "renaming-rule-series": "The name of the series",
-      "renaming-rule-volume": "The volume",
-      "variable-caption": "These are the available variables that can be used for renaming comics."
+      "comic-renaming-rule-cover-date": "The cover date",
+      "comic-renaming-rule-issue-number": "The issue number",
+      "comic-renaming-rule-published-month": "The month published",
+      "comic-renaming-rule-published-year": "The year published",
+      "comic-renaming-rule-publisher": "The name of the publisher",
+      "comic-renaming-rule-series": "The name of the series",
+      "comic-renaming-rule-volume": "The volume",
+      "comic-variable-caption": "These are the available variables that can be used for renaming comics.",
+      "page-renaming-rule-index": "The page index (1-based)",
+      "page-variable-caption": "These are the available variables that can be used for renaming pages."
     }
   },
   "filename-scraping-rules": {

--- a/comixed-webui/src/assets/i18n/fr/admin.json
+++ b/comixed-webui/src/assets/i18n/fr/admin.json
@@ -1,12 +1,16 @@
 {
   "configuration": {
     "label": {
+      "comic-renaming-rule": "Règle de renommage des bandes dessinées",
+      "comic-renaming-variables": "Comic Renaming Variables",
+      "comic-variable-description": "Description",
+      "comic-variable-name": "Variable",
       "comicvine-api-key": "ComicVine API Key",
-      "renaming-rule": "Règle de renommage des bandes dessinées",
-      "renaming-variables": "Variables de renommage disponibles",
+      "page-renaming-rule": "Page Renaming Rule",
+      "page-renaming-variables": "Page Renaming Variables",
       "root-directory": "Répertoire racine de la bibliothèque",
-      "variable-description": "Description du résultat",
-      "variable-name": "Nom de la variable"
+      "page-variable-description": "Description du résultat",
+      "page-variable-name": "Nom de la variable"
     },
     "load-all": {
       "effect-failure": "Échec du chargement des options de configuration."
@@ -19,14 +23,16 @@
     },
     "tab-title": "Configuration",
     "text": {
-      "renaming-rule-cover-date": "La date de couverture",
-      "renaming-rule-issue-number": "Le numéro",
-      "renaming-rule-published-month": "Le mois de publication",
-      "renaming-rule-published-year": "L'année de publication",
-      "renaming-rule-publisher": "Le nom de l'Éditeur",
-      "renaming-rule-series": "Le nom de la série",
-      "renaming-rule-volume": "Le volume",
-      "variable-caption": "Ce sont les variables disponibles qui peuvent être utilisées pour renommer les bandes dessinées."
+      "comic-renaming-rule-cover-date": "La date de couverture",
+      "comic-renaming-rule-issue-number": "Le numéro",
+      "comic-renaming-rule-published-month": "Le mois de publication",
+      "comic-renaming-rule-published-year": "L'année de publication",
+      "comic-renaming-rule-publisher": "Le nom de l'Éditeur",
+      "comic-renaming-rule-series": "Le nom de la série",
+      "comic-renaming-rule-volume": "Le volume",
+      "comic-variable-caption": "Ce sont les variables disponibles qui peuvent être utilisées pour renommer les bandes dessinées.",
+      "page-renaming-rule-index": "The page index (1-based)",
+      "page-variable-caption": "These are the available variables that can be used for renaming pages."
     }
   },
   "filename-scraping-rules": {

--- a/comixed-webui/src/assets/i18n/pt/admin.json
+++ b/comixed-webui/src/assets/i18n/pt/admin.json
@@ -1,12 +1,16 @@
 {
   "configuration": {
     "label": {
+      "comic-renaming-rule": "Comic Renaming Rule",
+      "comic-renaming-variables": "Comic Renaming Variables",
+      "comic-variable-description": "Description",
+      "comic-variable-name": "Variable",
       "comicvine-api-key": "ComicVine API Key",
-      "renaming-rule": "Comic Renaming Rule",
-      "renaming-variables": "Available Renaming Variables",
+      "page-renaming-rule": "Page Renaming Rule",
+      "page-renaming-variables": "Page Renaming Variables",
       "root-directory": "Library Root Directory",
-      "variable-description": "Description Of The Output",
-      "variable-name": "Variable Name"
+      "page-variable-description": "Description Of The Output",
+      "page-variable-name": "Variable Name"
     },
     "load-all": {
       "effect-failure": "Failed to load configuration options."
@@ -19,14 +23,16 @@
     },
     "tab-title": "Configuration",
     "text": {
-      "renaming-rule-cover-date": "The cover date",
-      "renaming-rule-issue-number": "The issue number",
-      "renaming-rule-published-month": "The month published",
-      "renaming-rule-published-year": "The year published",
-      "renaming-rule-publisher": "The name of the publisher",
-      "renaming-rule-series": "The name of the series",
-      "renaming-rule-volume": "The volume",
-      "variable-caption": "These are the available variables that can be used for renaming comics."
+      "comic-renaming-rule-cover-date": "The cover date",
+      "comic-renaming-rule-issue-number": "The issue number",
+      "comic-renaming-rule-published-month": "The month published",
+      "comic-renaming-rule-published-year": "The year published",
+      "comic-renaming-rule-publisher": "The name of the publisher",
+      "comic-renaming-rule-series": "The name of the series",
+      "comic-renaming-rule-volume": "The volume",
+      "comic-variable-caption": "These are the available variables that can be used for renaming comics.",
+      "page-renaming-rule-index": "The page index (1-based)",
+      "page-variable-caption": "These are the available variables that can be used for renaming pages."
     }
   },
   "filename-scraping-rules": {


### PR DESCRIPTION
 * Added a migration to insert a default page renaming rule.
 * Added a input for configuring the page renaming rule.
 * Added an adaptor for generating page names based on renaming rules.

Also removed the explicit page renaming flag when converting comics. Instead,
this flag is implicitly set if a page renaming rule is defined.

## Status
READY

## Does this PR contain migrations?
YES

## Before You Submit Your PR:
- [X] Have you announced your PR on the comixed-dev mailing list?
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

