### PR TITLE
Changed scraping to use the global API key [#1096]

### DIFF
--- a/comixed-model/src/main/java/org/comixedproject/model/net/library/LoadScrapingIssueRequest.java
+++ b/comixed-model/src/main/java/org/comixedproject/model/net/library/LoadScrapingIssueRequest.java
@@ -31,10 +31,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LoadScrapingIssueRequest {
-  @JsonProperty("apiKey")
-  @Getter
-  private String apiKey;
-
   @JsonProperty("skipCache")
   @Getter
   private boolean skipCache;

--- a/comixed-model/src/main/java/org/comixedproject/model/net/library/LoadScrapingVolumesRequest.java
+++ b/comixed-model/src/main/java/org/comixedproject/model/net/library/LoadScrapingVolumesRequest.java
@@ -32,10 +32,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class LoadScrapingVolumesRequest {
-  @JsonProperty("apiKey")
-  @Getter
-  private String apiKey;
-
   @JsonProperty("series")
   @Getter
   private String series;

--- a/comixed-model/src/main/java/org/comixedproject/model/net/library/ScrapeComicRequest.java
+++ b/comixed-model/src/main/java/org/comixedproject/model/net/library/ScrapeComicRequest.java
@@ -32,11 +32,6 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ScrapeComicRequest {
-  @JsonProperty("apiKey")
-  @Getter
-  @Setter
-  private String apiKey;
-
   @JsonProperty("issueId")
   @Getter
   @Setter

--- a/comixed-rest/src/main/java/org/comixedproject/rest/scraping/ScrapingController.java
+++ b/comixed-rest/src/main/java/org/comixedproject/rest/scraping/ScrapingController.java
@@ -71,12 +71,10 @@ public class ScrapingController {
       @RequestBody() final LoadScrapingIssueRequest request)
       throws ScrapingException {
     boolean skipCache = request.isSkipCache();
-    String apiKey = request.getApiKey();
 
-    log.info(
-        "Preparing to retrieve issue={} for volume={} (skipCache={})", issue, volume, skipCache);
+    log.info("Getting scraping issue");
 
-    return this.scrapingService.getIssue(apiKey, volume, issue, skipCache);
+    return this.scrapingService.getIssue(volume, issue, skipCache);
   }
 
   /**
@@ -94,18 +92,13 @@ public class ScrapingController {
   @AuditableEndpoint(logRequest = true, logResponse = true)
   public List<ScrapingVolume> loadScrapingVolumes(
       @RequestBody() final LoadScrapingVolumesRequest request) throws ScrapingException {
-    String apiKey = request.getApiKey();
     String series = request.getSeries();
     final int maxRecords = request.getMaxRecords();
     boolean skipCache = request.getSkipCache();
 
-    log.info(
-        "Getting volumes: series={} (max records={}) {}",
-        series,
-        maxRecords,
-        skipCache ? "(Skipping cache)" : "");
+    log.info("Getting scraping volumes");
 
-    return this.scrapingService.getVolumes(apiKey, series, maxRecords, skipCache);
+    return this.scrapingService.getVolumes(series, maxRecords, skipCache);
   }
 
   /**
@@ -131,11 +124,8 @@ public class ScrapingController {
       throws ScrapingException {
     boolean skipCache = request.getSkipCache();
     Integer issueId = request.getIssueId();
-    String apiKey = request.getApiKey();
 
-    log.info("Scraping code: id={} issue id={} (skip cache={})", comicId, issueId, apiKey);
-
-    log.debug("Scraping comic details");
-    return this.scrapingService.scrapeComic(apiKey, comicId, issueId, skipCache);
+    log.info("Scraping comic");
+    return this.scrapingService.scrapeComic(comicId, issueId, skipCache);
   }
 }

--- a/comixed-rest/src/test/java/org/comixedproject/rest/scraping/ScrapingControllerTest.java
+++ b/comixed-rest/src/test/java/org/comixedproject/rest/scraping/ScrapingControllerTest.java
@@ -41,7 +41,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 @RunWith(MockitoJUnitRunner.class)
 @SpringBootTest
 public class ScrapingControllerTest {
-  private static final String TEST_API_KEY = "12345";
   private static final String TEST_SERIES_NAME = "Awesome Comic";
   private static final Integer TEST_MAX_RECORDS = 37;
   private static final Integer TEST_VOLUME = 2018;
@@ -59,125 +58,112 @@ public class ScrapingControllerTest {
   @Test(expected = ScrapingException.class)
   public void testLoadScrapingVolumesAdaptorRaisesException() throws ScrapingException {
     Mockito.when(
-            scrapingService.getVolumes(
-                Mockito.anyString(), Mockito.anyString(), Mockito.anyInt(), Mockito.anyBoolean()))
+            scrapingService.getVolumes(Mockito.anyString(), Mockito.anyInt(), Mockito.anyBoolean()))
         .thenThrow(ScrapingException.class);
 
     try {
       controller.loadScrapingVolumes(
-          new LoadScrapingVolumesRequest(TEST_API_KEY, TEST_SERIES_NAME, TEST_MAX_RECORDS, false));
+          new LoadScrapingVolumesRequest(TEST_SERIES_NAME, TEST_MAX_RECORDS, false));
     } finally {
       Mockito.verify(scrapingService, Mockito.times(1))
-          .getVolumes(TEST_API_KEY, TEST_SERIES_NAME, TEST_MAX_RECORDS, false);
+          .getVolumes(TEST_SERIES_NAME, TEST_MAX_RECORDS, false);
     }
   }
 
   @Test
   public void testLoadScrapingVolumes() throws ScrapingException {
     Mockito.when(
-            scrapingService.getVolumes(
-                Mockito.anyString(), Mockito.anyString(), Mockito.anyInt(), Mockito.anyBoolean()))
+            scrapingService.getVolumes(Mockito.anyString(), Mockito.anyInt(), Mockito.anyBoolean()))
         .thenReturn(comicVolumeList);
 
     final List<ScrapingVolume> response =
         controller.loadScrapingVolumes(
-            new LoadScrapingVolumesRequest(
-                TEST_API_KEY, TEST_SERIES_NAME, TEST_MAX_RECORDS, false));
+            new LoadScrapingVolumesRequest(TEST_SERIES_NAME, TEST_MAX_RECORDS, false));
 
     assertNotNull(response);
     assertSame(comicVolumeList, response);
 
     Mockito.verify(scrapingService, Mockito.times(1))
-        .getVolumes(TEST_API_KEY, TEST_SERIES_NAME, TEST_MAX_RECORDS, false);
+        .getVolumes(TEST_SERIES_NAME, TEST_MAX_RECORDS, false);
   }
 
   @Test
   public void testLoadScrapingVolumesSkipCache() throws ScrapingException {
     Mockito.when(
-            scrapingService.getVolumes(
-                Mockito.anyString(), Mockito.anyString(), Mockito.anyInt(), Mockito.anyBoolean()))
+            scrapingService.getVolumes(Mockito.anyString(), Mockito.anyInt(), Mockito.anyBoolean()))
         .thenReturn(comicVolumeList);
 
     final List<ScrapingVolume> response =
         controller.loadScrapingVolumes(
-            new LoadScrapingVolumesRequest(TEST_API_KEY, TEST_SERIES_NAME, TEST_MAX_RECORDS, true));
+            new LoadScrapingVolumesRequest(TEST_SERIES_NAME, TEST_MAX_RECORDS, true));
 
     assertNotNull(response);
     assertSame(comicVolumeList, response);
 
     Mockito.verify(scrapingService, Mockito.times(1))
-        .getVolumes(TEST_API_KEY, TEST_SERIES_NAME, TEST_MAX_RECORDS, true);
+        .getVolumes(TEST_SERIES_NAME, TEST_MAX_RECORDS, true);
   }
 
   @Test(expected = ScrapingException.class)
   public void testLoadScrapingIssueAdaptorRaisesException() throws ScrapingException {
     Mockito.when(
-            scrapingService.getIssue(
-                Mockito.anyString(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyBoolean()))
+            scrapingService.getIssue(Mockito.anyInt(), Mockito.anyString(), Mockito.anyBoolean()))
         .thenThrow(ScrapingException.class);
 
     try {
       controller.loadScrapingIssue(
-          TEST_VOLUME,
-          TEST_ISSUE_NUMBER,
-          new LoadScrapingIssueRequest(TEST_API_KEY, TEST_SKIP_CACHE));
+          TEST_VOLUME, TEST_ISSUE_NUMBER, new LoadScrapingIssueRequest(TEST_SKIP_CACHE));
     } finally {
       Mockito.verify(scrapingService, Mockito.times(1))
-          .getIssue(TEST_API_KEY, TEST_VOLUME, TEST_ISSUE_NUMBER, TEST_SKIP_CACHE);
+          .getIssue(TEST_VOLUME, TEST_ISSUE_NUMBER, TEST_SKIP_CACHE);
     }
   }
 
   @Test
   public void testLoadScrapingIssue() throws ScrapingException {
     Mockito.when(
-            scrapingService.getIssue(
-                Mockito.anyString(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyBoolean()))
+            scrapingService.getIssue(Mockito.anyInt(), Mockito.anyString(), Mockito.anyBoolean()))
         .thenReturn(comicIssue);
 
     ScrapingIssue response =
         controller.loadScrapingIssue(
-            TEST_VOLUME,
-            TEST_ISSUE_NUMBER,
-            new LoadScrapingIssueRequest(TEST_API_KEY, TEST_SKIP_CACHE));
+            TEST_VOLUME, TEST_ISSUE_NUMBER, new LoadScrapingIssueRequest(TEST_SKIP_CACHE));
 
     assertNotNull(response);
     assertSame(comicIssue, response);
 
     Mockito.verify(scrapingService, Mockito.times(1))
-        .getIssue(TEST_API_KEY, TEST_VOLUME, TEST_ISSUE_NUMBER, TEST_SKIP_CACHE);
+        .getIssue(TEST_VOLUME, TEST_ISSUE_NUMBER, TEST_SKIP_CACHE);
   }
 
   @Test(expected = ScrapingException.class)
   public void testScrapeComicScrapingAdaptorRaisesException() throws ScrapingException {
     Mockito.when(
-            scrapingService.scrapeComic(
-                Mockito.anyString(), Mockito.anyLong(), Mockito.anyInt(), Mockito.anyBoolean()))
+            scrapingService.scrapeComic(Mockito.anyLong(), Mockito.anyInt(), Mockito.anyBoolean()))
         .thenThrow(ScrapingException.class);
 
     try {
-      controller.scrapeComic(
-          TEST_COMIC_ID, new ScrapeComicRequest(TEST_API_KEY, TEST_ISSUE_ID, TEST_SKIP_CACHE));
+      controller.scrapeComic(TEST_COMIC_ID, new ScrapeComicRequest(TEST_ISSUE_ID, TEST_SKIP_CACHE));
     } finally {
       Mockito.verify(scrapingService, Mockito.times(1))
-          .scrapeComic(TEST_API_KEY, TEST_COMIC_ID, TEST_ISSUE_ID, TEST_SKIP_CACHE);
+          .scrapeComic(TEST_COMIC_ID, TEST_ISSUE_ID, TEST_SKIP_CACHE);
     }
   }
 
   @Test
   public void testScrapeComic() throws ScrapingException {
     Mockito.when(
-            scrapingService.scrapeComic(
-                Mockito.anyString(), Mockito.anyLong(), Mockito.anyInt(), Mockito.anyBoolean()))
+            scrapingService.scrapeComic(Mockito.anyLong(), Mockito.anyInt(), Mockito.anyBoolean()))
         .thenReturn(comic);
 
     Comic response =
         controller.scrapeComic(
-            TEST_COMIC_ID, new ScrapeComicRequest(TEST_API_KEY, TEST_ISSUE_ID, TEST_SKIP_CACHE));
+            TEST_COMIC_ID, new ScrapeComicRequest(TEST_ISSUE_ID, TEST_SKIP_CACHE));
 
     assertNotNull(response);
     assertSame(comic, response);
 
     Mockito.verify(scrapingService, Mockito.times(1))
-        .scrapeComic(TEST_API_KEY, TEST_COMIC_ID, TEST_ISSUE_ID, TEST_SKIP_CACHE);
+        .scrapeComic(TEST_COMIC_ID, TEST_ISSUE_ID, TEST_SKIP_CACHE);
   }
 }

--- a/comixed-services/src/main/java/org/comixedproject/service/admin/ConfigurationService.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/admin/ConfigurationService.java
@@ -39,6 +39,7 @@ public class ConfigurationService {
   public static final String CFG_LIBRARY_ROOT_DIRECTORY = "library.root-directory";
   public static final String CFG_LIBRARY_COMIC_RENAMING_RULE = "library.comic-book.renaming-rule";
   public static final String CFG_LIBRARY_PAGE_RENAMING_RULE = "library.comic-page.renaming-rule";
+  public static final String CFG_COMICVINE_API_KEY = "comicvine.api-key";
 
   @Autowired private ConfigurationRepository configurationRepository;
 

--- a/comixed-webui/src/app/comic-books/actions/scraping.actions.ts
+++ b/comixed-webui/src/app/comic-books/actions/scraping.actions.ts
@@ -28,7 +28,6 @@ export const resetScraping = createAction(
 export const loadScrapingVolumes = createAction(
   '[Scraping] Loads scraping volumes',
   props<{
-    apiKey: string;
     series: string;
     maximumRecords: number;
     skipCache: boolean;
@@ -47,7 +46,6 @@ export const loadScrapingVolumesFailed = createAction(
 export const loadScrapingIssue = createAction(
   '[Scraping] Load a scraping issue',
   props<{
-    apiKey: string;
     volumeId: number;
     issueNumber: string;
     skipCache: boolean;
@@ -65,7 +63,7 @@ export const loadScrapingIssueFailed = createAction(
 
 export const scrapeComic = createAction(
   '[Scraping] Scrape the details for a comic',
-  props<{ apiKey: string; issueId: number; comic: Comic; skipCache: boolean }>()
+  props<{ issueId: number; comic: Comic; skipCache: boolean }>()
 );
 
 export const comicScraped = createAction(

--- a/comixed-webui/src/app/comic-books/components/comic-edit/comic-edit.component.html
+++ b/comixed-webui/src/app/comic-books/components/comic-edit/comic-edit.component.html
@@ -67,43 +67,13 @@
     mat-icon-button
     color="primary"
     [matTooltip]="'comic-book.tooltip.scrape-comic' | translate"
-    [disabled]="!comicForm.valid || !hasApiKey"
+    [disabled]="!comicForm.valid"
     (click)="onFetchScrapingVolumes()"
   >
-    <mat-icon>cloud_download</mat-icon>
+    <mat-icon>find_replace</mat-icon>
   </button>
 </mat-toolbar>
 <form *ngIf="!!comic" [formGroup]="comicForm">
-  <mat-form-field class="cx-width-100" appearance="fill">
-    <mat-label>{{ "comic-book.label.api-key" | translate }}</mat-label>
-    <button
-      id="reset-api-key-button"
-      class="cx-margin-left-5"
-      mat-icon-button
-      matPrefix
-      color="warn"
-      (click)="onResetApiKey()"
-    >
-      <mat-icon>undo</mat-icon>
-    </button>
-    <input
-      id="api-key-input"
-      id="api-key"
-      matInput
-      formControlName="apiKey"
-      [placeholder]="'comic-book.placeholder.api-key' | translate"
-    />
-    <button
-      id="save-api-key-button"
-      class="cx-margin-left-5"
-      mat-icon-button
-      matSuffix
-      color="primary"
-      (click)="onSaveApiKey()"
-    >
-      <mat-icon>save</mat-icon>
-    </button>
-  </mat-form-field>
   <mat-form-field class="cx-width-100" appearance="fill">
     <mat-label>{{ "comic-book.label.publisher" | translate }}</mat-label>
     <input
@@ -178,7 +148,7 @@
       [matTooltip]="'scraping.tooltip.use-comicvine-id' | translate"
       (click)="onScrapeUsingComicVineId()"
     >
-      <mat-icon>cloud_download</mat-icon>
+      <mat-icon>find_replace</mat-icon>
     </button>
     <mat-hint>
       {{ "comic-book.hint.useful-for-scraping" | translate }}

--- a/comixed-webui/src/app/comic-books/components/comic-edit/comic-edit.component.spec.ts
+++ b/comixed-webui/src/app/comic-books/components/comic-edit/comic-edit.component.spec.ts
@@ -39,10 +39,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatSelectModule } from '@angular/material/select';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { saveUserPreference } from '@app/user/actions/user.actions';
-import {
-  API_KEY_PREFERENCE,
-  MAXIMUM_RECORDS_PREFERENCE
-} from '@app/library/library.constants';
+import { MAXIMUM_RECORDS_PREFERENCE } from '@app/library/library.constants';
 import { updateComic } from '@app/comic-books/actions/comic.actions';
 import {
   IMPRINT_LIST_FEATURE_KEY,
@@ -58,7 +55,6 @@ import { scrapeComic } from '@app/comic-books/actions/scraping.actions';
 describe('ComicEditComponent', () => {
   const ENTRIES = [IMPRINT_1, IMPRINT_2, IMPRINT_3];
   const COMIC = COMIC_2;
-  const API_KEY = '1234567890ABCDEF';
   const SKIP_CACHE = Math.random() > 0.5;
   const MAXIMUM_RECORDS = 100;
   const ISSUE_NUMBER = '27';
@@ -96,7 +92,6 @@ describe('ComicEditComponent', () => {
 
       fixture = TestBed.createComponent(ComicEditComponent);
       component = fixture.componentInstance;
-      component.apiKey = API_KEY;
       component.maximumRecords = MAXIMUM_RECORDS;
       component.skipCache = SKIP_CACHE;
       component.comic = COMIC;
@@ -134,10 +129,6 @@ describe('ComicEditComponent', () => {
     });
   });
 
-  it('sets the API key', () => {
-    expect(component.apiKey).toEqual(API_KEY);
-  });
-
   describe('fetching the scraping volumes', () => {
     beforeEach(() => {
       spyOn(component.scrape, 'emit');
@@ -146,38 +137,11 @@ describe('ComicEditComponent', () => {
 
     it('emits an event', () => {
       expect(component.scrape.emit).toHaveBeenCalledWith({
-        apiKey: API_KEY,
         series: COMIC.series,
         volume: COMIC.volume,
         issueNumber: COMIC.issueNumber,
         maximumRecords: MAXIMUM_RECORDS,
         skipCache: SKIP_CACHE
-      });
-    });
-  });
-
-  describe('the API key', () => {
-    describe('saving it', () => {
-      beforeEach(() => {
-        component.onSaveApiKey();
-      });
-
-      it('fires an action', () => {
-        expect(store.dispatch).toHaveBeenCalledWith(
-          saveUserPreference({ name: API_KEY_PREFERENCE, value: API_KEY })
-        );
-      });
-    });
-
-    describe('resetting it', () => {
-      beforeEach(() => {
-        component.comicForm.controls.apiKey.setValue(API_KEY.substr(1));
-        fixture.detectChanges();
-        component.onResetApiKey();
-      });
-
-      it('restores the original value', () => {
-        expect(component.comicForm.controls.apiKey.value).toEqual(API_KEY);
       });
     });
   });
@@ -224,16 +188,6 @@ describe('ComicEditComponent', () => {
       expect(store.dispatch).toHaveBeenCalledWith(
         updateComic({ comic: COMIC })
       );
-    });
-  });
-
-  describe('checking for the api key', () => {
-    beforeEach(() => {
-      component.comicForm.controls.apiKey.setValue(API_KEY);
-    });
-
-    it('returns true when set', () => {
-      expect(component.hasApiKey).toBeTrue();
     });
   });
 
@@ -332,7 +286,6 @@ describe('ComicEditComponent', () => {
     it('fires an action', () => {
       expect(store.dispatch).toHaveBeenCalledWith(
         scrapeComic({
-          apiKey: API_KEY,
           issueId: COMIC.comicVineId,
           comic: COMIC,
           skipCache: SKIP_CACHE

--- a/comixed-webui/src/app/comic-books/components/comic-edit/comic-edit.component.ts
+++ b/comixed-webui/src/app/comic-books/components/comic-edit/comic-edit.component.ts
@@ -33,7 +33,6 @@ import { TranslateService } from '@ngx-translate/core';
 import { ScrapeEvent } from '@app/comic-books/models/ui/scrape-event';
 import { saveUserPreference } from '@app/user/actions/user.actions';
 import {
-  API_KEY_PREFERENCE,
   MAXIMUM_RECORDS_PREFERENCE,
   SKIP_CACHE_PREFERENCE
 } from '@app/library/library.constants';
@@ -83,7 +82,6 @@ export class ComicEditComponent implements OnInit, OnDestroy {
     private translateService: TranslateService
   ) {
     this.comicForm = this.formBuilder.group({
-      apiKey: [''],
       publisher: [''],
       series: ['', [Validators.required]],
       volume: ['', [Validators.pattern('[0-9]{4}')]],
@@ -125,17 +123,6 @@ export class ComicEditComponent implements OnInit, OnDestroy {
       });
   }
 
-  private _apiKey = '';
-
-  get apiKey(): string {
-    return this._apiKey;
-  }
-
-  @Input() set apiKey(apiKey: string) {
-    this._apiKey = apiKey;
-    this.comicForm.controls.apiKey.setValue(apiKey);
-  }
-
   private _comic: Comic;
 
   get comic(): Comic {
@@ -156,11 +143,6 @@ export class ComicEditComponent implements OnInit, OnDestroy {
     this.comicForm.controls.title.setValue(comic.title);
     this.comicForm.controls.description.setValue(comic.description);
     this.comicForm.updateValueAndValidity();
-  }
-
-  get hasApiKey(): boolean {
-    const apiKey = this.comicForm.controls.apiKey.value;
-    return !!apiKey && apiKey.length > 0;
   }
 
   ngOnDestroy(): void {
@@ -190,29 +172,12 @@ export class ComicEditComponent implements OnInit, OnDestroy {
   onFetchScrapingVolumes(): void {
     this.logger.trace('Loading scraping volumes');
     this.scrape.emit({
-      apiKey: this.comicForm.controls.apiKey.value,
       series: this.comicForm.controls.series.value,
       volume: this.comicForm.controls.volume.value,
       issueNumber: this.comicForm.controls.issueNumber.value,
       maximumRecords: this.maximumRecords,
       skipCache: this.skipCache
     });
-  }
-
-  onSaveApiKey(): void {
-    this.logger.trace('Saving the new API key');
-    this.store.dispatch(
-      saveUserPreference({
-        name: API_KEY_PREFERENCE,
-        value: this.comicForm.controls.apiKey.value
-      })
-    );
-  }
-
-  onResetApiKey(): void {
-    this.logger.trace('Resetting the API key changes');
-    this.comicForm.controls.apiKey.setValue(this.apiKey);
-    this.comicForm.controls.apiKey.markAsUntouched();
   }
 
   onSkipCacheToggle(): void {
@@ -280,7 +245,6 @@ export class ComicEditComponent implements OnInit, OnDestroy {
         this.logger.trace('Scraping issue using ComicVine ID');
         this.store.dispatch(
           scrapeComic({
-            apiKey: this.apiKey,
             issueId: this.comic.comicVineId,
             comic: this.comic,
             skipCache: this.skipCache

--- a/comixed-webui/src/app/comic-books/components/comic-scraping/comic-scraping.component.spec.ts
+++ b/comixed-webui/src/app/comic-books/components/comic-scraping/comic-scraping.component.spec.ts
@@ -66,7 +66,6 @@ describe('ComicScrapingComponent', () => {
     { ...SCRAPING_VOLUME, startYear: '1900' },
     { ...SCRAPING_VOLUME, name: SCRAPING_VOLUME.name.substr(1) }
   ];
-  const API_KEY = '1234567890ABCDEF';
   const SKIP_CACHE = Math.random() > 0.5;
   const ISSUE_NUMBER = '27';
   const COMIC = COMIC_4;
@@ -100,7 +99,6 @@ describe('ComicScrapingComponent', () => {
 
       fixture = TestBed.createComponent(ComicScrapingComponent);
       component = fixture.componentInstance;
-      component.apiKey = API_KEY;
       component.comicSeriesName = SCRAPING_VOLUME.name;
       component.comicVolume = SCRAPING_VOLUME.startYear;
       component.comicIssueNumber = ISSUE_NUMBER;
@@ -243,7 +241,6 @@ describe('ComicScrapingComponent', () => {
     it('fires an action', () => {
       expect(store.dispatch).toHaveBeenCalledWith(
         loadScrapingIssue({
-          apiKey: API_KEY,
           volumeId: SCRAPING_VOLUME.id,
           issueNumber: ISSUE_NUMBER,
           skipCache: SKIP_CACHE
@@ -269,7 +266,6 @@ describe('ComicScrapingComponent', () => {
       it('fires an action', () => {
         expect(store.dispatch).toHaveBeenCalledWith(
           scrapeComic({
-            apiKey: API_KEY,
             issueId: SCRAPING_ISSUE.id,
             comic: COMIC,
             skipCache: SKIP_CACHE

--- a/comixed-webui/src/app/comic-books/components/comic-scraping/comic-scraping.component.ts
+++ b/comixed-webui/src/app/comic-books/components/comic-scraping/comic-scraping.component.ts
@@ -70,7 +70,6 @@ export class ComicScrapingComponent implements OnDestroy, AfterViewInit {
   @Input() comicSeriesName: string;
   @Input() comicVolume: string;
   @Input() comicIssueNumber: string;
-  @Input() apiKey: string;
   @Input() skipCache = false;
   @Input() pageSize: number;
   @Input() multimode = false;
@@ -166,7 +165,6 @@ export class ComicScrapingComponent implements OnDestroy, AfterViewInit {
     this.selectedVolume = volume;
     this.store.dispatch(
       loadScrapingIssue({
-        apiKey: this.apiKey,
         volumeId: volume.id,
         issueNumber: this.comicIssueNumber,
         skipCache: this.skipCache
@@ -200,7 +198,6 @@ export class ComicScrapingComponent implements OnDestroy, AfterViewInit {
           }
           this.store.dispatch(
             scrapeComic({
-              apiKey: this.apiKey,
               issueId: this.issue.id,
               comic: this.comic,
               skipCache: this.skipCache

--- a/comixed-webui/src/app/comic-books/effects/scraping.effects.spec.ts
+++ b/comixed-webui/src/app/comic-books/effects/scraping.effects.spec.ts
@@ -48,7 +48,6 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { comicLoaded } from '@app/comic-books/actions/comic.actions';
 
 describe('ScrapingEffects', () => {
-  const API_KEY = '1234567890ABCDEF';
   const SERIES = 'The Series';
   const MAXIMUM_RECORDS = 100;
   const SKIP_CACHE = Math.random() > 0.5;
@@ -106,7 +105,6 @@ describe('ScrapingEffects', () => {
     it('fires an action on success', () => {
       const serviceResponse = VOLUMES;
       const action = loadScrapingVolumes({
-        apiKey: API_KEY,
         series: SERIES,
         maximumRecords: MAXIMUM_RECORDS,
         skipCache: SKIP_CACHE
@@ -123,7 +121,6 @@ describe('ScrapingEffects', () => {
     it('fires an action on service failure', () => {
       const serviceResponse = new HttpErrorResponse({});
       const action = loadScrapingVolumes({
-        apiKey: API_KEY,
         series: SERIES,
         maximumRecords: MAXIMUM_RECORDS,
         skipCache: SKIP_CACHE
@@ -142,7 +139,6 @@ describe('ScrapingEffects', () => {
 
     it('fires an action on general failure', () => {
       const action = loadScrapingVolumes({
-        apiKey: API_KEY,
         series: SERIES,
         maximumRecords: MAXIMUM_RECORDS,
         skipCache: SKIP_CACHE
@@ -162,7 +158,6 @@ describe('ScrapingEffects', () => {
     it('fires an action on success', () => {
       const serviceResponse = SCRAPING_ISSUE;
       const action = loadScrapingIssue({
-        apiKey: API_KEY,
         volumeId: VOLUME_ID,
         issueNumber: ISSUE_NUMBER,
         skipCache: SKIP_CACHE
@@ -179,7 +174,6 @@ describe('ScrapingEffects', () => {
     it('fires an action on service failure', () => {
       const serviceResponse = new HttpErrorResponse({});
       const action = loadScrapingIssue({
-        apiKey: API_KEY,
         volumeId: VOLUME_ID,
         issueNumber: ISSUE_NUMBER,
         skipCache: SKIP_CACHE
@@ -198,7 +192,6 @@ describe('ScrapingEffects', () => {
 
     it('fires an action on general failure', () => {
       const action = loadScrapingIssue({
-        apiKey: API_KEY,
         volumeId: VOLUME_ID,
         issueNumber: ISSUE_NUMBER,
         skipCache: SKIP_CACHE
@@ -218,7 +211,6 @@ describe('ScrapingEffects', () => {
     it('fires an action on success', () => {
       const serviceResponse = COMIC;
       const action = scrapeComic({
-        apiKey: API_KEY,
         issueId: SCRAPING_ISSUE.id,
         comic: COMIC,
         skipCache: SKIP_CACHE
@@ -237,7 +229,6 @@ describe('ScrapingEffects', () => {
     it('fires an action on service failure', () => {
       const serviceResponse = new HttpErrorResponse({});
       const action = scrapeComic({
-        apiKey: API_KEY,
         issueId: SCRAPING_ISSUE.id,
         comic: COMIC,
         skipCache: SKIP_CACHE
@@ -254,7 +245,6 @@ describe('ScrapingEffects', () => {
 
     it('fires an action on general failure', () => {
       const action = scrapeComic({
-        apiKey: API_KEY,
         issueId: SCRAPING_ISSUE.id,
         comic: COMIC,
         skipCache: SKIP_CACHE

--- a/comixed-webui/src/app/comic-books/effects/scraping.effects.ts
+++ b/comixed-webui/src/app/comic-books/effects/scraping.effects.ts
@@ -51,7 +51,6 @@ export class ScrapingEffects {
       switchMap(action =>
         this.scrapingService
           .loadScrapingVolumes({
-            apiKey: action.apiKey,
             series: action.series,
             maximumRecords: action.maximumRecords,
             skipCache: action.skipCache
@@ -89,7 +88,6 @@ export class ScrapingEffects {
       switchMap(action =>
         this.scrapingService
           .loadScrapingIssue({
-            apiKey: action.apiKey,
             volumeId: action.volumeId,
             issueNumber: action.issueNumber,
             skipCache: action.skipCache
@@ -127,7 +125,6 @@ export class ScrapingEffects {
       switchMap(action =>
         this.scrapingService
           .scrapeComic({
-            apiKey: action.apiKey,
             issueId: action.issueId,
             comic: action.comic,
             skipCache: action.skipCache

--- a/comixed-webui/src/app/comic-books/models/net/load-scraping-issue-request.ts
+++ b/comixed-webui/src/app/comic-books/models/net/load-scraping-issue-request.ts
@@ -17,6 +17,5 @@
  */
 
 export interface LoadScrapingIssueRequest {
-  apiKey: string;
   skipCache: boolean;
 }

--- a/comixed-webui/src/app/comic-books/models/net/load-scraping-volumes-request.ts
+++ b/comixed-webui/src/app/comic-books/models/net/load-scraping-volumes-request.ts
@@ -17,7 +17,6 @@
  */
 
 export interface LoadScrapingVolumesRequest {
-  apiKey: string;
   series: string;
   maxRecords: number;
   skipCache: boolean;

--- a/comixed-webui/src/app/comic-books/models/net/scrape-comic-request.ts
+++ b/comixed-webui/src/app/comic-books/models/net/scrape-comic-request.ts
@@ -17,7 +17,6 @@
  */
 
 export interface ScrapeComicRequest {
-  apiKey: string;
   issueId: number;
   skipCache: boolean;
 }

--- a/comixed-webui/src/app/comic-books/models/ui/scrape-event.ts
+++ b/comixed-webui/src/app/comic-books/models/ui/scrape-event.ts
@@ -17,7 +17,6 @@
  */
 
 export interface ScrapeEvent {
-  apiKey: string;
   series: string;
   volume: string;
   issueNumber: string;

--- a/comixed-webui/src/app/comic-books/pages/comic-book-page/comic-book-page.component.html
+++ b/comixed-webui/src/app/comic-books/pages/comic-book-page/comic-book-page.component.html
@@ -158,12 +158,10 @@
         <cx-comic-edit
           *ngIf="!!comic && volumes.length === 0"
           [comic]="comic"
-          [apiKey]="apiKey"
           [skipCache]="skipCache"
           [maximumRecords]="maximumRecords"
           (scrape)="
             onLoadScrapingVolumes(
-              $event.apiKey,
               $event.series,
               $event.volume,
               $event.issueNumber,
@@ -178,7 +176,6 @@
           [comicSeriesName]="scrapingSeriesName"
           [comicVolume]="scrapingVolume"
           [comicIssueNumber]="scrapingIssueNumber"
-          [apiKey]="apiKey"
           [skipCache]="skipCache"
           [pageSize]="pageSize"
           [volumes]="volumes"

--- a/comixed-webui/src/app/comic-books/pages/comic-book-page/comic-book-page.component.spec.ts
+++ b/comixed-webui/src/app/comic-books/pages/comic-book-page/comic-book-page.component.spec.ts
@@ -88,7 +88,6 @@ describe('ComicBookPageComponent', () => {
   const LAST_READ_ENTRY = LAST_READ_1;
   const OTHER_COMIC = COMIC_2;
   const USER = USER_READER;
-  const API_KEY = '1234567890ABCDEF';
   const SERIES = 'The Series';
   const VOLUME = '2000';
   const ISSUE_NUMBER = '27';
@@ -229,7 +228,6 @@ describe('ComicBookPageComponent', () => {
   describe('loading the scraping volumes', () => {
     beforeEach(() => {
       component.onLoadScrapingVolumes(
-        API_KEY,
         SERIES,
         VOLUME,
         ISSUE_NUMBER,
@@ -253,7 +251,6 @@ describe('ComicBookPageComponent', () => {
     it('fires an action', () => {
       expect(store.dispatch).toHaveBeenCalledWith(
         loadScrapingVolumes({
-          apiKey: API_KEY,
           series: SERIES,
           maximumRecords: MAXIMUM_RECORDS,
           skipCache: SKIP_CACHE

--- a/comixed-webui/src/app/comic-books/pages/comic-book-page/comic-book-page.component.ts
+++ b/comixed-webui/src/app/comic-books/pages/comic-book-page/comic-book-page.component.ts
@@ -31,7 +31,6 @@ import {
 } from '@app/user/user.functions';
 import { interpolate, updateQueryParam } from '@app/core';
 import {
-  API_KEY_PREFERENCE,
   MAXIMUM_RECORDS_PREFERENCE,
   PAGE_SIZE_DEFAULT,
   QUERY_PARAM_TAB,
@@ -87,7 +86,6 @@ export class ComicBookPageComponent
   displaySubscription: Subscription;
   pageSize = PAGE_SIZE_DEFAULT;
   volumesSubscription: Subscription;
-  apiKey = '';
   skipCache = false;
   maximumRecords = 0;
   volumes: ScrapingVolume[] = [];
@@ -149,11 +147,6 @@ export class ComicBookPageComponent
       this.isAdmin = isAdmin(user);
       this.logger.trace('Loading uer page size preference');
       this.pageSize = getPageSize(user);
-      this.apiKey = getUserPreference(
-        user.preferences,
-        API_KEY_PREFERENCE,
-        this.apiKey
-      );
       this.skipCache =
         getUserPreference(
           user.preferences,
@@ -224,7 +217,6 @@ export class ComicBookPageComponent
   }
 
   onLoadScrapingVolumes(
-    apiKey: string,
     series: string,
     volume: string,
     issueNumber: string,
@@ -236,7 +228,7 @@ export class ComicBookPageComponent
     this.scrapingVolume = volume;
     this.scrapingIssueNumber = issueNumber;
     this.store.dispatch(
-      loadScrapingVolumes({ apiKey, series, maximumRecords, skipCache })
+      loadScrapingVolumes({ series, maximumRecords, skipCache })
     );
   }
 

--- a/comixed-webui/src/app/comic-books/reducers/scraping.reducer.spec.ts
+++ b/comixed-webui/src/app/comic-books/reducers/scraping.reducer.spec.ts
@@ -38,7 +38,6 @@ import {
 } from '@app/comic-books/comic-books.fixtures';
 
 describe('Scraping Reducer', () => {
-  const API_KEY = '1234567890ABCDEF';
   const SERIES = 'The Series';
   const MAXIMUM_RECORDS = 100;
   const SKIP_CACHE = Math.random() > 0.5;
@@ -87,7 +86,6 @@ describe('Scraping Reducer', () => {
       state = reducer(
         { ...state, loadingRecords: false },
         loadScrapingVolumes({
-          apiKey: API_KEY,
           series: SERIES,
           maximumRecords: MAXIMUM_RECORDS,
           skipCache: SKIP_CACHE
@@ -135,7 +133,6 @@ describe('Scraping Reducer', () => {
       state = reducer(
         { ...state, loadingRecords: false },
         loadScrapingIssue({
-          apiKey: API_KEY,
           volumeId: VOLUME_ID,
           issueNumber: ISSUE_NUMBER,
           skipCache: SKIP_CACHE
@@ -183,7 +180,6 @@ describe('Scraping Reducer', () => {
       state = reducer(
         { ...state, loadingRecords: false },
         scrapeComic({
-          apiKey: API_KEY,
           comic: COMIC,
           issueId: SCRAPING_ISSUE.id,
           skipCache: SKIP_CACHE

--- a/comixed-webui/src/app/comic-books/services/scraping.service.spec.ts
+++ b/comixed-webui/src/app/comic-books/services/scraping.service.spec.ts
@@ -40,7 +40,6 @@ import { LoadScrapingIssueRequest } from '@app/comic-books/models/net/load-scrap
 import { ScrapeComicRequest } from '@app/comic-books/models/net/scrape-comic-request';
 
 describe('ScrapingService', () => {
-  const API_KEY = '1234567890ABCDEF';
   const SERIES = 'The Series';
   const MAXIMUM_RECORDS = 100;
   const SKIP_CACHE = Math.random() > 0.5;
@@ -69,7 +68,6 @@ describe('ScrapingService', () => {
   it('can load scraping volumes', () => {
     service
       .loadScrapingVolumes({
-        apiKey: API_KEY,
         series: SERIES,
         maximumRecords: MAXIMUM_RECORDS,
         skipCache: SKIP_CACHE
@@ -82,7 +80,6 @@ describe('ScrapingService', () => {
   it('can load a scraping issue', () => {
     service
       .loadScrapingIssue({
-        apiKey: API_KEY,
         volumeId: VOLUME_ID,
         issueNumber: ISSUE_NUMBER,
         skipCache: SKIP_CACHE
@@ -97,7 +94,6 @@ describe('ScrapingService', () => {
     );
     expect(req.request.method).toEqual('POST');
     expect(req.request.body).toEqual({
-      apiKey: API_KEY,
       skipCache: SKIP_CACHE
     } as LoadScrapingIssueRequest);
     req.flush(SCRAPING_ISSUE);
@@ -106,7 +102,6 @@ describe('ScrapingService', () => {
   it('can scrape a comic', () => {
     service
       .scrapeComic({
-        apiKey: API_KEY,
         issueId: SCRAPING_ISSUE.id,
         comic: COMIC,
         skipCache: SKIP_CACHE
@@ -118,7 +113,6 @@ describe('ScrapingService', () => {
     );
     expect(req.request.method).toEqual('POST');
     expect(req.request.body).toEqual({
-      apiKey: API_KEY,
       issueId: SCRAPING_ISSUE.id,
       skipCache: SKIP_CACHE
     } as ScrapeComicRequest);

--- a/comixed-webui/src/app/comic-books/services/scraping.service.ts
+++ b/comixed-webui/src/app/comic-books/services/scraping.service.ts
@@ -43,20 +43,17 @@ export class ScrapingService {
   /**
    * Retrieves volumes that match the series name being scraped.
    *
-   * @param args.apiKey the API key to use
    * @param args.series the series name
    * @param args.maximumRecords the maximum records to return
    * @param args.skipCache the skip cache flag
    */
   loadScrapingVolumes(args: {
-    apiKey: string;
     series: string;
     maximumRecords: number;
     skipCache: boolean;
   }): Observable<any> {
     this.logger.trace('Service: loading scraping volumes:', args);
     return this.http.post(interpolate(LOAD_SCRAPING_VOLUMES_URL), {
-      apiKey: args.apiKey,
       series: args.series,
       maxRecords: args.maximumRecords,
       skipCache: args.skipCache
@@ -66,13 +63,11 @@ export class ScrapingService {
   /**
    * Load a single scraping issue based on the provided details.
    *
-   * @param args.apiKey the API key
    * @param args.volumeId the volume id for the scraping issue
    * @param args.issueNumber the issue number for the comic
    * @param args.skipCache the skip cache flag
    */
   loadScrapingIssue(args: {
-    apiKey: string;
     volumeId: number;
     issueNumber: string;
     skipCache: boolean;
@@ -84,7 +79,6 @@ export class ScrapingService {
         issueNumber: args.issueNumber
       }),
       {
-        apiKey: args.apiKey,
         skipCache: args.skipCache
       } as LoadScrapingIssueRequest
     );
@@ -93,13 +87,11 @@ export class ScrapingService {
   /**
    * Scrape a single comic using the specified issue as the source.
    *
-   * @param args.apiKey the API key
    * @param args.issueId the source issue id
    * @param args.comic the comic to be updated
    * @param args.skipCache the skip cache flag
    */
   scrapeComic(args: {
-    apiKey: string;
     issueId: number;
     comic: Comic;
     skipCache: boolean;
@@ -108,7 +100,6 @@ export class ScrapingService {
     return this.http.post(
       interpolate(SCRAPE_COMIC_URL, { comicId: args.comic.id }),
       {
-        apiKey: args.apiKey,
         issueId: args.issueId,
         skipCache: args.skipCache
       } as ScrapeComicRequest

--- a/comixed-webui/src/app/interceptors/http.interceptor.ts
+++ b/comixed-webui/src/app/interceptors/http.interceptor.ts
@@ -23,7 +23,7 @@ import {
   HttpHandler,
   HttpRequest
 } from '@angular/common/http';
-import { Observable, of } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 import { LoggerService } from '@angular-ru/cdk/logger';
 import {
   HTTP_AUTHORIZATION_HEADER,
@@ -70,7 +70,7 @@ export class HttpInterceptor implements HttpInterceptor {
         if (error instanceof HttpErrorResponse) {
           this.logger.error('Error response received', error);
           if (error.status !== 401) {
-            return;
+            return throwError(error);
           }
           this.logger.info('Ensuring user is logged out');
           this.store.dispatch(logoutUser());

--- a/comixed-webui/src/app/library/components/library-toolbar/library-toolbar.component.html
+++ b/comixed-webui/src/app/library/components/library-toolbar/library-toolbar.component.html
@@ -103,7 +103,7 @@
     [matTooltip]="'library.tooltip.scrape-comics' | translate"
     (click)="onScrapeComics()"
   >
-    <mat-icon>plagiarism</mat-icon>
+    <mat-icon>find_replace</mat-icon>
   </button>
   <button
     id="rescan-comics-button"

--- a/comixed-webui/src/app/library/library.constants.ts
+++ b/comixed-webui/src/app/library/library.constants.ts
@@ -61,7 +61,6 @@ export const IMPORT_ROOT_DIRECTORY_DEFAULT = '';
 export const IMPORT_MAXIMUM_RESULTS_PREFERENCE =
   'preference.import.maximum-results';
 export const IMPORT_MAXIMUM_RESULTS_DEFAULT = 0;
-export const API_KEY_PREFERENCE = 'preference.scraping.api-key';
 export const SKIP_CACHE_PREFERENCE = 'preference.scraping.skip-cache';
 export const MAXIMUM_RECORDS_PREFERENCE = 'preference.scraping.maximum-records';
 

--- a/comixed-webui/src/app/library/pages/scraping-page/scraping-page.component.html
+++ b/comixed-webui/src/app/library/pages/scraping-page/scraping-page.component.html
@@ -26,7 +26,6 @@
     <cx-comic-edit
       *ngIf="!!currentComic && scrapingVolumes.length === 0"
       [comic]="currentComic"
-      [apiKey]="apiKey"
       [skipCache]="skipCache"
       [maximumRecords]="maximumRecords"
       [multimode]="true"
@@ -38,7 +37,6 @@
       [comicSeriesName]="currentSeries"
       [comicVolume]="currentVolume"
       [comicIssueNumber]="this.currentIssueNumber"
-      [apiKey]="apiKey"
       [skipCache]="skipCache"
       [pageSize]="pageSize"
       [multimode]="true"

--- a/comixed-webui/src/app/library/pages/scraping-page/scraping-page.component.spec.ts
+++ b/comixed-webui/src/app/library/pages/scraping-page/scraping-page.component.spec.ts
@@ -49,7 +49,6 @@ import { TitleService } from '@app/core/services/title.service';
 describe('ScrapingPageComponent', () => {
   const USER = USER_READER;
   const COMIC = COMIC_2;
-  const API_KEY = '1234567890';
   const MAXIMUM_RECORDS = 100;
   const SKIP_CACHE = Math.random() > 0.5;
   const initialState = {
@@ -125,7 +124,6 @@ describe('ScrapingPageComponent', () => {
   describe('when scraping starts', () => {
     beforeEach(() => {
       component.onScrape({
-        apiKey: API_KEY,
         series: COMIC.series,
         maximumRecords: MAXIMUM_RECORDS,
         skipCache: SKIP_CACHE,
@@ -137,7 +135,6 @@ describe('ScrapingPageComponent', () => {
     it('fires an action', () => {
       expect(store.dispatch).toHaveBeenCalledWith(
         loadScrapingVolumes({
-          apiKey: API_KEY,
           series: COMIC.series,
           maximumRecords: MAXIMUM_RECORDS,
           skipCache: SKIP_CACHE

--- a/comixed-webui/src/app/library/pages/scraping-page/scraping-page.component.ts
+++ b/comixed-webui/src/app/library/pages/scraping-page/scraping-page.component.ts
@@ -24,7 +24,6 @@ import { Store } from '@ngrx/store';
 import { selectSelectedComics } from '@app/library/selectors/library.selectors';
 import { TranslateService } from '@ngx-translate/core';
 import {
-  API_KEY_PREFERENCE,
   MAXIMUM_RECORDS_PREFERENCE,
   PAGE_SIZE_DEFAULT,
   PAGE_SIZE_PREFERENCE,
@@ -56,7 +55,6 @@ export class ScrapingPageComponent implements OnInit, OnDestroy {
   currentSeries = '';
   currentVolume = '';
   currentIssueNumber = '';
-  apiKey = '';
   skipCache = false;
   maximumRecords = 0;
   scrapingStateSubscription: Subscription;
@@ -74,7 +72,6 @@ export class ScrapingPageComponent implements OnInit, OnDestroy {
       () => this.loadTranslations()
     );
     this.userSubscription = this.store.select(selectUser).subscribe(user => {
-      this.apiKey = getUserPreference(user.preferences, API_KEY_PREFERENCE, '');
       this.skipCache =
         getUserPreference(
           user.preferences,
@@ -130,7 +127,6 @@ export class ScrapingPageComponent implements OnInit, OnDestroy {
     this.logger.trace('Fetching scraping volumes:', event);
     this.store.dispatch(
       loadScrapingVolumes({
-        apiKey: event.apiKey,
         series: event.series,
         maximumRecords: event.maximumRecords,
         skipCache: event.skipCache


### PR DESCRIPTION
 * Removed the API key from the comic edit tab.
 * Removed the API key as a request component during scraping.
 * Changed the REST APIs to fetch the key from the database.
 * Changed HTTP interceptor to throw errors received.

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [X] Have you announced your PR on the comixed-dev mailing list?
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

