### PR TITLE
Added indicators for when a comic is marked for deletion [#1038]

### DIFF
--- a/comixed-webui/src/app/comic-books/components/comic-detail-card/comic-detail-card.component.html
+++ b/comixed-webui/src/app/comic-books/components/comic-detail-card/comic-detail-card.component.html
@@ -41,10 +41,20 @@
         <mat-basic-chip
           *ngIf="comicChanged && isAdmin"
           color="warn"
-          (click)="onUpdateComicInfo(comic)"
           [matTooltip]="'comic-book.text.comic-changed' | translate"
+          (click)="onUpdateComicInfo(comic)"
         >
           <mat-icon>sync_alt</mat-icon>
+        </mat-basic-chip>
+        <mat-basic-chip
+          *ngIf="!!comic?.deletedDate"
+          color="warn"
+          [matTooltip]="
+            'comic-book.text.comic-deleted-date'
+              | translate: { date: comic.deletedDate | date }
+          "
+        >
+          <mat-icon>deleted</mat-icon>
         </mat-basic-chip>
       </mat-chip-list>
     </div>

--- a/comixed-webui/src/app/comic-books/components/comic-overview/comic-overview.component.html
+++ b/comixed-webui/src/app/comic-books/components/comic-overview/comic-overview.component.html
@@ -95,6 +95,24 @@
     </span>
   </mat-grid-tile>
 
+  <mat-grid-tile
+    *ngIf="!!comic.deletedDate"
+    class="cx-accent-light-background"
+    colspan="1"
+    rowspan="1"
+  >
+    <span class="cx-align-text-right">
+      {{ "comic-book.label.deleted-date" | translate }}
+    </span>
+  </mat-grid-tile>
+  <mat-grid-tile *ngIf="!!comic.deletedDate" colspan="3" rowspan="1">
+    <span
+      class="cx-width-100 cx-text-nowrap cx-align-text-left cx-padding-left-5"
+    >
+      {{ comic.deletedDate | date }}
+    </span>
+  </mat-grid-tile>
+
   <mat-grid-tile class="cx-accent-light-background" colspan="1" rowspan="1">
     <span class="cx-align-text-right">
       {{ "comic-book.label.filename" | translate }}

--- a/comixed-webui/src/assets/i18n/de/comic-books.json
+++ b/comixed-webui/src/assets/i18n/de/comic-books.json
@@ -32,6 +32,7 @@
       "comicvine-id": "ComicVine ID",
       "comicvine-issue-details": "Comic Details Page",
       "credits": "Creative Team ({count})",
+      "deleted-date": "Maked For Deletion",
       "description": "Issue Description",
       "file-details": "Comic File Details",
       "filename": "Filename",
@@ -82,6 +83,7 @@
     },
     "text": {
       "comic-changed": "Write metadata to the comic file.",
+      "comic-deleted-date": "Comic marked as deleted on {date}.",
       "comicvine-issue-link": "ComicVine Details Page",
       "filesize": "{size, plural, =1{One byte} other{# bytes}}",
       "no-matching-volumes": "No matching volumes were found...",

--- a/comixed-webui/src/assets/i18n/en/comic-books.json
+++ b/comixed-webui/src/assets/i18n/en/comic-books.json
@@ -32,6 +32,7 @@
       "comicvine-id": "ComicVine ID",
       "comicvine-issue-details": "Comic Details Page",
       "credits": "Creative Team ({count})",
+      "deleted-date": "Maked For Deletion",
       "description": "Issue Description",
       "file-details": "Comic File Details",
       "filename": "Filename",
@@ -80,6 +81,7 @@
     },
     "text": {
       "comic-changed": "Write metadata to the comic file.",
+      "comic-deleted-date": "Comic marked as deleted on {date}.",
       "comicvine-issue-link": "ComicVine Details Page",
       "filesize": "{size, plural, =1{One byte} other{# bytes}}",
       "no-matching-volumes": "No matching volumes were found...",

--- a/comixed-webui/src/assets/i18n/es/comic-books.json
+++ b/comixed-webui/src/assets/i18n/es/comic-books.json
@@ -32,6 +32,7 @@
       "comicvine-id": "ComicVine ID",
       "comicvine-issue-details": "Comic Details Page",
       "credits": "Equipo creativo ({count})",
+      "deleted-date": "Maked For Deletion",
       "description": "Descripción de la edición",
       "file-details": "Detalles del archivo cómico",
       "filename": "Nombre de archivo",
@@ -80,6 +81,7 @@
     },
     "text": {
       "comic-changed": "Write metadata to the comic file.",
+      "comic-deleted-date": "Comic marked as deleted on {date}.",
       "comicvine-issue-link": "ComicVine Details Page",
       "filesize": "{size, plural, =1{One byte} other{# bytes}}",
       "no-matching-volumes": "No matching volumes were found...",

--- a/comixed-webui/src/assets/i18n/fr/comic-books.json
+++ b/comixed-webui/src/assets/i18n/fr/comic-books.json
@@ -32,6 +32,7 @@
       "comicvine-id": "ComicVine ID",
       "comicvine-issue-details": "Page de détails de Bande Dessinée",
       "credits": "Équipe créative ({count})",
+      "deleted-date": "Maked For Deletion",
       "description": "Description de ce numéro",
       "file-details": "Détails du fichier de la Bande Dessinée",
       "filename": "Nom du fichier",
@@ -80,6 +81,7 @@
     },
     "text": {
       "comic-changed": "Écrire les métadonnées dans le fichier de la bande dessinée.",
+      "comic-deleted-date": "Comic marked as deleted on {date}.",
       "comicvine-issue-link": "Page de détails de ComicVine",
       "filesize": "{size, plural, =1{Un byte} other{# bytes}}",
       "no-matching-volumes": "No matching volumes were found...",

--- a/comixed-webui/src/assets/i18n/pt/comic-books.json
+++ b/comixed-webui/src/assets/i18n/pt/comic-books.json
@@ -32,6 +32,7 @@
       "comicvine-id": "ComicVine ID",
       "comicvine-issue-details": "Comic Details Page",
       "credits": "Creative Team ({count})",
+      "deleted-date": "Maked For Deletion",
       "description": "Issue Description",
       "file-details": "Comic File Details",
       "filename": "Filename",
@@ -80,6 +81,7 @@
     },
     "text": {
       "comic-changed": "Write metadata to the comic file.",
+      "comic-deleted-date": "Comic marked as deleted on {date}.",
       "comicvine-issue-link": "ComicVine Details Page",
       "filesize": "{size, plural, =1{One byte} other{# bytes}}",
       "no-matching-volumes": "No matching volumes were found...",


### PR DESCRIPTION
 * Added a button to the comic cover view to indicate deletion.
 * Added an overview row stating the date a comic was marked.

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [X] Have you announced your PR on the comixed-dev mailing list?
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

