### PR TITLE
Added padding the issue number in renaming rules [#512]

### DIFF
--- a/comixed-adaptors/src/test/java/org/comixedproject/adaptors/comicbooks/ComicFileAdaptorTest.java
+++ b/comixed-adaptors/src/test/java/org/comixedproject/adaptors/comicbooks/ComicFileAdaptorTest.java
@@ -49,10 +49,13 @@ public class ComicFileAdaptorTest {
   private static final String TEST_RELATIVE_NAME_WITHOUT_RULE = TEST_COMIC_FILENAME;
   private static final String TEST_RENAMING_RULE =
       "$PUBLISHER/$SERIES/$VOLUME/$SERIES v$VOLUME #$ISSUE $PUBMONTH $PUBYEAR $COVERDATE";
+  private static final String TEST_RENAMING_RULE_PADDED_ISSUE =
+      "$PUBLISHER/$SERIES/$VOLUME/$SERIES v$VOLUME #$ISSUE(8) $PUBMONTH $PUBYEAR $COVERDATE";
   private static final String TEST_PUBLISHER = "The Publisher";
   private static final String TEST_SERIES = "The Series";
   private static final String TEST_VOLUME = "2020";
   private static final String TEST_ISSUE = "717";
+  private static final String TEST_PADDED_ISSUE = "00000717";
   private static final Date TEST_COVER_DATE = new Date(120, 6, 1);
   private static final LocalDate TEST_COVER_DATE_LOCALDATE =
       TEST_COVER_DATE.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
@@ -106,6 +109,23 @@ public class ComicFileAdaptorTest {
             TEST_SERIES,
             TEST_VOLUME,
             TEST_ISSUE,
+            TEST_FORMATTED_COVER_DATE,
+            TEST_PUBLISHED_MONTH,
+            TEST_PUBLISHED_YEAR,
+            TEST_EXTENSION),
+        result);
+  }
+
+  @Test
+  public void testCreateFileFromRulePaddedIssue() {
+    final String result = adaptor.createFilenameFromRule(comic, TEST_RENAMING_RULE_PADDED_ISSUE);
+
+    assertEquals(
+        formattedName(
+            TEST_PUBLISHER,
+            TEST_SERIES,
+            TEST_VOLUME,
+            TEST_PADDED_ISSUE,
             TEST_FORMATTED_COVER_DATE,
             TEST_PUBLISHED_MONTH,
             TEST_PUBLISHED_YEAR,

--- a/comixed-webui/src/app/admin/components/library-configuration/library-configuration.component.ts
+++ b/comixed-webui/src/app/admin/components/library-configuration/library-configuration.component.ts
@@ -58,6 +58,10 @@ export class LibraryConfigurationComponent {
       value: 'configuration.text.comic-renaming-rule-issue-number'
     },
     {
+      label: '$ISSUE(8)',
+      value: 'configuration.text.comic-renaming-rule-issue-number-with-length'
+    },
+    {
       label: '$COVERDATE',
       value: 'configuration.text.comic-renaming-rule-cover-date'
     },

--- a/comixed-webui/src/assets/i18n/de/admin.json
+++ b/comixed-webui/src/assets/i18n/de/admin.json
@@ -25,6 +25,7 @@
     "text": {
       "comic-renaming-rule-cover-date": "The cover date",
       "comic-renaming-rule-issue-number": "The issue number",
+      "comic-renaming-rule-issue-number-with-length": "The issue number with a minimum length",
       "comic-renaming-rule-published-month": "The month published",
       "comic-renaming-rule-published-year": "The year published",
       "comic-renaming-rule-publisher": "The name of the publisher",
@@ -67,7 +68,7 @@
     "database-status": {
       "title": "Database Status"
     },
-    "disk-status":  {
+    "disk-status": {
       "exists": "Exists: {exists}",
       "free-space": "Free Space: {size}MB",
       "total-space": "Total Space: {size}MB",

--- a/comixed-webui/src/assets/i18n/en/admin.json
+++ b/comixed-webui/src/assets/i18n/en/admin.json
@@ -25,6 +25,7 @@
     "text": {
       "comic-renaming-rule-cover-date": "The cover date",
       "comic-renaming-rule-issue-number": "The issue number",
+      "comic-renaming-rule-issue-number-with-length": "The issue number with a minimum length",
       "comic-renaming-rule-published-month": "The month published",
       "comic-renaming-rule-published-year": "The year published",
       "comic-renaming-rule-publisher": "The name of the publisher",

--- a/comixed-webui/src/assets/i18n/es/admin.json
+++ b/comixed-webui/src/assets/i18n/es/admin.json
@@ -25,6 +25,7 @@
     "text": {
       "comic-renaming-rule-cover-date": "The cover date",
       "comic-renaming-rule-issue-number": "The issue number",
+      "comic-renaming-rule-issue-number-with-length": "The issue number with a minimum length",
       "comic-renaming-rule-published-month": "The month published",
       "comic-renaming-rule-published-year": "The year published",
       "comic-renaming-rule-publisher": "The name of the publisher",

--- a/comixed-webui/src/assets/i18n/fr/admin.json
+++ b/comixed-webui/src/assets/i18n/fr/admin.json
@@ -25,6 +25,7 @@
     "text": {
       "comic-renaming-rule-cover-date": "La date de couverture",
       "comic-renaming-rule-issue-number": "Le numéro",
+      "comic-renaming-rule-issue-number-with-length": "The issue number with a minimum length",
       "comic-renaming-rule-published-month": "Le mois de publication",
       "comic-renaming-rule-published-year": "L'année de publication",
       "comic-renaming-rule-publisher": "Le nom de l'Éditeur",

--- a/comixed-webui/src/assets/i18n/pt/admin.json
+++ b/comixed-webui/src/assets/i18n/pt/admin.json
@@ -25,6 +25,7 @@
     "text": {
       "comic-renaming-rule-cover-date": "The cover date",
       "comic-renaming-rule-issue-number": "The issue number",
+      "comic-renaming-rule-issue-number-with-length": "The issue number with a minimum length",
       "comic-renaming-rule-published-month": "The month published",
       "comic-renaming-rule-published-year": "The year published",
       "comic-renaming-rule-publisher": "The name of the publisher",


### PR DESCRIPTION
Closes #512 

Also added a second example to the configuration page to
let admins know they can specify a length.

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [X] Have you announced your PR on the comixed-dev mailing list?
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

