### PR TITLE
Fixed multibyte issue with MySQL and metadata [#1211]

### DIFF
--- a/comixed-model/src/main/resources/db/migrations/1.0.0/005_1211_fix_metadata_cache_entry_column_type.xml
+++ b/comixed-model/src/main/resources/db/migrations/1.0.0/005_1211_fix_metadata_cache_entry_column_type.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="005_1211_fix_metadata_cache_entry_column_type.xml"
+             author="mcpierce">
+
+    <sql dbms="mysql">
+      ALTER TABLE MetadataCacheEntries CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    </sql>
+
+  </changeSet>
+</databaseChangeLog>

--- a/comixed-model/src/main/resources/db/migrations/1.0.0/changelog-1.0.0.xml
+++ b/comixed-model/src/main/resources/db/migrations/1.0.0/changelog-1.0.0.xml
@@ -10,5 +10,6 @@
   <include file="/db/migrations/1.0.0/002_1152_add_metadata_source_to_comic.xml"/>
   <include file="/db/migrations/1.0.0/003_1145_remove_comic_deleted_date.xml"/>
   <include file="/db/migrations/1.0.0/004_439_add_metadata_audit_log.xml"/>
+  <include file="/db/migrations/1.0.0/005_1211_fix_metadata_cache_entry_column_type.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
Had to convert the MetadataCacheEntries table to use
utf8mb4 on MySQL databases.

Closes #1211 

## Status
READY

## Does this PR contain migrations?
YES

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

