### PR TITLE
Fixed the entry IDs for feeds [#1227]

### DIFF
--- a/comixed-model/src/main/java/org/comixedproject/model/comicbooks/Credit.java
+++ b/comixed-model/src/main/java/org/comixedproject/model/comicbooks/Credit.java
@@ -37,6 +37,7 @@ public class Credit {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @JsonView({View.ComicListView.class, View.AuditLogEntryDetail.class})
+  @Getter
   private Long id;
 
   @ManyToOne

--- a/comixed-opds/src/main/java/org/comixedproject/opds/model/CollectionFeedEntry.java
+++ b/comixed-opds/src/main/java/org/comixedproject/opds/model/CollectionFeedEntry.java
@@ -1,6 +1,6 @@
 /*
  * ComiXed - A digital comic book library management application.
- * Copyright (C) 2021, The ComiXed Project
+ * Copyright (C) 2022, The ComiXed Project
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,25 +18,18 @@
 
 package org.comixedproject.opds.model;
 
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 /**
- * <code>OPDSAuthor</code> is an author for content on a {@link OPDSFeedEntry}.
+ * <code>CollectionFeedEntry</code> is used to generate an OPDS feed.
  *
  * @author Darryl L. Pierce
  */
 @RequiredArgsConstructor
-public class OPDSAuthor {
-  @JacksonXmlProperty(localName = "name")
-  @Getter
-  @NonNull
-  private String name;
+public class CollectionFeedEntry {
+  @Getter @NonNull private String name;
 
-  @JacksonXmlProperty(localName = "uri")
-  @Getter
-  @NonNull
-  private String uri;
+  @Getter @NonNull private Long id;
 }

--- a/comixed-opds/src/main/java/org/comixedproject/opds/model/OPDSAcquisitionFeed.java
+++ b/comixed-opds/src/main/java/org/comixedproject/opds/model/OPDSAcquisitionFeed.java
@@ -1,5 +1,7 @@
 package org.comixedproject.opds.model;
 
+import lombok.NonNull;
+
 /**
  * <code>OPDSAcquisitionFeed</code> provides a {@link OPDSFeed} that represents an acquisition feed.
  *
@@ -9,7 +11,7 @@ public class OPDSAcquisitionFeed extends OPDSFeed<OPDSAcquisitionFeedEntry> {
   public static final String ACQUISITION_FEED_LINK_TYPE =
       "application/atom+xml; profile=opds-catalog; kind=acquisition";
 
-  public OPDSAcquisitionFeed(final String title) {
-    super(title);
+  public OPDSAcquisitionFeed(@NonNull final String title, @NonNull final String id) {
+    super(title, id);
   }
 }

--- a/comixed-opds/src/main/java/org/comixedproject/opds/model/OPDSAcquisitionFeedEntry.java
+++ b/comixed-opds/src/main/java/org/comixedproject/opds/model/OPDSAcquisitionFeedEntry.java
@@ -36,7 +36,7 @@ public class OPDSAcquisitionFeedEntry extends OPDSFeedEntry<OPDSAcquisitionFeedC
   @Setter
   private String summary;
 
-  public OPDSAcquisitionFeedEntry(@NonNull final String title) {
-    super(title);
+  public OPDSAcquisitionFeedEntry(@NonNull final String title, @NonNull final String id) {
+    super(title, id);
   }
 }

--- a/comixed-opds/src/main/java/org/comixedproject/opds/model/OPDSFeed.java
+++ b/comixed-opds/src/main/java/org/comixedproject/opds/model/OPDSFeed.java
@@ -30,7 +30,6 @@ import java.util.List;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.comixedproject.opds.utils.OPDSUtils;
 
 /**
  * <code>OPDSFeed</code> contains the content for a feed request.
@@ -46,6 +45,11 @@ public abstract class OPDSFeed<E extends OPDSFeedEntry> {
   @NonNull
   private String title;
 
+  @JacksonXmlProperty(localName = "id")
+  @Getter
+  @NonNull
+  private String id;
+
   @JacksonXmlProperty(localName = "icon")
   @Getter
   @NonNull
@@ -53,7 +57,7 @@ public abstract class OPDSFeed<E extends OPDSFeedEntry> {
 
   @JacksonXmlProperty(localName = "author")
   @Getter
-  private OPDSAuthor author = new OPDSAuthor("ComiXed");
+  private OPDSAuthor author = new OPDSAuthor("ComiXed", "0");
 
   @JacksonXmlProperty(localName = "updated")
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
@@ -74,14 +78,4 @@ public abstract class OPDSFeed<E extends OPDSFeedEntry> {
   @JacksonXmlProperty(localName = "entry")
   @Getter
   private List<E> entries = new ArrayList<>();
-
-  private String id;
-
-  @JacksonXmlProperty(localName = "id")
-  public String getId() {
-    if (this.id == null) {
-      this.id = OPDSUtils.generateID();
-    }
-    return this.id;
-  }
 }

--- a/comixed-opds/src/main/java/org/comixedproject/opds/model/OPDSFeedEntry.java
+++ b/comixed-opds/src/main/java/org/comixedproject/opds/model/OPDSFeedEntry.java
@@ -29,7 +29,6 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
-import org.comixedproject.opds.utils.OPDSUtils;
 
 /**
  * <code>OPDSFeedEntry</code> defines a type that is an entry in an OPDS feed.
@@ -43,6 +42,11 @@ public abstract class OPDSFeedEntry<C extends OPDSFeedContent> {
   @Getter
   @NonNull
   private String title;
+
+  @JacksonXmlProperty(localName = "id")
+  @Getter
+  @NonNull
+  private String id;
 
   @Override
   public boolean equals(final Object o) {
@@ -77,14 +81,4 @@ public abstract class OPDSFeedEntry<C extends OPDSFeedContent> {
   @JacksonXmlProperty(localName = "link")
   @Getter
   private List<OPDSLink> links = new ArrayList<>();
-
-  private String id;
-
-  @JacksonXmlProperty(localName = "id")
-  public String getId() {
-    if (this.id == null) {
-      this.id = OPDSUtils.generateID();
-    }
-    return this.id;
-  }
 }

--- a/comixed-opds/src/main/java/org/comixedproject/opds/model/OPDSNavigationFeed.java
+++ b/comixed-opds/src/main/java/org/comixedproject/opds/model/OPDSNavigationFeed.java
@@ -18,6 +18,8 @@
 
 package org.comixedproject.opds.model;
 
+import lombok.NonNull;
+
 /**
  * <code>OPDSNavigationFeed</code> provides a navigation feed.
  *
@@ -27,7 +29,7 @@ public class OPDSNavigationFeed extends OPDSFeed<OPDSNavigationFeedEntry> {
   public static final String NAVIGATION_FEED_LINK_TYPE =
       "application/atom+xml; profile=opds-catalog; kind=navigation";
 
-  public OPDSNavigationFeed(final String title) {
-    super(title);
+  public OPDSNavigationFeed(@NonNull final String title, @NonNull final String id) {
+    super(title, id);
   }
 }

--- a/comixed-opds/src/main/java/org/comixedproject/opds/model/OPDSNavigationFeedEntry.java
+++ b/comixed-opds/src/main/java/org/comixedproject/opds/model/OPDSNavigationFeedEntry.java
@@ -26,7 +26,7 @@ import lombok.NonNull;
  * @author Darryl L. Pierce
  */
 public class OPDSNavigationFeedEntry extends OPDSFeedEntry<OPDSNavigationFeedContent> {
-  public OPDSNavigationFeedEntry(@NonNull final String title) {
-    super(title);
+  public OPDSNavigationFeedEntry(@NonNull final String title, @NonNull final String id) {
+    super(title, id);
   }
 }

--- a/comixed-opds/src/main/java/org/comixedproject/opds/rest/OPDSCollectionController.java
+++ b/comixed-opds/src/main/java/org/comixedproject/opds/rest/OPDSCollectionController.java
@@ -20,10 +20,10 @@ package org.comixedproject.opds.rest;
 
 import static org.comixedproject.opds.model.OPDSAcquisitionFeed.ACQUISITION_FEED_LINK_TYPE;
 import static org.comixedproject.opds.model.OPDSNavigationFeed.NAVIGATION_FEED_LINK_TYPE;
-import static org.comixedproject.opds.rest.OPDSLibraryController.SELF;
-import static org.comixedproject.opds.rest.OPDSLibraryController.SUBSECTION;
+import static org.comixedproject.opds.rest.OPDSLibraryController.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang.StringUtils;
@@ -71,27 +71,66 @@ public class OPDSCollectionController {
       case publishers:
         return createCollectionFeed(
             collectionType,
-            new OPDSNavigationFeed("Publishers"),
-            this.comicService.getAllPublishers());
+            new OPDSNavigationFeed("Publishers", String.valueOf(PUBLISHERS_ID)),
+            PUBLISHERS_ID,
+            this.comicService.getAllPublishers().stream()
+                .map(
+                    publisher ->
+                        new CollectionFeedEntry(
+                            publisher, Long.valueOf(("PUBLISHER" + publisher).hashCode())))
+                .collect(Collectors.toUnmodifiableList()));
       case series:
         return createCollectionFeed(
-            collectionType, new OPDSNavigationFeed("Series"), this.comicService.getAllSeries());
+            collectionType,
+            new OPDSNavigationFeed("Series", String.valueOf(SERIES_ID)),
+            SERIES_ID,
+            this.comicService.getAllSeries().stream()
+                .map(
+                    series ->
+                        new CollectionFeedEntry(
+                            series, Long.valueOf(("SERIES" + series).hashCode())))
+                .collect(Collectors.toUnmodifiableList()));
       case characters:
         return createCollectionFeed(
             collectionType,
-            new OPDSNavigationFeed("Characters"),
-            this.comicService.getAllCharacters());
+            new OPDSNavigationFeed("Characters", String.valueOf(CHARACTERS_ID)),
+            CHARACTERS_ID,
+            this.comicService.getAllCharacters().stream()
+                .map(
+                    character ->
+                        new CollectionFeedEntry(
+                            character, Long.valueOf(("CHARACTER" + character).hashCode())))
+                .collect(Collectors.toUnmodifiableList()));
       case teams:
         return createCollectionFeed(
-            collectionType, new OPDSNavigationFeed("Teams"), this.comicService.getAllTeams());
+            collectionType,
+            new OPDSNavigationFeed("Teams", String.valueOf(TEAMS_ID)),
+            TEAMS_ID,
+            this.comicService.getAllTeams().stream()
+                .map(
+                    team -> new CollectionFeedEntry(team, Long.valueOf(("TEAM" + team).hashCode())))
+                .collect(Collectors.toUnmodifiableList()));
       case locations:
         return createCollectionFeed(
             collectionType,
-            new OPDSNavigationFeed("Locations"),
-            this.comicService.getAllLocations());
+            new OPDSNavigationFeed("Locations", String.valueOf(LOCATIONS_ID)),
+            LOCATIONS_ID,
+            this.comicService.getAllLocations().stream()
+                .map(
+                    location ->
+                        new CollectionFeedEntry(
+                            location, Long.valueOf(("LOCATION" + location).hashCode())))
+                .collect(Collectors.toUnmodifiableList()));
       case stories:
         return createCollectionFeed(
-            collectionType, new OPDSNavigationFeed("Stories"), this.comicService.getAllStories());
+            collectionType,
+            new OPDSNavigationFeed("Stories", String.valueOf(STORIES_ID)),
+            STORIES_ID,
+            this.comicService.getAllStories().stream()
+                .map(
+                    story ->
+                        new CollectionFeedEntry(story, Long.valueOf(("STORY" + story).hashCode())))
+                .collect(Collectors.toUnmodifiableList()));
     }
     throw new OPDSException("Failed to process collection: " + collectionType);
   }
@@ -99,16 +138,19 @@ public class OPDSCollectionController {
   private OPDSNavigationFeed createCollectionFeed(
       final CollectionType collectionType,
       final OPDSNavigationFeed feed,
-      final List<String> entries) {
+      final long entryOffset,
+      final List<CollectionFeedEntry> entries) {
     entries.forEach(
-        entryName -> {
-          String name = entryName;
+        entry -> {
+          String name = entry.getName();
+          final Long id = entry.getId();
           if (StringUtils.isEmpty(name)) {
             name = UNNAMED;
           }
-          log.trace("Adding {} link: {}", collectionType, name);
-          final OPDSNavigationFeedEntry entry = new OPDSNavigationFeedEntry(name);
-          entry
+          log.trace("Adding {} link: id={} name={}", collectionType, id, name);
+          final OPDSNavigationFeedEntry feedEntry =
+              new OPDSNavigationFeedEntry(name, String.valueOf(entryOffset + id));
+          feedEntry
               .getLinks()
               .add(
                   new OPDSLink(
@@ -117,7 +159,7 @@ public class OPDSCollectionController {
                       String.format(
                           "/opds/collections/%s/%s/",
                           collectionType, OPDSUtils.urlEncodeString(name))));
-          feed.getEntries().add(entry);
+          feed.getEntries().add(feedEntry);
         });
     feed.getLinks()
         .add(
@@ -149,27 +191,32 @@ public class OPDSCollectionController {
     switch (collectionType) {
       case publishers:
         return this.createCollectionEntriesFeed(
-            new OPDSAcquisitionFeed(String.format("Publisher: %s", nameValue)),
+            new OPDSAcquisitionFeed(
+                String.format("Publisher: %s", nameValue), String.valueOf(PUBLISHERS_ID)),
             this.comicService.getAllForPublisher(nameValue));
       case series:
         return this.createCollectionEntriesFeed(
-            new OPDSAcquisitionFeed(String.format("Series: %s", nameValue)),
+            new OPDSAcquisitionFeed(
+                String.format("Series: %s", nameValue), String.valueOf(SERIES_ID)),
             this.comicService.getAllForSeries(nameValue));
       case characters:
         return this.createCollectionEntriesFeed(
-            new OPDSAcquisitionFeed(String.format("Character: %s", nameValue)),
+            new OPDSAcquisitionFeed(
+                String.format("Character: %s", nameValue), String.valueOf(CHARACTERS_ID)),
             this.comicService.getAllForCharacter(nameValue));
       case teams:
         return this.createCollectionEntriesFeed(
-            new OPDSAcquisitionFeed(String.format("Team: %s", nameValue)),
+            new OPDSAcquisitionFeed(String.format("Team: %s", nameValue), String.valueOf(TEAMS_ID)),
             this.comicService.getAllForTeam(nameValue));
       case locations:
         return this.createCollectionEntriesFeed(
-            new OPDSAcquisitionFeed(String.format("Location: %s", nameValue)),
+            new OPDSAcquisitionFeed(
+                String.format("Location: %s", nameValue), String.valueOf(LOCATIONS_ID)),
             this.comicService.getAllForLocation(nameValue));
       case stories:
         return this.createCollectionEntriesFeed(
-            new OPDSAcquisitionFeed(String.format("Story: %s", nameValue)),
+            new OPDSAcquisitionFeed(
+                String.format("Story: %s", nameValue), String.valueOf(STORIES_ID)),
             this.comicService.getAllForStory(nameValue));
     }
     throw new OPDSException("Failed to process collection entries: " + collectionType);

--- a/comixed-opds/src/main/java/org/comixedproject/opds/rest/OPDSLibraryController.java
+++ b/comixed-opds/src/main/java/org/comixedproject/opds/rest/OPDSLibraryController.java
@@ -43,6 +43,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class OPDSLibraryController {
   public static final String SUBSECTION = "subsection";
   public static final String SELF = "self";
+  private static final String ROOT_ID = "1";
+  private static final String LIBRARY_ID = "10";
+  static final long PUBLISHERS_ID = 11L;
+  static final long SERIES_ID = 12L;
+  static final long CHARACTERS_ID = 13L;
+  static final long TEAMS_ID = 14L;
+  static final long LOCATIONS_ID = 15L;
+  static final long STORIES_ID = 16L;
 
   /**
    * Returns the root feed.
@@ -55,17 +63,17 @@ public class OPDSLibraryController {
   @ResponseBody
   public OPDSNavigationFeed getRootFeed() {
     log.info("Fetching root navigation feed");
-    final OPDSNavigationFeed response = new OPDSNavigationFeed("Comixed Comics Catalog");
+    final OPDSNavigationFeed response = new OPDSNavigationFeed("Comixed Comics Catalog", ROOT_ID);
     response.getLinks().add(new OPDSLink(NAVIGATION_FEED_LINK_TYPE, SELF, "/opds/"));
     log.trace("Adding library root feed");
     OPDSNavigationFeedEntry entry;
     // add the library link
-    entry = new OPDSNavigationFeedEntry("Library");
+    entry = new OPDSNavigationFeedEntry("Library", "1");
     entry.setContent(new OPDSNavigationFeedContent("The library root"));
     entry.getLinks().add(new OPDSLink(ACQUISITION_FEED_LINK_TYPE, SUBSECTION, "/opds/library/"));
     response.getEntries().add(entry);
     // add the reading lists link
-    entry = new OPDSNavigationFeedEntry("Reading Lists");
+    entry = new OPDSNavigationFeedEntry("Reading Lists", "2");
     entry.setContent(new OPDSNavigationFeedContent("Your reading lists"));
     entry.getLinks().add(new OPDSLink(ACQUISITION_FEED_LINK_TYPE, SUBSECTION, "/opds/lists/"));
     response.getEntries().add(entry);
@@ -83,47 +91,52 @@ public class OPDSLibraryController {
   @ResponseBody
   public OPDSNavigationFeed getLibraryFeed() {
     log.info("Fetching the library root feed");
-    final OPDSNavigationFeed response = new OPDSNavigationFeed("Library");
+    final OPDSNavigationFeed response = new OPDSNavigationFeed("Library", LIBRARY_ID);
     response.getLinks().add(new OPDSLink(NAVIGATION_FEED_LINK_TYPE, SELF, "/opds/library/"));
     OPDSNavigationFeedEntry entry;
     log.trace("Adding publishers link");
-    entry = new OPDSNavigationFeedEntry("Publishers");
-    entry.setContent(new OPDSNavigationFeedContent("For Publishers"));
+    entry = new OPDSNavigationFeedEntry("Publishers", String.valueOf(PUBLISHERS_ID));
+    entry.setContent(new OPDSNavigationFeedContent("All Publishers"));
     entry
         .getLinks()
         .add(new OPDSLink(ACQUISITION_FEED_LINK_TYPE, SUBSECTION, "/opds/collections/publishers/"));
     response.getEntries().add(entry);
 
     log.trace("Adding series link");
-    entry = new OPDSNavigationFeedEntry("Series");
+    entry = new OPDSNavigationFeedEntry("Series", String.valueOf(SERIES_ID));
+    entry.setContent(new OPDSNavigationFeedContent("All Series"));
     entry
         .getLinks()
         .add(new OPDSLink(ACQUISITION_FEED_LINK_TYPE, SUBSECTION, "/opds/collections/series/"));
     response.getEntries().add(entry);
 
     log.trace("Adding characters link");
-    entry = new OPDSNavigationFeedEntry("Characters");
+    entry = new OPDSNavigationFeedEntry("Characters", String.valueOf(CHARACTERS_ID));
+    entry.setContent(new OPDSNavigationFeedContent("All Characters"));
     entry
         .getLinks()
         .add(new OPDSLink(ACQUISITION_FEED_LINK_TYPE, SUBSECTION, "/opds/collections/characters/"));
     response.getEntries().add(entry);
 
     log.trace("Adding teams link");
-    entry = new OPDSNavigationFeedEntry("Teams");
+    entry = new OPDSNavigationFeedEntry("Teams", String.valueOf(TEAMS_ID));
+    entry.setContent(new OPDSNavigationFeedContent("All Teams"));
     entry
         .getLinks()
         .add(new OPDSLink(ACQUISITION_FEED_LINK_TYPE, SUBSECTION, "/opds/collections/teams/"));
     response.getEntries().add(entry);
 
     log.trace("Adding locations link");
-    entry = new OPDSNavigationFeedEntry("Locations");
+    entry = new OPDSNavigationFeedEntry("Locations", String.valueOf(LOCATIONS_ID));
+    entry.setContent(new OPDSNavigationFeedContent("All Locations"));
     entry
         .getLinks()
         .add(new OPDSLink(ACQUISITION_FEED_LINK_TYPE, SUBSECTION, "/opds/collections/locations/"));
     response.getEntries().add(entry);
 
     log.trace("Adding stories link");
-    entry = new OPDSNavigationFeedEntry("Stories");
+    entry = new OPDSNavigationFeedEntry("Stories", String.valueOf(STORIES_ID));
+    entry.setContent(new OPDSNavigationFeedContent("All Stories"));
     entry
         .getLinks()
         .add(new OPDSLink(ACQUISITION_FEED_LINK_TYPE, SUBSECTION, "/opds/collections/stories/"));

--- a/comixed-opds/src/main/java/org/comixedproject/opds/rest/OPDSListsController.java
+++ b/comixed-opds/src/main/java/org/comixedproject/opds/rest/OPDSListsController.java
@@ -49,6 +49,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @Log4j2
 public class OPDSListsController {
+  private static final String READING_LISTS_ID = "20";
+  public static final long READING_LIST_FACTOR_ID = 1000000L;
   @Autowired private ReadingListService readingListService;
 
   /**
@@ -68,7 +70,7 @@ public class OPDSListsController {
     final List<ReadingList> lists;
     try {
       lists = this.readingListService.loadReadingListsForUser(email);
-      final OPDSNavigationFeed response = new OPDSNavigationFeed("Reading lists");
+      final OPDSNavigationFeed response = new OPDSNavigationFeed("Reading lists", READING_LISTS_ID);
       response.getLinks().add(new OPDSLink(NAVIGATION_FEED_LINK_TYPE, SELF, "/opds/lists/"));
       lists.forEach(
           readingList -> {
@@ -76,7 +78,8 @@ public class OPDSListsController {
             final OPDSNavigationFeedEntry entry =
                 new OPDSNavigationFeedEntry(
                     String.format(
-                        "%s (%d comics)", readingList.getName(), readingList.getComics().size()));
+                        "%s (%d comics)", readingList.getName(), readingList.getComics().size()),
+                    String.valueOf(READING_LIST_FACTOR_ID + readingList.getId()));
             entry.setContent(new OPDSNavigationFeedContent(readingList.getSummary()));
             entry
                 .getLinks()
@@ -114,7 +117,8 @@ public class OPDSListsController {
       list = this.readingListService.loadReadingListForUser(email, id);
       final OPDSAcquisitionFeed response =
           new OPDSAcquisitionFeed(
-              String.format("Reading List: %s (%d)", list.getName(), list.getComics().size()));
+              String.format("Reading List: %s (%d)", list.getName(), list.getComics().size()),
+              String.valueOf(READING_LIST_FACTOR_ID + list.getId()));
       response
           .getLinks()
           .add(new OPDSLink(NAVIGATION_FEED_LINK_TYPE, SELF, String.format("/opds/lists/%d/", id)));

--- a/comixed-opds/src/main/java/org/comixedproject/opds/utils/OPDSUtils.java
+++ b/comixed-opds/src/main/java/org/comixedproject/opds/utils/OPDSUtils.java
@@ -22,7 +22,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -48,15 +47,6 @@ public class OPDSUtils {
   public static final String OPDS_IMAGE_RELATION = "http://opds-spec.org/image";
   public static final String OPDS_IMAGE_THUMBNAIL = "http://opds-spec.org/image/thumbnail";
   public static final String IMAGE_MIME_TYPE = "image/jpeg";
-
-  /**
-   * Generates a consistent URI value for the given value.
-   *
-   * @return the URI
-   */
-  public static String generateID() {
-    return String.format(URN_UUID_FORMAT_STRING, UUID.randomUUID().toString());
-  }
 
   /**
    * Creates a link for the given comic.
@@ -123,14 +113,17 @@ public class OPDSUtils {
    * @return the entry
    */
   public static OPDSAcquisitionFeedEntry createComicEntry(final Comic comic) {
-    final OPDSAcquisitionFeedEntry result = new OPDSAcquisitionFeedEntry(comic.getBaseFilename());
+    final OPDSAcquisitionFeedEntry result =
+        new OPDSAcquisitionFeedEntry(comic.getBaseFilename(), String.valueOf(comic.getId()));
     comic
         .getCredits()
         .forEach(
             credit -> {
               if (StringUtils.contains(credit.getRole(), "writer")) {
                 log.trace("Adding writer: {}", credit.getName());
-                result.getAuthors().add(new OPDSAuthor(credit.getName()));
+                result
+                    .getAuthors()
+                    .add(new OPDSAuthor(credit.getName(), String.valueOf(credit.getId())));
               }
             });
     if (StringUtils.isNotEmpty(comic.getDescription())) {

--- a/comixed-opds/src/test/java/org/comixedproject/opds/utils/OPDSUtilsTest.java
+++ b/comixed-opds/src/test/java/org/comixedproject/opds/utils/OPDSUtilsTest.java
@@ -20,7 +20,6 @@ package org.comixedproject.opds.utils;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.comixedproject.opds.utils.OPDSUtils.*;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 import org.comixedproject.model.archives.ArchiveType;
@@ -28,7 +27,6 @@ import org.comixedproject.model.comicbooks.Comic;
 import org.comixedproject.opds.model.OPDSLink;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.platform.commons.util.StringUtils;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -45,14 +43,6 @@ public class OPDSUtilsTest {
   public void setUp() {
     Mockito.when(comic.getArchiveType()).thenReturn(TEST_ARCHIVE_TYPE);
     Mockito.when(comic.getBaseFilename()).thenReturn(TEST_BASE_FILENAME);
-  }
-
-  @Test
-  public void testGenerateUUID() {
-    final String result = OPDSUtils.generateID();
-
-    assertNotNull(result);
-    assertFalse(StringUtils.isBlank(result));
   }
 
   @Test


### PR DESCRIPTION
The IDs are now based on either the unique name of the collection,
or else they are based on the id of the comic or reading list itself.

Closes #1227 

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

