### PR TITLE
Fixed batch processing loading too many records at once [#1313]

### DIFF
--- a/comixed-app/src/main/resources/application.properties
+++ b/comixed-app/src/main/resources/application.properties
@@ -40,7 +40,7 @@ spring.datasource.hikari.pool-name=CX-Conn-Pool
 # Batch processing
 spring.batch.initialize-schema=always
 spring.batch.job.enabled=true
-batch.chunk-size=1
+comixed.batch.chunk-size=10
 
 # Liquibase changelog
 spring.liquibase.change-log=classpath:db/liquibase-changelog.xml

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/AddComicsConfiguration.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/AddComicsConfiguration.java
@@ -50,7 +50,7 @@ import org.springframework.context.annotation.Configuration;
 public class AddComicsConfiguration {
   public static final String PARAM_ADD_COMICS_STARTED = "job.add-comics.started";
 
-  @Value("${batch.chunk-size}")
+  @Value("${comixed.batch.chunk-size}")
   private int batchChunkSize = 10;
 
   /**

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/ConsolidationConfiguration.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/ConsolidationConfiguration.java
@@ -54,7 +54,7 @@ public class ConsolidationConfiguration {
   public static final String PARAM_TARGET_DIRECTORY = "job.consolidation.target-directory";
   public static final String PARAM_RENAMING_RULE = "job.consolidation.renaming-rule";
 
-  @Value("${batch.chunk-size}")
+  @Value("${comixed.batch.chunk-size}")
   private int batchChunkSize = 10;
 
   /**

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/ProcessComicsConfiguration.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/ProcessComicsConfiguration.java
@@ -55,7 +55,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class ProcessComicsConfiguration {
   public static final String JOB_RESCAN_COMICS_START = "job.rescan-comics.started";
 
-  @Value("${batch.chunk-size}")
+  @Value("${comixed.batch.chunk-size}")
   private int batchChunkSize = 10;
 
   /**

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/PurgeLibraryConfiguration.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/PurgeLibraryConfiguration.java
@@ -44,7 +44,7 @@ import org.springframework.context.annotation.Configuration;
 public class PurgeLibraryConfiguration {
   public static final String JOB_PURGE_LIBRARY_START = "job.purge-library.started";
 
-  @Value("${batch.chunk-size}")
+  @Value("${comixed.batch.chunk-size}")
   private int batchChunkSize = 10;
 
   /**

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/RecreateComicFilesConfiguration.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/RecreateComicFilesConfiguration.java
@@ -45,7 +45,7 @@ public class RecreateComicFilesConfiguration {
   public static final String JOB_TARGET_ARCHIVE = "job.recreate-comic.target-archive";
   public static final String JOB_DELETE_MARKED_PAGES = "job.recreate-comic.delete-blocked-pages";
 
-  @Value("${batch.chunk-size}")
+  @Value("${comixed.batch.chunk-size}")
   private int batchChunkSize = 10;
 
   @Bean

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/UpdateMetadataConfiguration.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/UpdateMetadataConfiguration.java
@@ -46,7 +46,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class UpdateMetadataConfiguration {
   public static final String JOB_UPDATE_METADATA_STARTED = "job.update-metadata.started";
 
-  @Value("${batch.chunk-size}")
+  @Value("${comixed.batch.chunk-size}")
   private int batchChunkSize = 10;
 
   /**

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/AbstractComicReader.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/AbstractComicReader.java
@@ -19,9 +19,11 @@
 package org.comixedproject.batch.comicbooks.readers;
 
 import java.util.List;
+import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 import org.comixedproject.model.comicbooks.ComicBook;
 import org.springframework.batch.item.ItemReader;
+import org.springframework.beans.factory.annotation.Value;
 
 /**
  * <code>AbstractComicReader</code> provides a foundation for building new {@link ItemReader}
@@ -31,11 +33,15 @@ import org.springframework.batch.item.ItemReader;
  */
 @Log4j2
 public abstract class AbstractComicReader implements ItemReader<ComicBook> {
+  @Value("${comixed.batch.chunk-size}")
+  @Getter
+  private int batchChunkSize = 10;
+
   List<ComicBook> comicBookList = null;
 
   @Override
   public ComicBook read() {
-    if (this.comicBookList == null) {
+    if (this.comicBookList == null || this.comicBookList.isEmpty()) {
       log.trace("Load more comics to process");
       this.comicBookList = this.doLoadComics();
     }

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/ComicFileDescriptorReader.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/ComicFileDescriptorReader.java
@@ -19,11 +19,13 @@
 package org.comixedproject.batch.comicbooks.readers;
 
 import java.util.List;
+import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 import org.comixedproject.model.comicfiles.ComicFileDescriptor;
 import org.comixedproject.service.comicfiles.ComicFileService;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
@@ -36,13 +38,18 @@ import org.springframework.stereotype.Component;
 public class ComicFileDescriptorReader implements ItemReader<ComicFileDescriptor> {
   @Autowired private ComicFileService comicFileService;
 
+  @Value("${comixed.batch.chunk-size}")
+  @Getter
+  private int batchChunkSize = 10;
+
   private List<ComicFileDescriptor> comicFileDescriptorList = null;
 
   @Override
   public ComicFileDescriptor read() {
-    if (this.comicFileDescriptorList == null) {
+    if (this.comicFileDescriptorList == null || this.comicFileDescriptorList.isEmpty()) {
       log.trace("Load more descriptors to process");
-      this.comicFileDescriptorList = this.comicFileService.findComicFileDescriptors();
+      this.comicFileDescriptorList =
+          this.comicFileService.findComicFileDescriptors(this.batchChunkSize);
     }
 
     if (this.comicFileDescriptorList.isEmpty()) {

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/ContentsProcessedReader.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/ContentsProcessedReader.java
@@ -38,6 +38,6 @@ public class ContentsProcessedReader extends AbstractComicReader {
 
   @Override
   protected List<ComicBook> doLoadComics() {
-    return this.comicBookService.findProcessedComics();
+    return this.comicBookService.findProcessedComics(this.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/DeleteComicReader.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/DeleteComicReader.java
@@ -38,6 +38,6 @@ public class DeleteComicReader extends AbstractComicReader {
   @Override
   protected List<ComicBook> doLoadComics() {
     log.trace("Loading comics in the DELETED state");
-    return this.comicBookService.findComicsMarkedForDeletion();
+    return this.comicBookService.findComicsMarkedForDeletion(this.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/LoadFileContentsReader.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/LoadFileContentsReader.java
@@ -37,6 +37,6 @@ public class LoadFileContentsReader extends AbstractComicReader {
 
   @Override
   protected List<ComicBook> doLoadComics() {
-    return this.comicBookService.findUnprocessedComicsWithoutContent();
+    return this.comicBookService.findUnprocessedComicsWithoutContent(this.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/LoadFileDetailsReader.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/LoadFileDetailsReader.java
@@ -38,6 +38,6 @@ public class LoadFileDetailsReader extends AbstractComicReader {
 
   @Override
   protected List<ComicBook> doLoadComics() {
-    return this.comicBookService.findUnprocessedComicsWithoutFileDetails();
+    return this.comicBookService.findUnprocessedComicsWithoutFileDetails(this.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/MarkBlockedPagesReader.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/MarkBlockedPagesReader.java
@@ -38,6 +38,7 @@ public class MarkBlockedPagesReader extends AbstractComicReader {
 
   @Override
   protected List<ComicBook> doLoadComics() {
-    return this.comicBookService.findUnprocessedComicsForMarkedPageBlocking();
+    return this.comicBookService.findUnprocessedComicsForMarkedPageBlocking(
+        this.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/MoveComicReader.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/MoveComicReader.java
@@ -38,6 +38,6 @@ public class MoveComicReader extends AbstractComicReader {
   @Override
   protected List<ComicBook> doLoadComics() {
     log.trace("Loading comics to be moved");
-    return this.comicBookService.findComicsToBeMoved();
+    return this.comicBookService.findComicsToBeMoved(this.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/PurgeMarkedComicsReader.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/PurgeMarkedComicsReader.java
@@ -38,6 +38,6 @@ public class PurgeMarkedComicsReader extends AbstractComicReader {
   @Override
   protected List<ComicBook> doLoadComics() {
     log.trace("Loading comics marked for purging");
-    return this.comicBookService.findComicsMarkedForPurging();
+    return this.comicBookService.findComicsMarkedForPurging(this.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/RecordInsertedReader.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/RecordInsertedReader.java
@@ -38,6 +38,6 @@ public class RecordInsertedReader extends AbstractComicReader {
   @Override
   protected List<ComicBook> doLoadComics() {
     log.trace("Loading newly inserted comics");
-    return this.comicBookService.findInsertedComics();
+    return this.comicBookService.findInsertedComics(this.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/RecreateComicFileReader.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/RecreateComicFileReader.java
@@ -38,6 +38,6 @@ public class RecreateComicFileReader extends AbstractComicReader {
   @Override
   protected List<ComicBook> doLoadComics() {
     log.trace("Fetching comics to be recreated");
-    return this.comicBookService.findComicsToRecreate();
+    return this.comicBookService.findComicsToRecreate(this.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/UpdateMetadataReader.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/UpdateMetadataReader.java
@@ -38,6 +38,6 @@ public class UpdateMetadataReader extends AbstractComicReader {
   @Override
   protected List<ComicBook> doLoadComics() {
     log.trace("Loading comics to have their metadata updated");
-    return this.comicBookService.findComicsWithMetadataToUpdate();
+    return this.comicBookService.findComicsWithMetadataToUpdate(this.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicpages/MarkPagesWithHashConfiguration.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicpages/MarkPagesWithHashConfiguration.java
@@ -47,7 +47,7 @@ public class MarkPagesWithHashConfiguration {
   public static final String PARAM_MARK_PAGES_TARGET_HASH =
       "job.delete-pages-with-hash.target-hash";
 
-  @Value("${batch.chunk-size}")
+  @Value("${comixed.batch.chunk-size}")
   private int batchChunkSize = 10;
 
   /**

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicpages/UnmarkPagesWithHashConfiguration.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicpages/UnmarkPagesWithHashConfiguration.java
@@ -47,7 +47,7 @@ public class UnmarkPagesWithHashConfiguration {
   public static final String PARAM_UNMARK_PAGES_TARGET_HASH =
       "job.undelete-pages-with-hash.target-hash";
 
-  @Value("${batch.chunk-size}")
+  @Value("${comixed.batch.chunk-size}")
   private int batchChunkSize = 10;
 
   /**

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/ComicFileDescriptorReaderTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/ComicFileDescriptorReaderTest.java
@@ -43,25 +43,29 @@ public class ComicFileDescriptorReaderTest {
   public void read() {
     comicFileDescriptors.add(descriptor);
 
-    Mockito.when(comicFileService.findComicFileDescriptors()).thenReturn(comicFileDescriptors);
+    Mockito.when(comicFileService.findComicFileDescriptors(Mockito.anyInt()))
+        .thenReturn(comicFileDescriptors);
 
     final ComicFileDescriptor result = reader.read();
 
     assertNotNull(result);
     assertSame(descriptor, result);
 
-    Mockito.verify(comicFileService, Mockito.times(1)).findComicFileDescriptors();
+    Mockito.verify(comicFileService, Mockito.times(1))
+        .findComicFileDescriptors(reader.getBatchChunkSize());
     Mockito.verify(comicFileService, Mockito.times(1)).deleteComicFileDescriptor(descriptor);
   }
 
   @Test
   public void readNoRecordsFound() {
-    Mockito.when(comicFileService.findComicFileDescriptors()).thenReturn(comicFileDescriptors);
+    Mockito.when(comicFileService.findComicFileDescriptors(Mockito.anyInt()))
+        .thenReturn(comicFileDescriptors);
 
     final ComicFileDescriptor result = reader.read();
 
     assertNull(result);
 
-    Mockito.verify(comicFileService, Mockito.times(1)).findComicFileDescriptors();
+    Mockito.verify(comicFileService, Mockito.times(1))
+        .findComicFileDescriptors(reader.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/ContentsProcessedReaderTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/ContentsProcessedReaderTest.java
@@ -45,7 +45,7 @@ public class ContentsProcessedReaderTest {
   public void testReadNoneLoadedManyFound() {
     for (int index = 0; index < MAX_RECORDS; index++) comicBookList.add(comicBook);
 
-    Mockito.when(comicBookService.findProcessedComics()).thenReturn(comicBookList);
+    Mockito.when(comicBookService.findProcessedComics(10)).thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
 
@@ -54,11 +54,13 @@ public class ContentsProcessedReaderTest {
     assertFalse(comicBookList.isEmpty());
     assertEquals(MAX_RECORDS - 1, comicBookList.size());
 
-    Mockito.verify(comicBookService, Mockito.times(1)).findProcessedComics();
+    Mockito.verify(comicBookService, Mockito.times(1)).findProcessedComics(10);
   }
 
   @Test
   public void testReadNoneRemaining() {
+    Mockito.when(comicBookService.findProcessedComics(10)).thenReturn(comicBookList);
+
     reader.comicBookList = comicBookList;
 
     final ComicBook result = reader.read();
@@ -66,18 +68,18 @@ public class ContentsProcessedReaderTest {
     assertNull(result);
     assertNull(reader.comicBookList);
 
-    Mockito.verify(comicBookService, Mockito.never()).findProcessedComics();
+    Mockito.verify(comicBookService, Mockito.times(1)).findProcessedComics(10);
   }
 
   @Test
   public void testReadNoneLoadedNoneFound() {
-    Mockito.when(comicBookService.findProcessedComics()).thenReturn(comicBookList);
+    Mockito.when(comicBookService.findProcessedComics(10)).thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
 
     assertNull(result);
     assertNull(reader.comicBookList);
 
-    Mockito.verify(comicBookService, Mockito.times(1)).findProcessedComics();
+    Mockito.verify(comicBookService, Mockito.times(1)).findProcessedComics(10);
   }
 }

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/DeleteComicBookReaderTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/DeleteComicBookReaderTest.java
@@ -45,7 +45,8 @@ public class DeleteComicBookReaderTest {
   public void testReadNoneLoadedManyFound() {
     for (int index = 0; index < MAX_RECORDS; index++) comicBookList.add(comicBook);
 
-    Mockito.when(comicBookService.findComicsMarkedForDeletion()).thenReturn(comicBookList);
+    Mockito.when(comicBookService.findComicsMarkedForDeletion(Mockito.anyInt()))
+        .thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
 
@@ -54,11 +55,15 @@ public class DeleteComicBookReaderTest {
     assertFalse(comicBookList.isEmpty());
     assertEquals(MAX_RECORDS - 1, comicBookList.size());
 
-    Mockito.verify(comicBookService, Mockito.times(1)).findComicsMarkedForDeletion();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findComicsMarkedForDeletion(reader.getBatchChunkSize());
   }
 
   @Test
   public void testReadNoneRemaining() {
+    Mockito.when(comicBookService.findComicsMarkedForDeletion(Mockito.anyInt()))
+        .thenReturn(comicBookList);
+
     reader.comicBookList = comicBookList;
 
     final ComicBook result = reader.read();
@@ -66,18 +71,21 @@ public class DeleteComicBookReaderTest {
     assertNull(result);
     assertNull(reader.comicBookList);
 
-    Mockito.verify(comicBookService, Mockito.never()).findComicsMarkedForDeletion();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findComicsMarkedForDeletion(reader.getBatchChunkSize());
   }
 
   @Test
   public void testReadNoneLoadedNoneFound() {
-    Mockito.when(comicBookService.findComicsMarkedForDeletion()).thenReturn(comicBookList);
+    Mockito.when(comicBookService.findComicsMarkedForDeletion(Mockito.anyInt()))
+        .thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
 
     assertNull(result);
     assertNull(reader.comicBookList);
 
-    Mockito.verify(comicBookService, Mockito.times(1)).findComicsMarkedForDeletion();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findComicsMarkedForDeletion(reader.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/LoadFileContentsReaderTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/LoadFileContentsReaderTest.java
@@ -45,7 +45,8 @@ public class LoadFileContentsReaderTest {
   public void testReadNoneLoadedManyFound() {
     for (int index = 0; index < MAX_RECORDS; index++) comicBookList.add(comicBook);
 
-    Mockito.when(comicBookService.findUnprocessedComicsWithoutContent()).thenReturn(comicBookList);
+    Mockito.when(comicBookService.findUnprocessedComicsWithoutContent(Mockito.anyInt()))
+        .thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
 
@@ -54,11 +55,15 @@ public class LoadFileContentsReaderTest {
     assertFalse(comicBookList.isEmpty());
     assertEquals(MAX_RECORDS - 1, comicBookList.size());
 
-    Mockito.verify(comicBookService, Mockito.times(1)).findUnprocessedComicsWithoutContent();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findUnprocessedComicsWithoutContent(reader.getBatchChunkSize());
   }
 
   @Test
   public void testReadNoneRemaining() {
+    Mockito.when(comicBookService.findUnprocessedComicsWithoutContent(Mockito.anyInt()))
+        .thenReturn(comicBookList);
+
     reader.comicBookList = comicBookList;
 
     final ComicBook result = reader.read();
@@ -66,18 +71,21 @@ public class LoadFileContentsReaderTest {
     assertNull(result);
     assertNull(reader.comicBookList);
 
-    Mockito.verify(comicBookService, Mockito.never()).findUnprocessedComicsWithoutContent();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findUnprocessedComicsWithoutContent(reader.getBatchChunkSize());
   }
 
   @Test
   public void testReadNoneLoadedNoneFound() {
-    Mockito.when(comicBookService.findUnprocessedComicsWithoutContent()).thenReturn(comicBookList);
+    Mockito.when(comicBookService.findUnprocessedComicsWithoutContent(Mockito.anyInt()))
+        .thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
 
     assertNull(result);
     assertNull(reader.comicBookList);
 
-    Mockito.verify(comicBookService, Mockito.times(1)).findUnprocessedComicsWithoutContent();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findUnprocessedComicsWithoutContent(reader.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/LoadFileDetailsReaderTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/LoadFileDetailsReaderTest.java
@@ -45,7 +45,7 @@ public class LoadFileDetailsReaderTest {
   public void testReadNoneLoadedManyFound() {
     for (int index = 0; index < MAX_RECORDS; index++) comicBookList.add(comicBook);
 
-    Mockito.when(comicBookService.findUnprocessedComicsWithoutFileDetails())
+    Mockito.when(comicBookService.findUnprocessedComicsWithoutFileDetails(Mockito.anyInt()))
         .thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
@@ -55,11 +55,15 @@ public class LoadFileDetailsReaderTest {
     assertFalse(comicBookList.isEmpty());
     assertEquals(MAX_RECORDS - 1, comicBookList.size());
 
-    Mockito.verify(comicBookService, Mockito.times(1)).findUnprocessedComicsWithoutFileDetails();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findUnprocessedComicsWithoutFileDetails(reader.getBatchChunkSize());
   }
 
   @Test
   public void testReadNoneRemaining() {
+    Mockito.when(comicBookService.findUnprocessedComicsWithoutFileDetails(Mockito.anyInt()))
+        .thenReturn(comicBookList);
+
     reader.comicBookList = comicBookList;
 
     final ComicBook result = reader.read();
@@ -67,12 +71,13 @@ public class LoadFileDetailsReaderTest {
     assertNull(result);
     assertNull(reader.comicBookList);
 
-    Mockito.verify(comicBookService, Mockito.never()).findUnprocessedComicsWithoutFileDetails();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findUnprocessedComicsWithoutFileDetails(reader.getBatchChunkSize());
   }
 
   @Test
   public void testReadNoneLoadedNoneFound() {
-    Mockito.when(comicBookService.findUnprocessedComicsWithoutFileDetails())
+    Mockito.when(comicBookService.findUnprocessedComicsWithoutFileDetails(Mockito.anyInt()))
         .thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
@@ -80,6 +85,7 @@ public class LoadFileDetailsReaderTest {
     assertNull(result);
     assertNull(reader.comicBookList);
 
-    Mockito.verify(comicBookService, Mockito.times(1)).findUnprocessedComicsWithoutFileDetails();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findUnprocessedComicsWithoutFileDetails(reader.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/MarkBlockedPagesReaderTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/MarkBlockedPagesReaderTest.java
@@ -45,7 +45,7 @@ public class MarkBlockedPagesReaderTest {
   public void testReadNoneLoadedManyFound() {
     for (int index = 0; index < MAX_RECORDS; index++) comicBookList.add(comicBook);
 
-    Mockito.when(comicBookService.findUnprocessedComicsForMarkedPageBlocking())
+    Mockito.when(comicBookService.findUnprocessedComicsForMarkedPageBlocking(Mockito.anyInt()))
         .thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
@@ -55,11 +55,15 @@ public class MarkBlockedPagesReaderTest {
     assertFalse(comicBookList.isEmpty());
     assertEquals(MAX_RECORDS - 1, comicBookList.size());
 
-    Mockito.verify(comicBookService, Mockito.times(1)).findUnprocessedComicsForMarkedPageBlocking();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findUnprocessedComicsForMarkedPageBlocking(reader.getBatchChunkSize());
   }
 
   @Test
   public void testReadNoneRemaining() {
+    Mockito.when(comicBookService.findUnprocessedComicsForMarkedPageBlocking(Mockito.anyInt()))
+        .thenReturn(comicBookList);
+
     reader.comicBookList = comicBookList;
 
     final ComicBook result = reader.read();
@@ -67,12 +71,13 @@ public class MarkBlockedPagesReaderTest {
     assertNull(result);
     assertNull(reader.comicBookList);
 
-    Mockito.verify(comicBookService, Mockito.never()).findUnprocessedComicsForMarkedPageBlocking();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findUnprocessedComicsForMarkedPageBlocking(reader.getBatchChunkSize());
   }
 
   @Test
   public void testReadNoneLoadedNoneFound() {
-    Mockito.when(comicBookService.findUnprocessedComicsForMarkedPageBlocking())
+    Mockito.when(comicBookService.findUnprocessedComicsForMarkedPageBlocking(Mockito.anyInt()))
         .thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
@@ -80,6 +85,7 @@ public class MarkBlockedPagesReaderTest {
     assertNull(result);
     assertNull(reader.comicBookList);
 
-    Mockito.verify(comicBookService, Mockito.times(1)).findUnprocessedComicsForMarkedPageBlocking();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findUnprocessedComicsForMarkedPageBlocking(reader.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/MoveComicBookReaderTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/MoveComicBookReaderTest.java
@@ -45,7 +45,7 @@ public class MoveComicBookReaderTest {
   public void testReadNoneLoadedManyFound() {
     for (int index = 0; index < MAX_RECORDS; index++) comicBookList.add(comicBook);
 
-    Mockito.when(comicBookService.findComicsToBeMoved()).thenReturn(comicBookList);
+    Mockito.when(comicBookService.findComicsToBeMoved(Mockito.anyInt())).thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
 
@@ -54,11 +54,14 @@ public class MoveComicBookReaderTest {
     assertFalse(comicBookList.isEmpty());
     assertEquals(MAX_RECORDS - 1, comicBookList.size());
 
-    Mockito.verify(comicBookService, Mockito.times(1)).findComicsToBeMoved();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findComicsToBeMoved(reader.getBatchChunkSize());
   }
 
   @Test
   public void testReadNoneRemaining() {
+    Mockito.when(comicBookService.findComicsToBeMoved(Mockito.anyInt())).thenReturn(comicBookList);
+
     reader.comicBookList = comicBookList;
 
     final ComicBook result = reader.read();
@@ -66,18 +69,20 @@ public class MoveComicBookReaderTest {
     assertNull(result);
     assertNull(reader.comicBookList);
 
-    Mockito.verify(comicBookService, Mockito.never()).findComicsToBeMoved();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findComicsToBeMoved(reader.getBatchChunkSize());
   }
 
   @Test
   public void testReadNoneLoadedNoneFound() {
-    Mockito.when(comicBookService.findComicsToBeMoved()).thenReturn(comicBookList);
+    Mockito.when(comicBookService.findComicsToBeMoved(Mockito.anyInt())).thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
 
     assertNull(result);
     assertNull(reader.comicBookList);
 
-    Mockito.verify(comicBookService, Mockito.times(1)).findComicsToBeMoved();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findComicsToBeMoved(reader.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/PurgeMarkedComicsReaderTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/PurgeMarkedComicsReaderTest.java
@@ -45,7 +45,8 @@ public class PurgeMarkedComicsReaderTest {
   public void testReadNoneLoadedManyFound() {
     for (int index = 0; index < MAX_RECORDS; index++) comicBookList.add(comicBook);
 
-    Mockito.when(comicBookService.findComicsMarkedForPurging()).thenReturn(comicBookList);
+    Mockito.when(comicBookService.findComicsMarkedForPurging(Mockito.anyInt()))
+        .thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
 
@@ -54,11 +55,15 @@ public class PurgeMarkedComicsReaderTest {
     assertFalse(comicBookList.isEmpty());
     assertEquals(MAX_RECORDS - 1, comicBookList.size());
 
-    Mockito.verify(comicBookService, Mockito.times(1)).findComicsMarkedForPurging();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findComicsMarkedForPurging(reader.getBatchChunkSize());
   }
 
   @Test
   public void testReadNoneRemaining() {
+    Mockito.when(comicBookService.findComicsMarkedForPurging(Mockito.anyInt()))
+        .thenReturn(comicBookList);
+
     reader.comicBookList = comicBookList;
 
     final ComicBook result = reader.read();
@@ -66,18 +71,21 @@ public class PurgeMarkedComicsReaderTest {
     assertNull(result);
     assertNull(reader.comicBookList);
 
-    Mockito.verify(comicBookService, Mockito.never()).findComicsMarkedForPurging();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findComicsMarkedForPurging(reader.getBatchChunkSize());
   }
 
   @Test
   public void testReadNoneLoadedNoneFound() {
-    Mockito.when(comicBookService.findComicsMarkedForPurging()).thenReturn(comicBookList);
+    Mockito.when(comicBookService.findComicsMarkedForPurging(Mockito.anyInt()))
+        .thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
 
     assertNull(result);
     assertNull(reader.comicBookList);
 
-    Mockito.verify(comicBookService, Mockito.times(1)).findComicsMarkedForPurging();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findComicsMarkedForPurging(reader.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/RecordInsertedReaderTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/RecordInsertedReaderTest.java
@@ -45,7 +45,7 @@ public class RecordInsertedReaderTest {
   public void testReadNoneLoadedManyFound() {
     for (int index = 0; index < MAX_RECORDS; index++) comicBookList.add(comicBook);
 
-    Mockito.when(comicBookService.findInsertedComics()).thenReturn(comicBookList);
+    Mockito.when(comicBookService.findInsertedComics(Mockito.anyInt())).thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
 
@@ -54,11 +54,14 @@ public class RecordInsertedReaderTest {
     assertFalse(comicBookList.isEmpty());
     assertEquals(MAX_RECORDS - 1, comicBookList.size());
 
-    Mockito.verify(comicBookService, Mockito.times(1)).findInsertedComics();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findInsertedComics(reader.getBatchChunkSize());
   }
 
   @Test
   public void testReadNoneRemaining() {
+    Mockito.when(comicBookService.findInsertedComics(Mockito.anyInt())).thenReturn(comicBookList);
+
     reader.comicBookList = comicBookList;
 
     final ComicBook result = reader.read();
@@ -66,18 +69,20 @@ public class RecordInsertedReaderTest {
     assertNull(result);
     assertNull(reader.comicBookList);
 
-    Mockito.verify(comicBookService, Mockito.never()).findInsertedComics();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findInsertedComics(reader.getBatchChunkSize());
   }
 
   @Test
   public void testReadNoneLoadedNoneFound() {
-    Mockito.when(comicBookService.findInsertedComics()).thenReturn(comicBookList);
+    Mockito.when(comicBookService.findInsertedComics(Mockito.anyInt())).thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
 
     assertNull(result);
     assertNull(reader.comicBookList);
 
-    Mockito.verify(comicBookService, Mockito.times(1)).findInsertedComics();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findInsertedComics(reader.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/RecreateComicFileReaderTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/RecreateComicFileReaderTest.java
@@ -45,7 +45,7 @@ public class RecreateComicFileReaderTest {
   public void testReadNoneLoadedManyFound() {
     for (int index = 0; index < MAX_RECORDS; index++) comicBookList.add(comicBook);
 
-    Mockito.when(comicBookService.findComicsToRecreate()).thenReturn(comicBookList);
+    Mockito.when(comicBookService.findComicsToRecreate(Mockito.anyInt())).thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
 
@@ -54,11 +54,14 @@ public class RecreateComicFileReaderTest {
     assertFalse(comicBookList.isEmpty());
     assertEquals(MAX_RECORDS - 1, comicBookList.size());
 
-    Mockito.verify(comicBookService, Mockito.times(1)).findComicsToRecreate();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findComicsToRecreate(reader.getBatchChunkSize());
   }
 
   @Test
   public void testReadNoneRemaining() {
+    Mockito.when(comicBookService.findComicsToRecreate(Mockito.anyInt())).thenReturn(comicBookList);
+
     reader.comicBookList = comicBookList;
 
     final ComicBook result = reader.read();
@@ -66,18 +69,20 @@ public class RecreateComicFileReaderTest {
     assertNull(result);
     assertNull(reader.comicBookList);
 
-    Mockito.verify(comicBookService, Mockito.never()).findComicsToRecreate();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findComicsToRecreate(reader.getBatchChunkSize());
   }
 
   @Test
   public void testReadNoneLoadedNoneFound() {
-    Mockito.when(comicBookService.findComicsToRecreate()).thenReturn(comicBookList);
+    Mockito.when(comicBookService.findComicsToRecreate(Mockito.anyInt())).thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
 
     assertNull(result);
     assertNull(reader.comicBookList);
 
-    Mockito.verify(comicBookService, Mockito.times(1)).findComicsToRecreate();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findComicsToRecreate(reader.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/UpdateMetadataReaderTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/UpdateMetadataReaderTest.java
@@ -45,7 +45,8 @@ public class UpdateMetadataReaderTest {
   public void testReadNoneLoadedManyFound() {
     for (int index = 0; index < MAX_RECORDS; index++) comicBookList.add(comicBook);
 
-    Mockito.when(comicBookService.findComicsWithMetadataToUpdate()).thenReturn(comicBookList);
+    Mockito.when(comicBookService.findComicsWithMetadataToUpdate(Mockito.anyInt()))
+        .thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
 
@@ -54,11 +55,15 @@ public class UpdateMetadataReaderTest {
     assertFalse(comicBookList.isEmpty());
     assertEquals(MAX_RECORDS - 1, comicBookList.size());
 
-    Mockito.verify(comicBookService, Mockito.times(1)).findComicsWithMetadataToUpdate();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findComicsWithMetadataToUpdate(reader.getBatchChunkSize());
   }
 
   @Test
   public void testReadNoneRemaining() {
+    Mockito.when(comicBookService.findComicsWithMetadataToUpdate(Mockito.anyInt()))
+        .thenReturn(comicBookList);
+
     reader.comicBookList = comicBookList;
 
     final ComicBook result = reader.read();
@@ -66,18 +71,21 @@ public class UpdateMetadataReaderTest {
     assertNull(result);
     assertNull(reader.comicBookList);
 
-    Mockito.verify(comicBookService, Mockito.never()).findComicsWithMetadataToUpdate();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findComicsWithMetadataToUpdate(reader.getBatchChunkSize());
   }
 
   @Test
   public void testReadNoneLoadedNoneFound() {
-    Mockito.when(comicBookService.findComicsWithMetadataToUpdate()).thenReturn(comicBookList);
+    Mockito.when(comicBookService.findComicsWithMetadataToUpdate(Mockito.anyInt()))
+        .thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
 
     assertNull(result);
     assertNull(reader.comicBookList);
 
-    Mockito.verify(comicBookService, Mockito.times(1)).findComicsWithMetadataToUpdate();
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findComicsWithMetadataToUpdate(reader.getBatchChunkSize());
   }
 }

--- a/comixed-repositories/src/test/java/org/comixedproject/repositories/comicbooks/ComicBookRepositoryTest.java
+++ b/comixed-repositories/src/test/java/org/comixedproject/repositories/comicbooks/ComicBookRepositoryTest.java
@@ -76,6 +76,7 @@ public class ComicBookRepositoryTest {
   private static final Date TEST_COVER_DATE_WITH_PREV = new Date(1488258000000L);
   private static final String TEST_HASH_WITH_NO_COMICS = "FEDCBA9876543210FEDCBA9876543210";
   private static final String TEST_HASH_WITH_COMICS = "0123456789ABCDEF0123456789ABCDEF";
+  private static final int TEST_BATCH_SIZE = 1;
 
   @Autowired private ComicBookRepository repository;
 
@@ -386,10 +387,12 @@ public class ComicBookRepositoryTest {
 
   @Test
   public void testFindAllMarkedForDeletion() {
-    List<ComicBook> result = repository.findComicsMarkedForDeletion();
+    List<ComicBook> result =
+        repository.findComicsMarkedForDeletion(PageRequest.of(0, TEST_BATCH_SIZE));
 
     assertNotNull(result);
     assertFalse(result.isEmpty());
+    assertEquals(TEST_BATCH_SIZE, result.size());
     for (ComicBook comicBook : result) {
       assertEquals(ComicState.DELETED, comicBook.getComicState());
     }

--- a/comixed-services/src/main/java/org/comixedproject/service/comicbooks/ComicBookService.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/comicbooks/ComicBookService.java
@@ -309,11 +309,12 @@ public class ComicBookService implements InitializingBean, ComicStateChangeListe
   /**
    * Retrieves inserted comics that have not been processed.
    *
+   * @param count the number of comics to return
    * @return the comics
    */
-  public List<ComicBook> findInsertedComics() {
+  public List<ComicBook> findInsertedComics(final int count) {
     log.trace("Loading newly inserted comics");
-    return this.comicBookRepository.findForState(ComicState.ADDED);
+    return this.comicBookRepository.findForState(ComicState.ADDED, PageRequest.of(0, count));
   }
 
   /**
@@ -323,17 +324,18 @@ public class ComicBookService implements InitializingBean, ComicStateChangeListe
    */
   public long getUnprocessedComicsWithoutContentCount() {
     log.trace("Getting the number of unprocessed comics without content");
-    return this.comicBookRepository.findUnprocessedComicsWithoutContent().size();
+    return this.comicBookRepository.findUnprocessedComicsWithoutContentCount();
   }
 
   /**
    * Retrieves unprocessed comics that are waiting to have their contents loaded.
    *
+   * @param count the number of comics to return
    * @return the comics
    */
-  public List<ComicBook> findUnprocessedComicsWithoutContent() {
+  public List<ComicBook> findUnprocessedComicsWithoutContent(int count) {
     log.trace("Loading unprocessed comics that need to have their contents loaded");
-    return this.comicBookRepository.findUnprocessedComicsWithoutContent();
+    return this.comicBookRepository.findUnprocessedComicsWithoutContent(PageRequest.of(0, count));
   }
 
   /**
@@ -343,17 +345,19 @@ public class ComicBookService implements InitializingBean, ComicStateChangeListe
    */
   public long getUnprocessedComicsForMarkedPageBlockingCount() {
     log.trace("Getting unprocessed comics that need page blocking count");
-    return this.comicBookRepository.findUnprocessedComicsForMarkedPageBlocking().size();
+    return this.comicBookRepository.findUnprocessedComicsForMarkedPageBlockingCount();
   }
 
   /**
    * Retrieves unprocessed comics that are waiting to have the blocked pages marked.
    *
+   * @param count the number of comics to return
    * @return the comics
    */
-  public List<ComicBook> findUnprocessedComicsForMarkedPageBlocking() {
+  public List<ComicBook> findUnprocessedComicsForMarkedPageBlocking(final int count) {
     log.trace("Loading unprocessed comics that need page blocking");
-    return this.comicBookRepository.findUnprocessedComicsForMarkedPageBlocking();
+    return this.comicBookRepository.findUnprocessedComicsForMarkedPageBlocking(
+        PageRequest.of(0, count));
   }
 
   /**
@@ -363,17 +367,19 @@ public class ComicBookService implements InitializingBean, ComicStateChangeListe
    */
   public long getUnprocessedComicsWithoutFileDetailsCount() {
     log.trace("Getting unprocessed comics without file details loaded count");
-    return this.comicBookRepository.findUnprocessedComicsWithoutFileDetails().size();
+    return this.comicBookRepository.findUnprocessedComicsWithoutFileDetailsCount();
   }
 
   /**
    * Retrieves unprocessed comics that don't have file details.
    *
+   * @param count the number of comics to return
    * @return the comics
    */
-  public List<ComicBook> findUnprocessedComicsWithoutFileDetails() {
+  public List<ComicBook> findUnprocessedComicsWithoutFileDetails(final int count) {
     log.trace("Loading unprocessed comics without file details loaded");
-    return this.comicBookRepository.findUnprocessedComicsWithoutFileDetails();
+    return this.comicBookRepository.findUnprocessedComicsWithoutFileDetails(
+        PageRequest.of(0, count));
   }
 
   /**
@@ -383,17 +389,18 @@ public class ComicBookService implements InitializingBean, ComicStateChangeListe
    */
   public long getProcessedComicsCount() {
     log.trace("Getting count of unprocessed comics that are fully processed");
-    return this.comicBookRepository.findProcessedComics().size();
+    return this.comicBookRepository.findProcessedComicsCount();
   }
 
   /**
    * Retrieves unprocessed comics that have had their contents processed.
    *
+   * @param count the number of comics to return
    * @return the comics
    */
-  public List<ComicBook> findProcessedComics() {
+  public List<ComicBook> findProcessedComics(final int count) {
     log.trace("Loading unprocessed comics that are fully processed");
-    return this.comicBookRepository.findProcessedComics();
+    return this.comicBookRepository.findProcessedComics(PageRequest.of(0, count));
   }
 
   /**
@@ -423,37 +430,40 @@ public class ComicBookService implements InitializingBean, ComicStateChangeListe
    */
   public int getCountForState(final ComicState state) {
     log.trace("Getting record count for state: {}", state);
-    return this.comicBookRepository.findForState(state).size();
+    return this.comicBookRepository.findForStateCount(state);
   }
 
   /**
    * Returns comics that are waiting to have their metadata updated.
    *
+   * @param count the number of comics to return
    * @return the list of comics
    */
-  public List<ComicBook> findComicsWithMetadataToUpdate() {
+  public List<ComicBook> findComicsWithMetadataToUpdate(final int count) {
     log.trace("Getting comics that are ready to have their metadata updated");
-    return this.comicBookRepository.findComicsWithMetadataToUpdate();
+    return this.comicBookRepository.findComicsWithMetadataToUpdate(PageRequest.of(0, count));
   }
 
   /**
    * Finds all comics marked for deletion.
    *
+   * @param count the number of comics to return
    * @return the list of comics
    */
-  public List<ComicBook> findComicsMarkedForDeletion() {
+  public List<ComicBook> findComicsMarkedForDeletion(final int count) {
     log.trace("Finding all comics marked for deletion");
-    return this.comicBookRepository.findComicsMarkedForDeletion();
+    return this.comicBookRepository.findComicsMarkedForDeletion(PageRequest.of(0, count));
   }
 
   /**
    * Finds all comics that are to be moved.
    *
+   * @param count the numer of comics to return
    * @return the list of comics
    */
-  public List<ComicBook> findComicsToBeMoved() {
+  public List<ComicBook> findComicsToBeMoved(final int count) {
     log.trace("Finding all comics to be moved");
-    return this.comicBookRepository.findComicsToBeMoved();
+    return this.comicBookRepository.findComicsToBeMoved(PageRequest.of(0, count));
   }
 
   /**
@@ -501,11 +511,12 @@ public class ComicBookService implements InitializingBean, ComicStateChangeListe
   /**
    * Finds all comics to be recreated.
    *
+   * @param count the number of comics to return
    * @return the list of comics
    */
-  public List<ComicBook> findComicsToRecreate() {
+  public List<ComicBook> findComicsToRecreate(final int count) {
     log.trace("Finding all comics to be recreated");
-    return this.comicBookRepository.findComicsToRecreate();
+    return this.comicBookRepository.findComicsToRecreate(PageRequest.of(0, count));
   }
 
   /**
@@ -671,11 +682,12 @@ public class ComicBookService implements InitializingBean, ComicStateChangeListe
   /**
    * Returns comics marked for purging.
    *
+   * @param count the number of comics to return
    * @return the comics
    */
-  public List<ComicBook> findComicsMarkedForPurging() {
+  public List<ComicBook> findComicsMarkedForPurging(final int count) {
     log.trace("Loading comics marked for purging");
-    return this.comicBookRepository.findComicsMarkedForPurging();
+    return this.comicBookRepository.findComicsMarkedForPurging(PageRequest.of(0, count));
   }
 
   /**

--- a/comixed-services/src/main/java/org/comixedproject/service/comicfiles/ComicFileService.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/comicfiles/ComicFileService.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.io.FilenameUtils;
 import org.comixedproject.adaptors.AdaptorException;
@@ -35,6 +36,7 @@ import org.comixedproject.model.comicfiles.ComicFileGroup;
 import org.comixedproject.repositories.comicfiles.ComicFileDescriptorRepository;
 import org.comixedproject.service.comicbooks.ComicBookService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -169,11 +171,13 @@ public class ComicFileService {
   /**
    * Returns all comic file descriptor records.
    *
+   * @param pageSize the number of descriptors to return
    * @return the descriptors
    */
-  public List<ComicFileDescriptor> findComicFileDescriptors() {
+  public List<ComicFileDescriptor> findComicFileDescriptors(final int pageSize) {
     log.trace("Loading all comic file descriptors");
-    return this.comicFileDescriptorRepository.findAll();
+    return this.comicFileDescriptorRepository.findAll(PageRequest.of(0, pageSize)).stream()
+        .collect(Collectors.toList());
   }
 
   /**

--- a/comixed-services/src/test/java/org/comixedproject/service/comicbooks/ComicBookServiceTest.java
+++ b/comixed-services/src/test/java/org/comixedproject/service/comicbooks/ComicBookServiceTest.java
@@ -476,115 +476,152 @@ public class ComicBookServiceTest {
 
   @Test
   public void testFindInsertedComics() {
-    Mockito.when(comicBookRepository.findForState(Mockito.any(ComicState.class)))
+    Mockito.when(
+            comicBookRepository.findForState(
+                Mockito.any(ComicState.class), pageableCaptor.capture()))
         .thenReturn(comicBookList);
 
-    final List<ComicBook> result = service.findInsertedComics();
+    final List<ComicBook> result = service.findInsertedComics(TEST_MAXIMUM_COMICS);
 
     assertNotNull(result);
     assertSame(comicBookList, result);
 
-    Mockito.verify(comicBookRepository, Mockito.times(1)).findForState(ComicState.ADDED);
+    final Pageable pageable = pageableCaptor.getValue();
+    assertNotNull(pageable);
+    assertEquals(0, pageable.getPageNumber());
+    assertEquals(TEST_MAXIMUM_COMICS, pageable.getPageSize());
+
+    Mockito.verify(comicBookRepository, Mockito.times(1)).findForState(ComicState.ADDED, pageable);
   }
 
   @Test
   public void testGetUnprocessedComicsWithoutContentCount() {
-    Mockito.when(comicBookRepository.findUnprocessedComicsWithoutContent())
-        .thenReturn(comicBookList);
+    Mockito.when(comicBookRepository.findUnprocessedComicsWithoutContentCount())
+        .thenReturn(TEST_MAXIMUM_COMICS);
 
     final long result = service.getUnprocessedComicsWithoutContentCount();
 
-    assertEquals(comicBookList.size(), result);
+    assertEquals(TEST_MAXIMUM_COMICS, result);
 
-    Mockito.verify(comicBookRepository, Mockito.times(1)).findUnprocessedComicsWithoutContent();
+    Mockito.verify(comicBookRepository, Mockito.times(1))
+        .findUnprocessedComicsWithoutContentCount();
   }
 
   @Test
   public void testFindUnprocessedComicsWithoutContent() {
-    Mockito.when(comicBookRepository.findUnprocessedComicsWithoutContent())
+    Mockito.when(comicBookRepository.findUnprocessedComicsWithoutContent(pageableCaptor.capture()))
         .thenReturn(comicBookList);
 
-    final List<ComicBook> result = service.findUnprocessedComicsWithoutContent();
+    final List<ComicBook> result = service.findUnprocessedComicsWithoutContent(TEST_MAXIMUM_COMICS);
 
     assertNotNull(result);
     assertSame(comicBookList, result);
 
-    Mockito.verify(comicBookRepository, Mockito.times(1)).findUnprocessedComicsWithoutContent();
+    final Pageable pageable = pageableCaptor.getValue();
+    assertNotNull(pageable);
+    assertEquals(0, pageable.getPageNumber());
+    assertEquals(TEST_MAXIMUM_COMICS, pageable.getPageSize());
+
+    Mockito.verify(comicBookRepository, Mockito.times(1))
+        .findUnprocessedComicsWithoutContent(pageable);
   }
 
   @Test
   public void testGetUnprocessedComicsForMarkedPageBlockingCount() {
-    Mockito.when(comicBookRepository.findUnprocessedComicsForMarkedPageBlocking())
-        .thenReturn(comicBookList);
+    Mockito.when(comicBookRepository.findUnprocessedComicsForMarkedPageBlockingCount())
+        .thenReturn(TEST_MAXIMUM_COMICS);
 
     final long result = service.getUnprocessedComicsForMarkedPageBlockingCount();
 
-    assertEquals(comicBookList.size(), result);
+    assertEquals(TEST_MAXIMUM_COMICS, result);
 
     Mockito.verify(comicBookRepository, Mockito.times(1))
-        .findUnprocessedComicsForMarkedPageBlocking();
+        .findUnprocessedComicsForMarkedPageBlockingCount();
   }
 
   @Test
   public void testFindUnprocessedComicsForMarkedPageBlocking() {
-    Mockito.when(comicBookRepository.findUnprocessedComicsForMarkedPageBlocking())
+    Mockito.when(
+            comicBookRepository.findUnprocessedComicsForMarkedPageBlocking(
+                pageableCaptor.capture()))
         .thenReturn(comicBookList);
 
-    final List<ComicBook> result = service.findUnprocessedComicsForMarkedPageBlocking();
+    final List<ComicBook> result =
+        service.findUnprocessedComicsForMarkedPageBlocking(TEST_MAXIMUM_COMICS);
 
     assertNotNull(result);
     assertSame(comicBookList, result);
 
+    final Pageable pageable = pageableCaptor.getValue();
+    assertNotNull(pageable);
+    assertEquals(0, pageable.getPageNumber());
+    assertEquals(TEST_MAXIMUM_COMICS, pageable.getPageSize());
+
     Mockito.verify(comicBookRepository, Mockito.times(1))
-        .findUnprocessedComicsForMarkedPageBlocking();
+        .findUnprocessedComicsForMarkedPageBlocking(pageable);
   }
 
   @Test
   public void testGetUnprocessedComicsWithoutFileDetailsCount() {
-    Mockito.when(comicBookRepository.findUnprocessedComicsWithoutFileDetails())
-        .thenReturn(comicBookList);
+    Mockito.when(comicBookRepository.findUnprocessedComicsWithoutFileDetailsCount())
+        .thenReturn(TEST_MAXIMUM_COMICS);
 
     final long result = service.getUnprocessedComicsWithoutFileDetailsCount();
 
-    assertEquals(comicBookList.size(), result);
+    assertEquals(TEST_MAXIMUM_COMICS, result);
 
-    Mockito.verify(comicBookRepository, Mockito.times(1)).findUnprocessedComicsWithoutFileDetails();
+    Mockito.verify(comicBookRepository, Mockito.times(1))
+        .findUnprocessedComicsWithoutFileDetailsCount();
   }
 
   @Test
   public void testFindUnprocessedComicsWithoutFileDetails() {
-    Mockito.when(comicBookRepository.findUnprocessedComicsWithoutFileDetails())
+    Mockito.when(
+            comicBookRepository.findUnprocessedComicsWithoutFileDetails(pageableCaptor.capture()))
         .thenReturn(comicBookList);
 
-    final List<ComicBook> result = service.findUnprocessedComicsWithoutFileDetails();
+    final List<ComicBook> result =
+        service.findUnprocessedComicsWithoutFileDetails(TEST_MAXIMUM_COMICS);
 
     assertNotNull(result);
     assertSame(comicBookList, result);
 
-    Mockito.verify(comicBookRepository, Mockito.times(1)).findUnprocessedComicsWithoutFileDetails();
+    final Pageable pageable = pageableCaptor.getValue();
+    assertNotNull(pageable);
+    assertEquals(0, pageable.getPageNumber());
+    assertEquals(TEST_MAXIMUM_COMICS, pageable.getPageSize());
+
+    Mockito.verify(comicBookRepository, Mockito.times(1))
+        .findUnprocessedComicsWithoutFileDetails(pageable);
   }
 
   @Test
   public void testGetProcessedComicsCount() {
-    Mockito.when(comicBookRepository.findProcessedComics()).thenReturn(comicBookList);
+    Mockito.when(comicBookRepository.findProcessedComicsCount()).thenReturn(TEST_MAXIMUM_COMICS);
 
     final long result = service.getProcessedComicsCount();
 
-    assertEquals(comicBookList.size(), result);
+    assertEquals(TEST_MAXIMUM_COMICS, result);
 
-    Mockito.verify(comicBookRepository, Mockito.times(1)).findProcessedComics();
+    Mockito.verify(comicBookRepository, Mockito.times(1)).findProcessedComicsCount();
   }
 
   @Test
   public void testFindProcessedComics() {
-    Mockito.when(comicBookRepository.findProcessedComics()).thenReturn(comicBookList);
+    Mockito.when(comicBookRepository.findProcessedComics(pageableCaptor.capture()))
+        .thenReturn(comicBookList);
 
-    final List<ComicBook> result = service.findProcessedComics();
+    final List<ComicBook> result = service.findProcessedComics(TEST_MAXIMUM_COMICS);
 
     assertNotNull(result);
     assertSame(comicBookList, result);
 
-    Mockito.verify(comicBookRepository, Mockito.times(1)).findProcessedComics();
+    final Pageable pageable = pageableCaptor.getValue();
+    assertNotNull(pageable);
+    assertEquals(0, pageable.getPageNumber());
+    assertEquals(TEST_MAXIMUM_COMICS, pageable.getPageSize());
+
+    Mockito.verify(comicBookRepository, Mockito.times(1)).findProcessedComics(pageable);
   }
 
   @Test
@@ -618,50 +655,68 @@ public class ComicBookServiceTest {
   public void testGetCountForState() {
     for (int index = 0; index < 50; index++) comicBookList.add(comicBook);
 
-    Mockito.when(comicBookRepository.findForState(Mockito.any(ComicState.class)))
-        .thenReturn(comicBookList);
+    Mockito.when(comicBookRepository.findForStateCount(Mockito.any(ComicState.class)))
+        .thenReturn(TEST_MAXIMUM_COMICS);
 
     final int result = service.getCountForState(TEST_STATE);
 
-    assertEquals(comicBookList.size(), result);
+    assertEquals(TEST_MAXIMUM_COMICS, result);
 
-    Mockito.verify(comicBookRepository, Mockito.times(1)).findForState(TEST_STATE);
+    Mockito.verify(comicBookRepository, Mockito.times(1)).findForStateCount(TEST_STATE);
   }
 
   @Test
   public void testFindComicsWithMetadataToUpdate() {
-    Mockito.when(comicBookRepository.findComicsWithMetadataToUpdate()).thenReturn(comicBookList);
+    Mockito.when(comicBookRepository.findComicsWithMetadataToUpdate(pageableCaptor.capture()))
+        .thenReturn(comicBookList);
 
-    final List<ComicBook> result = service.findComicsWithMetadataToUpdate();
+    final List<ComicBook> result = service.findComicsWithMetadataToUpdate(TEST_MAXIMUM_COMICS);
 
     assertNotNull(result);
     assertSame(comicBookList, result);
 
-    Mockito.verify(comicBookRepository, Mockito.times(1)).findComicsWithMetadataToUpdate();
+    final Pageable pageable = pageableCaptor.getValue();
+    assertNotNull(pageable);
+    assertEquals(0, pageable.getPageNumber());
+    assertEquals(TEST_MAXIMUM_COMICS, pageable.getPageSize());
+
+    Mockito.verify(comicBookRepository, Mockito.times(1)).findComicsWithMetadataToUpdate(pageable);
   }
 
   @Test
   public void testFindAllComicsMarkedForDeletion() {
-    Mockito.when(comicBookRepository.findComicsMarkedForDeletion()).thenReturn(comicBookList);
+    Mockito.when(comicBookRepository.findComicsMarkedForDeletion(pageableCaptor.capture()))
+        .thenReturn(comicBookList);
 
-    final List<ComicBook> result = service.findComicsMarkedForDeletion();
+    final List<ComicBook> result = service.findComicsMarkedForDeletion(TEST_MAXIMUM_COMICS);
 
     assertNotNull(result);
     assertSame(comicBookList, result);
 
-    Mockito.verify(comicBookRepository, Mockito.times(1)).findComicsMarkedForDeletion();
+    final Pageable pageable = pageableCaptor.getValue();
+    assertNotNull(pageable);
+    assertEquals(0, pageable.getPageNumber());
+    assertEquals(TEST_MAXIMUM_COMICS, pageable.getPageSize());
+
+    Mockito.verify(comicBookRepository, Mockito.times(1)).findComicsMarkedForDeletion(pageable);
   }
 
   @Test
   public void testFindComicsToBeMoved() {
-    Mockito.when(comicBookRepository.findComicsToBeMoved()).thenReturn(comicBookList);
+    Mockito.when(comicBookRepository.findComicsToBeMoved(pageableCaptor.capture()))
+        .thenReturn(comicBookList);
 
-    final List<ComicBook> result = service.findComicsToBeMoved();
+    final List<ComicBook> result = service.findComicsToBeMoved(TEST_MAXIMUM_COMICS);
 
     assertNotNull(result);
     assertSame(comicBookList, result);
 
-    Mockito.verify(comicBookRepository, Mockito.times(1)).findComicsToBeMoved();
+    final Pageable pageable = pageableCaptor.getValue();
+    assertNotNull(pageable);
+    assertEquals(0, pageable.getPageNumber());
+    assertEquals(TEST_MAXIMUM_COMICS, pageable.getPageSize());
+
+    Mockito.verify(comicBookRepository, Mockito.times(1)).findComicsToBeMoved(pageable);
   }
 
   @Test
@@ -729,14 +784,20 @@ public class ComicBookServiceTest {
 
   @Test
   public void testFindAllComicsToRecreate() {
-    Mockito.when(comicBookRepository.findComicsToRecreate()).thenReturn(comicBookList);
+    Mockito.when(comicBookRepository.findComicsToRecreate(pageableCaptor.capture()))
+        .thenReturn(comicBookList);
 
-    final List<ComicBook> result = service.findComicsToRecreate();
+    final List<ComicBook> result = service.findComicsToRecreate(TEST_MAXIMUM_COMICS);
 
     assertNotNull(result);
     assertSame(comicBookList, result);
 
-    Mockito.verify(comicBookRepository, Mockito.times(1)).findComicsToRecreate();
+    final Pageable pageable = pageableCaptor.getValue();
+    assertNotNull(pageable);
+    assertEquals(0, pageable.getPageNumber());
+    assertEquals(TEST_MAXIMUM_COMICS, pageable.getPageSize());
+
+    Mockito.verify(comicBookRepository, Mockito.times(1)).findComicsToRecreate(pageable);
   }
 
   @Test
@@ -1028,14 +1089,20 @@ public class ComicBookServiceTest {
 
   @Test
   public void testFindComicsMarkedForPurging() {
-    Mockito.when(comicBookRepository.findComicsMarkedForPurging()).thenReturn(comicBookList);
+    Mockito.when(comicBookRepository.findComicsMarkedForPurging(pageableCaptor.capture()))
+        .thenReturn(comicBookList);
 
-    final List<ComicBook> result = service.findComicsMarkedForPurging();
+    final List<ComicBook> result = service.findComicsMarkedForPurging(TEST_MAXIMUM_COMICS);
 
     assertNotNull(result);
     assertSame(comicBookList, result);
 
-    Mockito.verify(comicBookRepository, Mockito.times(1)).findComicsMarkedForPurging();
+    final Pageable pageable = pageableCaptor.getValue();
+    assertNotNull(pageable);
+    assertEquals(0, pageable.getPageNumber());
+    assertEquals(TEST_MAXIMUM_COMICS, pageable.getPageSize());
+
+    Mockito.verify(comicBookRepository, Mockito.times(1)).findComicsMarkedForPurging(pageable);
   }
 
   @Test(expected = ComicException.class)


### PR DESCRIPTION
 * Changed the default batch size to 10.
 * Changed each comic item reader to use the batch size.
 * Changed the comic item reader base class to reload on empty.

Closes #1313 

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

