### PR TITLE
Changed comic processors to not raise exceptions [#1313]

### DIFF
--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/processors/LoadFileContentsProcessor.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/processors/LoadFileContentsProcessor.java
@@ -19,6 +19,7 @@
 package org.comixedproject.batch.comicbooks.processors;
 
 import lombok.extern.log4j.Log4j2;
+import org.comixedproject.adaptors.AdaptorException;
 import org.comixedproject.adaptors.comicbooks.ComicBookAdaptor;
 import org.comixedproject.model.comicbooks.ComicBook;
 import org.springframework.batch.item.ItemProcessor;
@@ -36,12 +37,17 @@ public class LoadFileContentsProcessor implements ItemProcessor<ComicBook, Comic
   @Autowired private ComicBookAdaptor comicBookAdaptor;
 
   @Override
-  public ComicBook process(final ComicBook comicBook) throws Exception {
+  public ComicBook process(final ComicBook comicBook) {
     log.debug("Loading comicBook file contents: id={}", comicBook.getId());
-    this.comicBookAdaptor.load(comicBook);
-    log.trace("Sorting comicBook pages");
-    comicBook.getPages().sort((o1, o2) -> o1.getFilename().compareTo(o2.getFilename()));
-    log.trace("Returning updated comicBook");
-    return comicBook;
+    try {
+      this.comicBookAdaptor.load(comicBook);
+      log.trace("Sorting comicBook pages");
+      comicBook.getPages().sort((o1, o2) -> o1.getFilename().compareTo(o2.getFilename()));
+      log.trace("Returning updated comicBook");
+      return comicBook;
+    } catch (AdaptorException error) {
+      log.error("Error loading comic file content", error);
+      return comicBook;
+    }
   }
 }

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/processors/LoadFileDetailsProcessor.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/processors/LoadFileDetailsProcessor.java
@@ -19,6 +19,7 @@
 package org.comixedproject.batch.comicbooks.processors;
 
 import java.io.FileInputStream;
+import java.io.IOException;
 import lombok.extern.log4j.Log4j2;
 import org.comixedproject.adaptors.GenericUtilitiesAdaptor;
 import org.comixedproject.model.comicbooks.ComicBook;
@@ -38,13 +39,19 @@ public class LoadFileDetailsProcessor implements ItemProcessor<ComicBook, ComicB
   @Autowired private GenericUtilitiesAdaptor genericUtilitiesAdaptor;
 
   @Override
-  public ComicBook process(final ComicBook comicBook) throws Exception {
+  public ComicBook process(final ComicBook comicBook) {
     log.debug("Creating file details container: id={}", comicBook.getId());
     final ComicFileDetails fileDetails = new ComicFileDetails(comicBook);
     comicBook.setFileDetails(fileDetails);
     log.trace("Getting comicBook file hash");
-    fileDetails.setHash(
-        this.genericUtilitiesAdaptor.createHash(new FileInputStream(comicBook.getFilename())));
-    return comicBook;
+    try {
+      fileDetails.setHash(
+          this.genericUtilitiesAdaptor.createHash(new FileInputStream(comicBook.getFilename())));
+
+      return comicBook;
+    } catch (IOException error) {
+      log.error("Error loading comic file details", error);
+      return null;
+    }
   }
 }

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/processors/ComicBookInsertProcessorTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/processors/ComicBookInsertProcessorTest.java
@@ -21,6 +21,7 @@ package org.comixedproject.batch.comicbooks.processors;
 import static junit.framework.TestCase.*;
 
 import java.util.Date;
+import org.comixedproject.adaptors.AdaptorException;
 import org.comixedproject.adaptors.comicbooks.ComicBookAdaptor;
 import org.comixedproject.model.comicbooks.ComicBook;
 import org.comixedproject.model.comicfiles.ComicFileDescriptor;
@@ -70,6 +71,20 @@ public class ComicBookInsertProcessorTest {
     assertNull(result);
 
     Mockito.verify(comicBookService, Mockito.times(1)).findByFilename(TEST_FILENAME);
+  }
+
+  @Test
+  public void testProcessCreateComicException() throws Exception {
+    Mockito.when(comicBookService.findByFilename(Mockito.anyString())).thenReturn(null);
+    Mockito.when(comicBookAdaptor.createComic(Mockito.anyString()))
+        .thenThrow(AdaptorException.class);
+
+    final ComicBook result = processor.process(descriptor);
+
+    assertNull(result);
+
+    Mockito.verify(comicBookService, Mockito.times(1)).findByFilename(TEST_FILENAME);
+    Mockito.verify(comicBookAdaptor, Mockito.times(1)).createComic(TEST_FILENAME);
   }
 
   @Test

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/processors/LoadFileContentsProcessorTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/processors/LoadFileContentsProcessorTest.java
@@ -18,7 +18,10 @@
 
 package org.comixedproject.batch.comicbooks.processors;
 
+import static junit.framework.TestCase.*;
+
 import java.util.List;
+import org.comixedproject.adaptors.AdaptorException;
 import org.comixedproject.adaptors.comicbooks.ComicBookAdaptor;
 import org.comixedproject.model.comicbooks.ComicBook;
 import org.comixedproject.model.comicpages.Page;
@@ -40,9 +43,26 @@ public class LoadFileContentsProcessorTest {
   public void testProcess() throws Exception {
     Mockito.when(comicBook.getPages()).thenReturn(pageList);
 
-    processor.process(comicBook);
+    final ComicBook result = processor.process(comicBook);
+
+    assertNotNull(result);
+    assertSame(comicBook, result);
 
     Mockito.verify(comicBookAdaptor, Mockito.times(1)).load(comicBook);
     Mockito.verify(pageList, Mockito.times(1)).sort(Mockito.any());
+  }
+
+  @Test
+  public void testProcessAdaptorException() throws Exception {
+    Mockito.doThrow(AdaptorException.class)
+        .when(comicBookAdaptor)
+        .load(Mockito.any(ComicBook.class));
+
+    final ComicBook result = processor.process(comicBook);
+
+    assertNotNull(result);
+    assertSame(comicBook, result);
+
+    Mockito.verify(comicBookAdaptor, Mockito.times(1)).load(comicBook);
   }
 }

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/processors/LoadFileDetailsProcessorTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/processors/LoadFileDetailsProcessorTest.java
@@ -20,6 +20,7 @@ package org.comixedproject.batch.comicbooks.processors;
 
 import static junit.framework.TestCase.*;
 
+import java.io.IOException;
 import java.io.InputStream;
 import org.comixedproject.adaptors.GenericUtilitiesAdaptor;
 import org.comixedproject.model.comicbooks.ComicBook;
@@ -41,11 +42,28 @@ public class LoadFileDetailsProcessorTest {
   @Captor private ArgumentCaptor<ComicFileDetails> comicFileDetailsArgumentCaptor;
 
   @Test
+  public void testProcessCreateHashException() throws Exception {
+    Mockito.when(comicBook.getFilename()).thenReturn(TEST_COMIC_FILENAME);
+    Mockito.doNothing().when(comicBook).setFileDetails(comicFileDetailsArgumentCaptor.capture());
+    Mockito.when(genericUtilitiesAdaptor.createHash(Mockito.any(InputStream.class)))
+        .thenThrow(IOException.class);
+
+    final ComicBook result = processor.process(comicBook);
+
+    assertNull(result);
+
+    final ComicFileDetails fileDetails = comicFileDetailsArgumentCaptor.getValue();
+    assertNotNull(fileDetails);
+    assertSame(comicBook, fileDetails.getComicBook());
+    assertNull(fileDetails.getHash());
+  }
+
+  @Test
   public void testProcess() throws Exception {
     Mockito.when(comicBook.getFilename()).thenReturn(TEST_COMIC_FILENAME);
+    Mockito.doNothing().when(comicBook).setFileDetails(comicFileDetailsArgumentCaptor.capture());
     Mockito.when(genericUtilitiesAdaptor.createHash(Mockito.any(InputStream.class)))
         .thenReturn(TEST_HASH);
-    Mockito.doNothing().when(comicBook).setFileDetails(comicFileDetailsArgumentCaptor.capture());
 
     final ComicBook result = processor.process(comicBook);
 

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/processors/UpdateMetadataProcessorTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/processors/UpdateMetadataProcessorTest.java
@@ -21,6 +21,7 @@ package org.comixedproject.batch.comicbooks.processors;
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertSame;
 
+import org.comixedproject.adaptors.AdaptorException;
 import org.comixedproject.adaptors.comicbooks.ComicBookAdaptor;
 import org.comixedproject.model.archives.ArchiveType;
 import org.comixedproject.model.comicbooks.ComicBook;
@@ -47,6 +48,14 @@ public class UpdateMetadataProcessorTest {
 
   @Test
   public void testProcessUpdateException() throws Exception {
+    Mockito.doThrow(AdaptorException.class)
+        .when(comicBookAdaptor)
+        .save(
+            Mockito.any(ComicBook.class),
+            Mockito.any(ArchiveType.class),
+            Mockito.anyBoolean(),
+            Mockito.anyString());
+
     final ComicBook result = processor.process(comicBook);
 
     assertNotNull(result);


### PR DESCRIPTION
To keep the batch processes from dying, each  process now
logs any exception thrown and returns null to allow the batch
to continue processing.

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

