### PR TITLE
Added creating a metadata source for comics  [#1315]

### DIFF
--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/ConsolidationConfiguration.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/ConsolidationConfiguration.java
@@ -63,6 +63,7 @@ public class ConsolidationConfiguration {
    * @param jobBuilderFactory the job builder factory
    * @param deleteComicStep the delete comics step
    * @param moveComicStep the move comics step
+   * @param deleteEmptyDirectoriesStep the delete empty directories step
    * @return the job
    */
   @Bean

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/listeners/CreateMetadataSourceStepListener.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/listeners/CreateMetadataSourceStepListener.java
@@ -1,0 +1,49 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2022, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.batch.comicbooks.listeners;
+
+import static org.comixedproject.model.messaging.batch.ProcessComicStatus.*;
+
+import lombok.extern.log4j.Log4j2;
+import org.comixedproject.service.comicbooks.ComicBookService;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * <code>CreateMetadataSourceStepListener</code> relates batch status while creating the metadata
+ * source.
+ *
+ * @author Darryl L. Pierce
+ */
+@Component
+@Log4j2
+public class CreateMetadataSourceStepListener extends AbstractComicProcessingStepExecutionListener {
+  @Autowired private ComicBookService comicBookService;
+
+  @Override
+  public void beforeStep(final StepExecution stepExecution) {
+    final ExecutionContext context = stepExecution.getJobExecution().getExecutionContext();
+    context.putString(STEP_NAME, CREATE_METADATA_SOURCE_STEP_NAME);
+    log.trace("Getting comic count");
+    context.putLong(TOTAL_COMICS, this.comicBookService.getWithCreateMetadataSourceFlagCount());
+    this.doPublishState(context);
+  }
+}

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/processors/CreateMetadataSourceProcessor.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/processors/CreateMetadataSourceProcessor.java
@@ -1,0 +1,101 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2022, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.batch.comicbooks.processors;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.extern.log4j.Log4j2;
+import org.comixedproject.adaptors.comicbooks.ComicBookAdaptor;
+import org.comixedproject.model.comicbooks.ComicBook;
+import org.comixedproject.model.comicbooks.ComicMetadataSource;
+import org.comixedproject.model.metadata.ComicInfo;
+import org.comixedproject.model.metadata.MetadataSource;
+import org.comixedproject.service.metadata.MetadataSourceService;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * <code>CreateMetadataSourceProcessor</code> creates a {@link MetadataSource} for a comic during
+ * processing.
+ *
+ * @author Darryl L. Pierce
+ */
+@Component
+@Log4j2
+public class CreateMetadataSourceProcessor
+    implements ItemProcessor<ComicBook, ComicBook>, InitializingBean {
+  public static final String COMIC_INFO_XML = "ComicInfo.xml";
+  public static final String COMIC_VINE_METADATA_ADAPTOR = "comicVineMetadataAdaptor";
+
+  @Autowired private MetadataSourceService metadataSourceService;
+  @Autowired private ComicBookAdaptor comicBookAdaptor;
+  @Autowired MappingJackson2XmlHttpMessageConverter xmlConverter;
+
+  private Pattern pattern =
+      Pattern.compile("^http.*comicvine\\.gamespot\\.com.*4000-([\\d]{3,6})\\/");
+
+  @Override
+  public void afterPropertiesSet() {
+    this.xmlConverter
+        .getObjectMapper()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  }
+
+  @Override
+  public ComicBook process(final ComicBook comicBook) throws Exception {
+    log.trace("Loading ComicVine metadata source");
+    final MetadataSource source = this.metadataSourceService.getByName(COMIC_VINE_METADATA_ADAPTOR);
+    if (source != null) {
+      try {
+        log.trace("Loading ComicInfo.xml content");
+        final byte[] content = this.comicBookAdaptor.loadFile(comicBook, COMIC_INFO_XML);
+        if (content != null) {
+          log.trace("Extracting comic metadata");
+          final ComicInfo comicInfo =
+              this.xmlConverter
+                  .getObjectMapper()
+                  .readValue(new ByteArrayInputStream(content), ComicInfo.class);
+          final String web = comicInfo.getWeb();
+          if (StringUtils.hasLength(web)) {
+            log.trace("Checking if web address is for ComicVine: {}", web);
+            final Matcher matcher = this.pattern.matcher(web);
+            if (matcher.matches()) {
+              log.trace("Web address matches: extracting ComicVine ID");
+              final String comicVineId = matcher.group(1);
+              log.trace("Creating metadata source for comic");
+              comicBook.setMetadata(new ComicMetadataSource(comicBook, source, comicVineId));
+            }
+          }
+        }
+      } catch (IOException error) {
+        log.error("Failed to create metadata source", error);
+      }
+    } else {
+      log.trace("No ComicVine metadata source found");
+    }
+    return comicBook;
+  }
+}

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/CreateMetadataSourceReader.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/CreateMetadataSourceReader.java
@@ -1,6 +1,6 @@
 /*
  * ComiXed - A digital comic book library management application.
- * Copyright (C) 2021, The ComiXed Project
+ * Copyright (C) 2022, The ComiXed Project
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,22 +16,23 @@
  * along with this program. If not, see <http://www.gnu.org/licenses>
  */
 
-package org.comixedproject.batch.comicbooks.writers;
+package org.comixedproject.batch.comicbooks.readers;
 
+import java.util.List;
+import lombok.extern.log4j.Log4j2;
 import org.comixedproject.model.comicbooks.ComicBook;
-import org.comixedproject.state.comicbooks.ComicEvent;
-import org.springframework.batch.item.ItemWriter;
+import org.comixedproject.service.comicbooks.ComicBookService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-/**
- * <code>LoadFileContentsWriter</code> provides an {@link ItemWriter} for instances of {@link
- * ComicBook} that have had their contents loaded.
- *
- * @author Darryl L. Pierce
- */
+/** <code>CreateMetadataSourceReader</code> loads comics that have the */
 @Component
-public class LoadFileContentsWriter extends AbstractComicWriter {
-  public LoadFileContentsWriter() {
-    super(ComicEvent.fileContentsLoaded);
+@Log4j2
+public class CreateMetadataSourceReader extends AbstractComicReader {
+  @Autowired private ComicBookService comicBookService;
+
+  @Override
+  protected List<ComicBook> doLoadComics() {
+    return this.comicBookService.findComicsWithCreateMetadataFlagSet(this.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/writers/ComicInsertWriter.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/writers/ComicInsertWriter.java
@@ -18,12 +18,8 @@
 
 package org.comixedproject.batch.comicbooks.writers;
 
-import java.util.List;
 import lombok.extern.log4j.Log4j2;
-import org.comixedproject.model.comicbooks.ComicBook;
-import org.comixedproject.service.comicbooks.ComicBookService;
-import org.springframework.batch.item.ItemWriter;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.comixedproject.state.comicbooks.ComicEvent;
 import org.springframework.stereotype.Component;
 
 /**
@@ -33,19 +29,8 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @Log4j2
-public class ComicInsertWriter implements ItemWriter<ComicBook> {
-  @Autowired private ComicBookService comicBookService;
-
-  @Override
-  public void write(final List<? extends ComicBook> comics) throws Exception {
-    comics.forEach(
-        comic -> {
-          try {
-            log.trace("Saving comic: {}", comic.getFilename());
-            this.comicBookService.save(comic);
-          } catch (Exception error) {
-            log.error("Failed to insert new comic", error);
-          }
-        });
+public class ComicInsertWriter extends AbstractComicWriter {
+  public ComicInsertWriter() {
+    super(ComicEvent.readyForProcessing);
   }
 }

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/writers/CreateMetadataSourceWriter.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/writers/CreateMetadataSourceWriter.java
@@ -1,6 +1,6 @@
 /*
  * ComiXed - A digital comic book library management application.
- * Copyright (C) 2021, The ComiXed Project
+ * Copyright (C) 2022, The ComiXed Project
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,20 +18,21 @@
 
 package org.comixedproject.batch.comicbooks.writers;
 
-import org.comixedproject.model.comicbooks.ComicBook;
+import lombok.extern.log4j.Log4j2;
 import org.comixedproject.state.comicbooks.ComicEvent;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.stereotype.Component;
 
 /**
- * <code>LoadFileContentsWriter</code> provides an {@link ItemWriter} for instances of {@link
- * ComicBook} that have had their contents loaded.
+ * <code>CreateMetadataSourceWriter</code> provides an {@link ItemWriter} for comic books that have
+ * been processed for creating a metadata source.
  *
  * @author Darryl L. Pierce
  */
 @Component
-public class LoadFileContentsWriter extends AbstractComicWriter {
-  public LoadFileContentsWriter() {
-    super(ComicEvent.fileContentsLoaded);
+@Log4j2
+public class CreateMetadataSourceWriter extends AbstractComicWriter {
+  public CreateMetadataSourceWriter() {
+    super(ComicEvent.metadataSourceCreated);
   }
 }

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/listeners/CreateMetadataSourceStepListenerTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/listeners/CreateMetadataSourceStepListenerTest.java
@@ -1,0 +1,131 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2022, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.batch.comicbooks.listeners;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static org.comixedproject.model.messaging.batch.ProcessComicStatus.*;
+import static org.comixedproject.model.messaging.batch.ProcessComicStatus.CREATE_METADATA_SOURCE_STEP_NAME;
+
+import java.util.Date;
+import org.comixedproject.messaging.PublishingException;
+import org.comixedproject.messaging.comicbooks.PublishProcessComicsStatusAction;
+import org.comixedproject.model.messaging.batch.ProcessComicStatus;
+import org.comixedproject.service.comicbooks.ComicBookService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.*;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.item.ExecutionContext;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CreateMetadataSourceStepListenerTest {
+  private static final long TEST_TOTAL_COMICS = 77L;
+  private static final Date TEST_JOB_STARTED = new Date();
+  private static final long TEST_PROCESSED_COMICS = 15L;
+
+  @InjectMocks private CreateMetadataSourceStepListener listener;
+  @Mock private StepExecution stepExecution;
+  @Mock private JobExecution jobExecution;
+  @Mock private ExecutionContext executionContext;
+  @Mock private ComicBookService comicBookService;
+  @Mock private PublishProcessComicsStatusAction publishProcessComicsStatusAction;
+
+  @Captor ArgumentCaptor<ProcessComicStatus> processComicStatusArgumentCaptor;
+
+  @Before
+  public void setUp() throws PublishingException {
+    Mockito.when(stepExecution.getJobExecution()).thenReturn(jobExecution);
+    Mockito.when(jobExecution.getExecutionContext()).thenReturn(executionContext);
+    Mockito.when(executionContext.containsKey(JOB_STARTED)).thenReturn(true);
+    Mockito.when(executionContext.containsKey(JOB_FINISHED)).thenReturn(false);
+    Mockito.when(executionContext.getLong(JOB_STARTED)).thenReturn(TEST_JOB_STARTED.getTime());
+    Mockito.when(executionContext.getString(STEP_NAME))
+        .thenReturn(CREATE_METADATA_SOURCE_STEP_NAME);
+    Mockito.when(executionContext.getLong(TOTAL_COMICS)).thenReturn(TEST_TOTAL_COMICS);
+    Mockito.when(executionContext.getLong(PROCESSED_COMICS)).thenReturn(TEST_PROCESSED_COMICS);
+    Mockito.doNothing()
+        .when(publishProcessComicsStatusAction)
+        .publish(processComicStatusArgumentCaptor.capture());
+  }
+
+  @Test
+  public void testBeforeStep() throws PublishingException {
+    Mockito.when(comicBookService.getWithCreateMetadataSourceFlagCount())
+        .thenReturn(TEST_TOTAL_COMICS);
+
+    listener.beforeStep(stepExecution);
+
+    final ProcessComicStatus status = processComicStatusArgumentCaptor.getValue();
+    assertTrue(status.isActive());
+    assertEquals(CREATE_METADATA_SOURCE_STEP_NAME, status.getStepName());
+    assertEquals(TEST_TOTAL_COMICS, status.getTotal());
+    assertEquals(TEST_PROCESSED_COMICS, status.getProcessed());
+
+    Mockito.verify(comicBookService, Mockito.times(1)).getWithCreateMetadataSourceFlagCount();
+    Mockito.verify(executionContext, Mockito.times(1))
+        .putString(STEP_NAME, CREATE_METADATA_SOURCE_STEP_NAME);
+    Mockito.verify(executionContext, Mockito.times(1)).putLong(TOTAL_COMICS, TEST_TOTAL_COMICS);
+    Mockito.verify(publishProcessComicsStatusAction, Mockito.times(1)).publish(status);
+  }
+
+  @Test
+  public void testBeforeStepPublisingException() throws PublishingException {
+    Mockito.when(comicBookService.getWithCreateMetadataSourceFlagCount())
+        .thenReturn(TEST_TOTAL_COMICS);
+    Mockito.doThrow(PublishingException.class)
+        .when(publishProcessComicsStatusAction)
+        .publish(Mockito.any());
+
+    listener.beforeStep(stepExecution);
+
+    Mockito.verify(comicBookService, Mockito.times(1)).getWithCreateMetadataSourceFlagCount();
+    Mockito.verify(executionContext, Mockito.times(1))
+        .putString(STEP_NAME, CREATE_METADATA_SOURCE_STEP_NAME);
+    Mockito.verify(executionContext, Mockito.times(1)).putLong(TOTAL_COMICS, TEST_TOTAL_COMICS);
+    Mockito.verify(publishProcessComicsStatusAction, Mockito.times(1)).publish(Mockito.any());
+  }
+
+  @Test
+  public void testAfterStep() throws PublishingException {
+    listener.afterStep(stepExecution);
+
+    final ProcessComicStatus status = processComicStatusArgumentCaptor.getValue();
+    assertTrue(status.isActive());
+    assertEquals(CREATE_METADATA_SOURCE_STEP_NAME, status.getStepName());
+    assertEquals(TEST_TOTAL_COMICS, status.getTotal());
+    assertEquals(TEST_PROCESSED_COMICS, status.getProcessed());
+
+    Mockito.verify(publishProcessComicsStatusAction, Mockito.times(1)).publish(status);
+  }
+
+  @Test
+  public void testAfterStepPublisingException() throws PublishingException {
+    Mockito.doThrow(PublishingException.class)
+        .when(publishProcessComicsStatusAction)
+        .publish(Mockito.any());
+
+    listener.afterStep(stepExecution);
+
+    Mockito.verify(publishProcessComicsStatusAction, Mockito.times(1)).publish(Mockito.any());
+  }
+}

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/processors/CreateMetadataSourceProcessorTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/processors/CreateMetadataSourceProcessorTest.java
@@ -1,0 +1,197 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2022, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.batch.comicbooks.processors;
+
+import static junit.framework.TestCase.*;
+import static org.comixedproject.batch.comicbooks.processors.CreateMetadataSourceProcessor.COMIC_INFO_XML;
+import static org.comixedproject.batch.comicbooks.processors.CreateMetadataSourceProcessor.COMIC_VINE_METADATA_ADAPTOR;
+import static org.junit.Assert.assertArrayEquals;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import org.comixedproject.adaptors.AdaptorException;
+import org.comixedproject.adaptors.comicbooks.ComicBookAdaptor;
+import org.comixedproject.model.comicbooks.ComicBook;
+import org.comixedproject.model.comicbooks.ComicMetadataSource;
+import org.comixedproject.model.metadata.ComicInfo;
+import org.comixedproject.model.metadata.MetadataSource;
+import org.comixedproject.service.metadata.MetadataSourceService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.*;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CreateMetadataSourceProcessorTest {
+  private static final byte[] TEST_METADATA_CONTENT = "The file content".getBytes();
+  private static final String TEST_COMIC_VINE_ID = "73823";
+  private static final String TEST_WEB_ADDRESS_NO_MATCH = "http://this.is.not.comicvine";
+  private static final String TEST_WEB_ADDRESS =
+      String.format("https://comicvine.gamespot.com/spider-man-1/4000-%s/", TEST_COMIC_VINE_ID);
+
+  @InjectMocks private CreateMetadataSourceProcessor processor;
+  @Mock private MetadataSourceService metadataSourceService;
+  @Mock private ComicBookAdaptor comicBookAdaptor;
+  @Mock MappingJackson2XmlHttpMessageConverter xmlConverter;
+  @Mock private ComicBook comicBook;
+  @Mock private ObjectMapper objectMapper;
+  @Mock private MetadataSource metadataSource;
+  @Mock private ComicInfo comicInfo;
+
+  @Captor private ArgumentCaptor<ByteArrayInputStream> byteArrayInputStreamArgumentCaptor;
+  @Captor private ArgumentCaptor<ComicMetadataSource> comicMetadataSourceArgumentCaptor;
+
+  @Before
+  public void setUp() throws AdaptorException, IOException {
+    Mockito.when(xmlConverter.getObjectMapper()).thenReturn(objectMapper);
+    Mockito.when(metadataSourceService.getByName(Mockito.anyString())).thenReturn(metadataSource);
+    Mockito.when(comicBookAdaptor.loadFile(Mockito.any(ComicBook.class), Mockito.anyString()))
+        .thenReturn(TEST_METADATA_CONTENT);
+    Mockito.when(
+            objectMapper.readValue(
+                byteArrayInputStreamArgumentCaptor.capture(), Mockito.any(Class.class)))
+        .thenReturn(comicInfo);
+    Mockito.doNothing().when(comicBook).setMetadata(comicMetadataSourceArgumentCaptor.capture());
+  }
+
+  @Test
+  public void testAfterPropertiesSet() {
+    processor.afterPropertiesSet();
+
+    Mockito.verify(objectMapper, Mockito.times(1))
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  }
+
+  @Test
+  public void testProcessNoSuchMetadataSource() throws Exception {
+    Mockito.when(metadataSourceService.getByName(Mockito.anyString())).thenReturn(null);
+
+    final ComicBook result = processor.process(comicBook);
+
+    assertNotNull(result);
+    assertSame(comicBook, result);
+
+    Mockito.verify(metadataSourceService, Mockito.times(1)).getByName(COMIC_VINE_METADATA_ADAPTOR);
+  }
+
+  @Test
+  public void testProcessNoContent() throws Exception {
+    Mockito.when(comicBookAdaptor.loadFile(Mockito.any(ComicBook.class), Mockito.anyString()))
+        .thenReturn(null);
+
+    final ComicBook result = processor.process(comicBook);
+
+    assertNotNull(result);
+    assertSame(comicBook, result);
+
+    Mockito.verify(metadataSourceService, Mockito.times(1)).getByName(COMIC_VINE_METADATA_ADAPTOR);
+    Mockito.verify(comicBookAdaptor, Mockito.times(1)).loadFile(comicBook, COMIC_INFO_XML);
+    Mockito.verify(comicBook, Mockito.never()).setMetadata(Mockito.any());
+  }
+
+  @Test
+  public void testProcessWithIOException() throws Exception {
+    Mockito.when(
+            objectMapper.readValue(
+                byteArrayInputStreamArgumentCaptor.capture(), Mockito.any(Class.class)))
+        .thenThrow(IOException.class);
+
+    final ComicBook result = processor.process(comicBook);
+
+    assertNotNull(result);
+    assertSame(comicBook, result);
+
+    final ByteArrayInputStream inputStream = byteArrayInputStreamArgumentCaptor.getValue();
+    assertNotNull(inputStream);
+    assertArrayEquals(TEST_METADATA_CONTENT, inputStream.readAllBytes());
+
+    Mockito.verify(metadataSourceService, Mockito.times(1)).getByName(COMIC_VINE_METADATA_ADAPTOR);
+    Mockito.verify(comicBookAdaptor, Mockito.times(1)).loadFile(comicBook, COMIC_INFO_XML);
+    Mockito.verify(comicBook, Mockito.never()).setMetadata(Mockito.any());
+  }
+
+  @Test
+  public void testProcessNoWebAddress() throws Exception {
+    Mockito.when(comicInfo.getWeb()).thenReturn(null);
+
+    final ComicBook result = processor.process(comicBook);
+
+    assertNotNull(result);
+    assertSame(comicBook, result);
+
+    final ByteArrayInputStream inputStream = byteArrayInputStreamArgumentCaptor.getValue();
+    assertNotNull(inputStream);
+    assertArrayEquals(TEST_METADATA_CONTENT, inputStream.readAllBytes());
+
+    Mockito.verify(metadataSourceService, Mockito.times(1)).getByName(COMIC_VINE_METADATA_ADAPTOR);
+    Mockito.verify(comicBookAdaptor, Mockito.times(1)).loadFile(comicBook, COMIC_INFO_XML);
+    Mockito.verify(comicInfo, Mockito.times(1)).getWeb();
+    Mockito.verify(comicBook, Mockito.never()).setMetadata(Mockito.any());
+  }
+
+  @Test
+  public void testProcessWebAddressDoesntMatch() throws Exception {
+    Mockito.when(comicInfo.getWeb()).thenReturn(TEST_WEB_ADDRESS_NO_MATCH);
+
+    Mockito.when(comicInfo.getWeb()).thenReturn(null);
+
+    final ComicBook result = processor.process(comicBook);
+
+    assertNotNull(result);
+    assertSame(comicBook, result);
+
+    final ByteArrayInputStream inputStream = byteArrayInputStreamArgumentCaptor.getValue();
+    assertNotNull(inputStream);
+    assertArrayEquals(TEST_METADATA_CONTENT, inputStream.readAllBytes());
+
+    Mockito.verify(metadataSourceService, Mockito.times(1)).getByName(COMIC_VINE_METADATA_ADAPTOR);
+    Mockito.verify(comicBookAdaptor, Mockito.times(1)).loadFile(comicBook, COMIC_INFO_XML);
+    Mockito.verify(comicInfo, Mockito.times(1)).getWeb();
+    Mockito.verify(comicBook, Mockito.never()).setMetadata(Mockito.any());
+  }
+
+  @Test
+  public void testProcess() throws Exception {
+    Mockito.when(comicInfo.getWeb()).thenReturn(TEST_WEB_ADDRESS);
+
+    final ComicBook result = processor.process(comicBook);
+
+    assertNotNull(result);
+    assertSame(comicBook, result);
+
+    final ByteArrayInputStream inputStream = byteArrayInputStreamArgumentCaptor.getValue();
+    assertNotNull(inputStream);
+    assertArrayEquals(TEST_METADATA_CONTENT, inputStream.readAllBytes());
+
+    final ComicMetadataSource metadata = comicMetadataSourceArgumentCaptor.getValue();
+    assertNotNull(metadata);
+    assertSame(comicBook, metadata.getComicBook());
+    assertSame(metadataSource, metadata.getMetadataSource());
+    assertEquals(TEST_COMIC_VINE_ID, metadata.getReferenceId());
+
+    Mockito.verify(metadataSourceService, Mockito.times(1)).getByName(COMIC_VINE_METADATA_ADAPTOR);
+    Mockito.verify(comicBookAdaptor, Mockito.times(1)).loadFile(comicBook, COMIC_INFO_XML);
+    Mockito.verify(comicInfo, Mockito.times(1)).getWeb();
+    Mockito.verify(comicBook, Mockito.times(1)).setMetadata(metadata);
+  }
+}

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/CreateMetadataSourceReaderTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/CreateMetadataSourceReaderTest.java
@@ -1,0 +1,95 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2022, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.batch.comicbooks.readers;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.assertSame;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.comixedproject.model.comicbooks.ComicBook;
+import org.comixedproject.service.comicbooks.ComicBookService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CreateMetadataSourceReaderTest {
+  private static final int MAX_RECORDS = 25;
+
+  @InjectMocks private CreateMetadataSourceReader reader;
+  @Mock private ComicBookService comicBookService;
+  @Mock private ComicBook comicBook;
+
+  private List<ComicBook> comicBookList = new ArrayList<>();
+
+  @Test
+  public void testReadNoneLoadedManyFound() {
+    for (int index = 0; index < MAX_RECORDS; index++) comicBookList.add(comicBook);
+
+    Mockito.when(comicBookService.findComicsWithCreateMetadataFlagSet(Mockito.anyInt()))
+        .thenReturn(comicBookList);
+
+    final ComicBook result = reader.read();
+
+    assertNotNull(result);
+    assertSame(comicBook, result);
+    assertFalse(comicBookList.isEmpty());
+    assertEquals(MAX_RECORDS - 1, comicBookList.size());
+
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findComicsWithCreateMetadataFlagSet(reader.getBatchChunkSize());
+  }
+
+  @Test
+  public void testReadNoneRemaining() {
+    Mockito.when(comicBookService.findComicsWithCreateMetadataFlagSet(Mockito.anyInt()))
+        .thenReturn(comicBookList);
+
+    reader.comicBookList = comicBookList;
+
+    final ComicBook result = reader.read();
+
+    assertNull(result);
+    assertNull(reader.comicBookList);
+
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findComicsWithCreateMetadataFlagSet(reader.getBatchChunkSize());
+  }
+
+  @Test
+  public void testReadNoneLoadedNoneFound() {
+    Mockito.when(comicBookService.findComicsWithCreateMetadataFlagSet(Mockito.anyInt()))
+        .thenReturn(comicBookList);
+
+    final ComicBook result = reader.read();
+
+    assertNull(result);
+    assertNull(reader.comicBookList);
+
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .findComicsWithCreateMetadataFlagSet(reader.getBatchChunkSize());
+  }
+}

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/writers/CreateMetadataSourceWriterTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/writers/CreateMetadataSourceWriterTest.java
@@ -1,6 +1,6 @@
 /*
- * ComiXed - A digital comicBook book library management application.
- * Copyright (C) 2021, The ComiXed Project
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2022, The ComiXed Project
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,6 +18,8 @@
 
 package org.comixedproject.batch.comicbooks.writers;
 
+import static org.junit.Assert.*;
+
 import java.util.ArrayList;
 import java.util.List;
 import org.comixedproject.model.comicbooks.ComicBook;
@@ -31,8 +33,8 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ComicBookInsertWriterTest {
-  @InjectMocks private ComicInsertWriter writer;
+public class CreateMetadataSourceWriterTest {
+  @InjectMocks private CreateMetadataSourceWriter writer;
   @Mock private ComicStateHandler comicStateHandler;
   @Mock private ComicBook comicBook;
 
@@ -45,6 +47,6 @@ public class ComicBookInsertWriterTest {
     writer.write(comicBookList);
 
     Mockito.verify(comicStateHandler, Mockito.times(comicBookList.size()))
-        .fireEvent(comicBook, ComicEvent.readyForProcessing);
+        .fireEvent(comicBook, ComicEvent.metadataSourceCreated);
   }
 }

--- a/comixed-model/src/main/java/org/comixedproject/model/comicbooks/ComicBook.java
+++ b/comixed-model/src/main/java/org/comixedproject/model/comicbooks/ComicBook.java
@@ -104,6 +104,12 @@ public class ComicBook {
   @Setter
   private ComicState comicState = ComicState.ADDED;
 
+  @Column(name = "CreateMetadataSource", nullable = false, updatable = true)
+  @JsonIgnore
+  @Getter
+  @Setter
+  private boolean createMetadataSource = false;
+
   @Column(name = "FileContentsLoaded", nullable = false, updatable = true)
   @JsonIgnore
   @Getter

--- a/comixed-model/src/main/java/org/comixedproject/model/messaging/batch/ProcessComicStatus.java
+++ b/comixed-model/src/main/java/org/comixedproject/model/messaging/batch/ProcessComicStatus.java
@@ -38,6 +38,7 @@ public class ProcessComicStatus {
   public static final String JOB_FINISHED = "add-comic-state.job-finished";
   public static final String STEP_NAME = "add-comic-state.step-name";
   public static final String CREATE_INSERT_STEP_NAME = "create-insert-step";
+  public static final String CREATE_METADATA_SOURCE_STEP_NAME = "create-metadata-source-step";
   public static final String LOAD_FILE_CONTENTS_STEP_NAME = "load-file-contents-step";
   public static final String MARK_BLOCKED_PAGES_STEP_NAME = "mark-blocked-pages-step";
   public static final String LOAD_FILE_DETAILS_STEP_NAME = "load-file-details-step";

--- a/comixed-model/src/main/java/org/comixedproject/model/metadata/ComicInfo.java
+++ b/comixed-model/src/main/java/org/comixedproject/model/metadata/ComicInfo.java
@@ -131,6 +131,11 @@ public class ComicInfo {
   @Setter
   private String locations;
 
+  @JsonProperty("Web")
+  @Getter
+  @Setter
+  private String web;
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) return true;
@@ -155,7 +160,8 @@ public class ComicInfo {
         && Objects.equals(publisher, comicInfo.publisher)
         && Objects.equals(characters, comicInfo.characters)
         && Objects.equals(teams, comicInfo.teams)
-        && Objects.equals(locations, comicInfo.locations);
+        && Objects.equals(locations, comicInfo.locations)
+        && Objects.equals(web, comicInfo.web);
   }
 
   @Override
@@ -180,6 +186,7 @@ public class ComicInfo {
         publisher,
         characters,
         teams,
-        locations);
+        locations,
+        web);
   }
 }

--- a/comixed-model/src/main/resources/db/migrations/1.1/004_1315_add_create_metadata_source_flag.xml
+++ b/comixed-model/src/main/resources/db/migrations/1.1/004_1315_add_create_metadata_source_flag.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="004_1315_add_create_metadata_source_flag.xml"
+             author="mcpierce">
+
+    <addColumn tableName="ComicBooks">
+      <column name="CreateMetadataSource"
+              type="boolean"
+              defaultValueBoolean="false">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+
+    <createIndex tableName="ComicBooks"
+                 indexName="ComicBookCreateMetadataSourceIdx">
+      <column name="CreateMetadataSource"/>
+    </createIndex>
+
+  </changeSet>
+</databaseChangeLog>

--- a/comixed-model/src/main/resources/db/migrations/1.1/changelog-1.1.xml
+++ b/comixed-model/src/main/resources/db/migrations/1.1/changelog-1.1.xml
@@ -9,5 +9,6 @@
   <include file="/db/migrations/1.1/001_1206_add_delete_empty_directories_option.xml"/>
   <include file="/db/migrations/1.1/002_1158_rename_comic_to_comic_book.xml"/>
   <include file="/db/migrations/1.1/003_1306_add_indices_for_opds.xml"/>
+  <include file="/db/migrations/1.1/004_1315_add_create_metadata_source_flag.xml"/>
 
 </databaseChangeLog>

--- a/comixed-repositories/src/main/java/org/comixedproject/repositories/comicbooks/ComicBookRepository.java
+++ b/comixed-repositories/src/main/java/org/comixedproject/repositories/comicbooks/ComicBookRepository.java
@@ -124,8 +124,18 @@ public interface ComicBookRepository extends JpaRepository<ComicBook, Long> {
    * @param state the state
    * @return the count
    */
-  @Query("SELECT COUNT(c) FROM ComicBook c WHERE c.comicState = :state ORDER BY c.lastModifiedOn")
+  @Query("SELECT COUNT(c) FROM ComicBook c WHERE c.comicState = :state")
   int findForStateCount(@Param("state") ComicState state);
+
+  /**
+   * Returns unprocessed comics that have their file loaded flag turned off.
+   *
+   * @param pageable the page request
+   * @return the list of comics
+   */
+  @Query(
+      "SELECT c FROM ComicBook c WHERE c.comicState = 'UNPROCESSED' AND c.createMetadataSource = true ORDER BY c.lastModifiedOn")
+  List<ComicBook> findUnprocessedComicsWithCreateMetadataFlagSet(Pageable pageable);
 
   /**
    * Returns unprocessed comics that have their file loaded flag turned off.
@@ -143,8 +153,17 @@ public interface ComicBookRepository extends JpaRepository<ComicBook, Long> {
    * @return the count
    */
   @Query(
-      "SELECT COUNT(c) FROM ComicBook c WHERE c.comicState = 'UNPROCESSED' AND c.fileContentsLoaded = false ORDER BY c.lastModifiedOn")
+      "SELECT COUNT(c) FROM ComicBook c WHERE c.comicState = 'UNPROCESSED' AND c.fileContentsLoaded = false")
   int findUnprocessedComicsWithoutContentCount();
+
+  /**
+   * Returns the number of comics with the create metadata source flag set.
+   *
+   * @return the count
+   */
+  @Query(
+      "SELECT COUNT(c) FROM ComicBook c WHERE c.comicState = 'UNPROCESSED' AND c.createMetadataSource = true")
+  int findComicsWithCreateMeatadataSourceFlag();
 
   /**
    * Returns unprocessed comics that have their blocked pages marked flag turned off.
@@ -162,7 +181,7 @@ public interface ComicBookRepository extends JpaRepository<ComicBook, Long> {
    * @return the count
    */
   @Query(
-      "SELECT COUNT(c) FROM ComicBook c WHERE c.comicState = 'UNPROCESSED' AND c.fileContentsLoaded = true AND c.blockedPagesMarked = false ORDER BY c.lastModifiedOn")
+      "SELECT COUNT(c) FROM ComicBook c WHERE c.comicState = 'UNPROCESSED' AND c.fileContentsLoaded = true AND c.blockedPagesMarked = false")
   int findUnprocessedComicsForMarkedPageBlockingCount();
 
   /**
@@ -200,7 +219,7 @@ public interface ComicBookRepository extends JpaRepository<ComicBook, Long> {
    * @return the count
    */
   @Query(
-      "SELECT COUNT(c) FROM ComicBook c WHERE c.comicState = 'UNPROCESSED' AND c.fileContentsLoaded = true AND c.blockedPagesMarked = true ORDER BY c.lastModifiedOn")
+      "SELECT COUNT(c) FROM ComicBook c WHERE c.comicState = 'UNPROCESSED' AND c.fileContentsLoaded = true AND c.blockedPagesMarked = true")
   int findProcessedComicsCount();
 
   /**

--- a/comixed-repositories/src/main/java/org/comixedproject/repositories/metadata/MetadataSourceRepository.java
+++ b/comixed-repositories/src/main/java/org/comixedproject/repositories/metadata/MetadataSourceRepository.java
@@ -49,4 +49,13 @@ public interface MetadataSourceRepository extends JpaRepository<MetadataSource, 
    */
   @Query("SELECT s FROM MetadataSource s WHERE s.id = :id")
   MetadataSource getById(@Param("id") final long id);
+
+  /**
+   * Returns a single record by bean name.
+   *
+   * @param name the bean name
+   * @return the record
+   */
+  @Query("SELECT s FROM MetadataSource s WHERE s.beanName = :name")
+  MetadataSource getByName(@Param("name") String name);
 }

--- a/comixed-repositories/src/test/resources/test-database.xml
+++ b/comixed-repositories/src/test/resources/test-database.xml
@@ -29,7 +29,8 @@
               UpdateMetadata="true"
               Consolidating="false"
               Recreating="true"
-              PurgeComic="false"/>
+              PurgeComic="false"
+              CreateMetadataSource="false"/>
   <ComicBooks Id="1001"
               Filename="C:/users/mcpierce/Documents/comicBooks/example2.cbz"
               ComicState="STABLE"
@@ -47,7 +48,8 @@
               UpdateMetadata="true"
               Consolidating="false"
               Recreating="true"
-              PurgeComic="false"/>
+              PurgeComic="false"
+              CreateMetadataSource="false"/>
   <ComicBooks Id="1002"
               Filename="C:/users/mcpierce/Documents/comicBooks/example3.cbz"
               ComicState="STABLE"
@@ -65,7 +67,8 @@
               UpdateMetadata="true"
               Consolidating="false"
               Recreating="true"
-              PurgeComic="false"/>
+              PurgeComic="false"
+              CreateMetadataSource="false"/>
   <ComicBooks Id="1003"
               Filename="C:/users/mcpierce/Documents/comicBooks/example4.cbz"
               ComicState="STABLE"
@@ -83,7 +86,8 @@
               UpdateMetadata="true"
               Consolidating="false"
               Recreating="true"
-              PurgeComic="false"/>
+              PurgeComic="false"
+              CreateMetadataSource="false"/>
   <ComicBooks Id="1004"
               Filename="C:/users/mcpierce/Documents/comicBooks/example5.cbz"
               ComicState="STABLE"
@@ -101,7 +105,8 @@
               UpdateMetadata="true"
               Consolidating="false"
               Recreating="true"
-              PurgeComic="false"/>
+              PurgeComic="false"
+              CreateMetadataSource="false"/>
   <ComicBooks Id="1005"
               Filename="C:/users/mcpierce/Documents/comicBooks/example6.cbz"
               ComicState="STABLE"
@@ -119,7 +124,8 @@
               UpdateMetadata="true"
               Consolidating="false"
               Recreating="true"
-              PurgeComic="false"/>
+              PurgeComic="false"
+              CreateMetadataSource="false"/>
   <ComicBooks Id="1006"
               Filename="C:/users/mcpierce/Documents/comicBooks/example7.cbz"
               ComicState="STABLE"
@@ -137,7 +143,8 @@
               UpdateMetadata="true"
               Consolidating="false"
               Recreating="true"
-              PurgeComic="false"/>
+              PurgeComic="false"
+              CreateMetadataSource="false"/>
   <ComicBooks Id="1010"
               Filename="C:/users/mcpierce/Documents/comicBooks/deleted-example1.cbz"
               ComicState="DELETED"
@@ -155,7 +162,8 @@
               UpdateMetadata="true"
               Consolidating="false"
               Recreating="true"
-              PurgeComic="false"/>
+              PurgeComic="false"
+              CreateMetadataSource="false"/>
   <ComicBooks Id="1020"
               Filename="C:/users/mcpierce/Documents/comicBooks/duplicate-1.cbz"
               ComicState="STABLE"
@@ -173,7 +181,8 @@
               UpdateMetadata="true"
               Consolidating="false"
               Recreating="true"
-              PurgeComic="false"/>
+              PurgeComic="false"
+              CreateMetadataSource="false"/>
   <ComicBooks Id="1021"
               Filename="C:/users/mcpierce/Documents/comicBooks/duplicate-2.cbz"
               ComicState="STABLE"
@@ -191,7 +200,8 @@
               UpdateMetadata="true"
               Consolidating="false"
               Recreating="true"
-              PurgeComic="false"/>
+              PurgeComic="false"
+              CreateMetadataSource="false"/>
   <ComicBooks Id="2000"
               Filename="C:/users/mcpierce/Documents/comicBooks/unread-1.cbz"
               ComicState="STABLE"
@@ -209,7 +219,8 @@
               UpdateMetadata="true"
               Consolidating="false"
               Recreating="true"
-              PurgeComic="false"/>
+              PurgeComic="false"
+              CreateMetadataSource="false"/>
   <CharacterTags ComicBookId="1000"
                  Name="Captain America"/>
   <CharacterTags ComicBookId="1000"

--- a/comixed-services/src/main/java/org/comixedproject/service/comicbooks/ComicBookService.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/comicbooks/ComicBookService.java
@@ -328,6 +328,28 @@ public class ComicBookService implements InitializingBean, ComicStateChangeListe
   }
 
   /**
+   * Returns the number of comic books with the create metadata source flag set.
+   *
+   * @return the comic book count
+   */
+  public long getWithCreateMetadataSourceFlagCount() {
+    log.trace("Getting comics with the create metadata source flag set");
+    return this.comicBookRepository.findComicsWithCreateMeatadataSourceFlag();
+  }
+
+  /**
+   * Retrieves unprocessed comics that have the create metadata flag set.
+   *
+   * @param count the number of comics to return
+   * @return the comics
+   */
+  public List<ComicBook> findComicsWithCreateMetadataFlagSet(int count) {
+    log.trace("Loading unprocessed comics that need to have their contents loaded");
+    return this.comicBookRepository.findUnprocessedComicsWithCreateMetadataFlagSet(
+        PageRequest.of(0, count));
+  }
+
+  /**
    * Retrieves unprocessed comics that are waiting to have their contents loaded.
    *
    * @param count the number of comics to return

--- a/comixed-services/src/main/java/org/comixedproject/service/metadata/MetadataSourceService.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/metadata/MetadataSourceService.java
@@ -62,6 +62,17 @@ public class MetadataSourceService {
     return this.doGetById(id);
   }
 
+  /**
+   * Loads a single metadata source by the bean name.
+   *
+   * @param name the bean name
+   * @return the source
+   */
+  public MetadataSource getByName(final String name) {
+    log.debug("Loading metadata source: name={}", name);
+    return this.metadataSourceRepository.getByName(name);
+  }
+
   private MetadataSource doGetById(final long id) throws MetadataSourceException {
     final MetadataSource result = this.metadataSourceRepository.getById(id);
     if (result == null) throw new MetadataSourceException("No such metadata source: id=" + id);

--- a/comixed-services/src/test/java/org/comixedproject/service/comicbooks/ComicBookServiceTest.java
+++ b/comixed-services/src/test/java/org/comixedproject/service/comicbooks/ComicBookServiceTest.java
@@ -508,6 +508,18 @@ public class ComicBookServiceTest {
   }
 
   @Test
+  public void testGetWithCreateMetadataSourceFlag() {
+    Mockito.when(comicBookRepository.findComicsWithCreateMeatadataSourceFlag())
+        .thenReturn(TEST_MAXIMUM_COMICS);
+
+    final long result = service.getWithCreateMetadataSourceFlagCount();
+
+    assertEquals(TEST_MAXIMUM_COMICS, result);
+
+    Mockito.verify(comicBookRepository, Mockito.times(1)).findComicsWithCreateMeatadataSourceFlag();
+  }
+
+  @Test
   public void testFindUnprocessedComicsWithoutContent() {
     Mockito.when(comicBookRepository.findUnprocessedComicsWithoutContent(pageableCaptor.capture()))
         .thenReturn(comicBookList);

--- a/comixed-services/src/test/java/org/comixedproject/service/metadata/MetadataSourceServiceTest.java
+++ b/comixed-services/src/test/java/org/comixedproject/service/metadata/MetadataSourceServiceTest.java
@@ -103,6 +103,30 @@ public class MetadataSourceServiceTest {
     Mockito.verify(metadataSourceRepository, Mockito.times(1)).getById(TEST_SOURCE_ID);
   }
 
+  @Test
+  public void testGetByNameNotFound() {
+    Mockito.when(metadataSourceRepository.getByName(Mockito.anyString())).thenReturn(null);
+
+    final MetadataSource result = service.getByName(TEST_BEAN_NAME);
+
+    assertNull(result);
+
+    Mockito.verify(metadataSourceRepository, Mockito.times(1)).getByName(TEST_BEAN_NAME);
+  }
+
+  @Test
+  public void testGetByName() {
+    Mockito.when(metadataSourceRepository.getByName(Mockito.anyString()))
+        .thenReturn(existingSource);
+
+    final MetadataSource result = service.getByName(TEST_BEAN_NAME);
+
+    assertNotNull(result);
+    assertSame(existingSource, result);
+
+    Mockito.verify(metadataSourceRepository, Mockito.times(1)).getByName(TEST_BEAN_NAME);
+  }
+
   @Test(expected = MetadataSourceException.class)
   public void testCreateExceptionOnSave() throws MetadataSourceException {
     Mockito.when(metadataSourceRepository.save(metadataSourceArgumentCaptor.capture()))

--- a/comixed-state/src/main/java/org/comixedproject/state/comicbooks/ComicEvent.java
+++ b/comixed-state/src/main/java/org/comixedproject/state/comicbooks/ComicEvent.java
@@ -28,6 +28,8 @@ public enum ComicEvent {
   recordInserted,
   // the record is ready for processing
   readyForProcessing,
+  // metadata source created
+  metadataSourceCreated,
   // the file entries have been loaded
   fileContentsLoaded,
   // blocked pages have been marked

--- a/comixed-state/src/main/java/org/comixedproject/state/comicbooks/ComicStateMachineConfiguration.java
+++ b/comixed-state/src/main/java/org/comixedproject/state/comicbooks/ComicStateMachineConfiguration.java
@@ -42,6 +42,7 @@ public class ComicStateMachineConfiguration
     extends EnumStateMachineConfigurerAdapter<ComicState, ComicEvent> {
   @Autowired private PrepareComicForProcessingAction prepareComicForProcessingAction;
   @Autowired private FileContentsLoadedAction fileContentsLoadedAction;
+  @Autowired private MetadataSourceCreatedAction metadataSourceCreatedAction;
   @Autowired private BlockedPagesMarkedAction blockedPagesMarkedAction;
   @Autowired private FileDetailsCreatedGuard fileDetailsCreatedGuard;
   @Autowired private ComicContentsProcessedGuard comicContentsProcessedGuard;
@@ -101,6 +102,13 @@ public class ComicStateMachineConfiguration
         .target(ComicState.UNPROCESSED)
         .event(ComicEvent.rescanComic)
         .action(prepareComicForProcessingAction)
+        // the comic file contents have been loaded
+        .and()
+        .withExternal()
+        .source(ComicState.UNPROCESSED)
+        .target(ComicState.UNPROCESSED)
+        .event(ComicEvent.metadataSourceCreated)
+        .action(metadataSourceCreatedAction)
         // the comic file contents have been loaded
         .and()
         .withExternal()

--- a/comixed-state/src/main/java/org/comixedproject/state/comicbooks/actions/MetadataSourceCreatedAction.java
+++ b/comixed-state/src/main/java/org/comixedproject/state/comicbooks/actions/MetadataSourceCreatedAction.java
@@ -1,6 +1,6 @@
 /*
  * ComiXed - A digital comic book library management application.
- * Copyright (C) 2021, The ComiXed Project
+ * Copyright (C) 2022, The ComiXed Project
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,22 +16,28 @@
  * along with this program. If not, see <http://www.gnu.org/licenses>
  */
 
-package org.comixedproject.batch.comicbooks.writers;
+package org.comixedproject.state.comicbooks.actions;
 
+import lombok.extern.log4j.Log4j2;
 import org.comixedproject.model.comicbooks.ComicBook;
+import org.comixedproject.model.comicbooks.ComicState;
 import org.comixedproject.state.comicbooks.ComicEvent;
-import org.springframework.batch.item.ItemWriter;
+import org.springframework.statemachine.StateContext;
 import org.springframework.stereotype.Component;
 
 /**
- * <code>LoadFileContentsWriter</code> provides an {@link ItemWriter} for instances of {@link
- * ComicBook} that have had their contents loaded.
+ * <code>MetadataSourceCreatedAction</code> is executed after comic book's metadata source was
+ * created.
  *
  * @author Darryl L. Pierce
  */
 @Component
-public class LoadFileContentsWriter extends AbstractComicWriter {
-  public LoadFileContentsWriter() {
-    super(ComicEvent.fileContentsLoaded);
+@Log4j2
+public class MetadataSourceCreatedAction extends AbstractComicAction {
+  @Override
+  public void execute(final StateContext<ComicState, ComicEvent> context) {
+    final ComicBook comicBook = this.fetchComic(context);
+    log.trace("Turning off create metadata source flag");
+    comicBook.setCreateMetadataSource(false);
   }
 }

--- a/comixed-state/src/main/java/org/comixedproject/state/comicbooks/actions/PrepareComicForProcessingAction.java
+++ b/comixed-state/src/main/java/org/comixedproject/state/comicbooks/actions/PrepareComicForProcessingAction.java
@@ -41,6 +41,8 @@ public class PrepareComicForProcessingAction extends AbstractComicAction {
     comicBook.setFileDetails(null);
     log.trace("Clearing pages");
     comicBook.getPages().clear();
+    log.trace("Turn on creating metadata source flag");
+    comicBook.setCreateMetadataSource(true);
     log.trace("Turning off file contents loaded flag");
     comicBook.setFileContentsLoaded(false);
     log.trace("Turning off blocked pages marked flag");

--- a/comixed-state/src/test/java/org/comixedproject/state/comicbooks/actions/MetadataSourceCreatedActionTest.java
+++ b/comixed-state/src/test/java/org/comixedproject/state/comicbooks/actions/MetadataSourceCreatedActionTest.java
@@ -1,6 +1,6 @@
 /*
- * ComiXed - A digital comicBook book library management application.
- * Copyright (C) 2021, The ComiXed Project
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2022, The ComiXed Project
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,10 +18,10 @@
 
 package org.comixedproject.state.comicbooks.actions;
 
-import java.util.List;
+import static org.junit.Assert.*;
+
 import org.comixedproject.model.comicbooks.ComicBook;
 import org.comixedproject.model.comicbooks.ComicState;
-import org.comixedproject.model.comicpages.Page;
 import org.comixedproject.state.comicbooks.ComicEvent;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,12 +34,11 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.statemachine.StateContext;
 
 @RunWith(MockitoJUnitRunner.class)
-public class PrepareComicBookForProcessingActionTest {
-  @InjectMocks private PrepareComicForProcessingAction action;
+public class MetadataSourceCreatedActionTest {
+  @InjectMocks private MetadataSourceCreatedAction action;
   @Mock private StateContext<ComicState, ComicEvent> context;
   @Mock private MessageHeaders messageHeaders;
   @Mock private ComicBook comicBook;
-  @Mock private List<Page> pageList;
 
   @Before
   public void setUp() {
@@ -49,15 +48,9 @@ public class PrepareComicBookForProcessingActionTest {
   }
 
   @Test
-  public void testEvaluate() {
-    Mockito.when(comicBook.getPages()).thenReturn(pageList);
-
+  public void testExecute() {
     action.execute(context);
 
-    Mockito.verify(comicBook, Mockito.times(1)).setFileDetails(null);
-    Mockito.verify(pageList, Mockito.times(1)).clear();
-    Mockito.verify(comicBook, Mockito.times(1)).setCreateMetadataSource(true);
-    Mockito.verify(comicBook, Mockito.times(1)).setFileContentsLoaded(false);
-    Mockito.verify(comicBook, Mockito.times(1)).setBlockedPagesMarked(false);
+    Mockito.verify(comicBook, Mockito.times(1)).setCreateMetadataSource(false);
   }
 }

--- a/comixed-webui/src/assets/i18n/de/comic-files.json
+++ b/comixed-webui/src/assets/i18n/de/comic-files.json
@@ -38,6 +38,7 @@
     },
     "processing-comics": {
       "create-insert-step": "Creating Comic Records",
+      "create-metadata-source-step": "Loaing Comic Book Metadata",
       "file-contents-processed-step": "Completing Processing",
       "load-file-contents-step": "Loading File Contents",
       "load-file-details-step": "Loading Comic File Details",

--- a/comixed-webui/src/assets/i18n/en/comic-files.json
+++ b/comixed-webui/src/assets/i18n/en/comic-files.json
@@ -38,6 +38,7 @@
     },
     "processing-comics": {
       "create-insert-step": "Creating Comic Records",
+      "create-metadata-source-step": "Loaing Comic Book Metadata",
       "file-contents-processed-step": "Completing Processing",
       "load-file-contents-step": "Loading File Contents",
       "load-file-details-step": "Loading Comic File Details",

--- a/comixed-webui/src/assets/i18n/es/comic-files.json
+++ b/comixed-webui/src/assets/i18n/es/comic-files.json
@@ -38,9 +38,10 @@
     },
     "processing-comics": {
       "create-insert-step": "Creating Comic Records",
+      "create-metadata-source-step": "Loaing Comic Book Metadata",
+      "load-file-details-step": "Loading Comic File Details",
       "file-contents-processed-step": "Completing Processing",
       "load-file-contents-step": "Loading File Contents",
-      "load-file-details-step": "Loading Comic File Details",
       "mark-blocked-pages-step": "Marking Blocked Pages",
       "subtitle": "Processed {processed} Of {total} Comics ({percentage}%)"
     },

--- a/comixed-webui/src/assets/i18n/fr/comic-files.json
+++ b/comixed-webui/src/assets/i18n/fr/comic-files.json
@@ -38,6 +38,7 @@
     },
     "processing-comics": {
       "create-insert-step": "Création de registres de bande dessinée",
+      "create-metadata-source-step": "Loaing Comic Book Metadata",
       "file-contents-processed-step": "Achèvement du traitement",
       "load-file-contents-step": "Chargement du contenu des fichiers",
       "load-file-details-step": "Chargement des détails de fichiers de bande dessinée",

--- a/comixed-webui/src/assets/i18n/pt/comic-files.json
+++ b/comixed-webui/src/assets/i18n/pt/comic-files.json
@@ -37,6 +37,12 @@
       "root-directory": "Pasta raiz para procurar..."
     },
     "processing-comics": {
+      "create-insert-step": "Creating Comic Records",
+      "create-metadata-source-step": "Loaing Comic Book Metadata",
+      "file-contents-processed-step": "Completing Processing",
+      "load-file-contents-step": "Loading File Contents",
+      "load-file-details-step": "Loading Comic File Details",
+      "mark-blocked-pages-step": "Marking Blocked Pages",
       "subtitle": "Analisados {processed} de {total} Comics ({percentage}%)"
     },
     "tab-title": "Importar Comics",


### PR DESCRIPTION
 * Added a new column to the ComicBooks table.
 * Added a new comic book event to handle state changes.

If, during import, a comic has a ComicVine ID in its metadata,
then a MetadataSource is automatically created for it.

Closes #1315 

## Status
READY

## Does this PR contain migrations?
YES

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

