### PR TITLE
Changed the series OPDS feed to poing to publishers [#1494]

### DIFF
--- a/comixed-model/src/main/java/org/comixedproject/model/comicbooks/ComicTagType.java
+++ b/comixed-model/src/main/java/org/comixedproject/model/comicbooks/ComicTagType.java
@@ -30,19 +30,20 @@ import lombok.Getter;
  */
 @AllArgsConstructor
 public enum ComicTagType {
-  CHARACTER("character"),
-  TEAM("team"),
-  LOCATION("location"),
-  STORY("story"),
-  WRITER("writer"),
-  EDITOR("editor"),
-  PENCILLER("penciller"),
-  INKER("inker"),
-  COLORIST("colorist"),
-  LETERRER("leterrer"),
-  COVER("cover");
+  CHARACTER("character", "CHARACTER"),
+  TEAM("team", "TEAM"),
+  LOCATION("location", "LOCATION"),
+  STORY("story", "STORIE"),
+  WRITER("writer", "WRITER"),
+  EDITOR("editor", "EDITOR"),
+  PENCILLER("penciller", "PENCILLER"),
+  INKER("inker", "INKER"),
+  COLORIST("colorist", "COLORIST"),
+  LETERRER("leterrer", "LETERRER"),
+  COVER("cover", "COVER");
 
   @Getter private String value;
+  @Getter private String opdsValue;
 
   public static ComicTagType forValue(final String value) {
     final Optional<ComicTagType> result =

--- a/comixed-opds/src/main/java/org/comixedproject/opds/OPDSUtils.java
+++ b/comixed-opds/src/main/java/org/comixedproject/opds/OPDSUtils.java
@@ -28,6 +28,7 @@ import org.comixedproject.adaptors.comicbooks.ComicBookAdaptor;
 import org.comixedproject.adaptors.comicbooks.ComicBookMetadataAdaptor;
 import org.comixedproject.adaptors.file.FileTypeAdaptor;
 import org.comixedproject.model.comicbooks.ComicDetail;
+import org.comixedproject.model.comicbooks.ComicTagType;
 import org.comixedproject.opds.model.OPDSAcquisitionFeedContent;
 import org.comixedproject.opds.model.OPDSAcquisitionFeedEntry;
 import org.comixedproject.opds.model.OPDSLink;
@@ -130,6 +131,17 @@ public class OPDSUtils {
     result.getLinks().add(this.createComicLink(comicDetail));
     result.setContent(new OPDSAcquisitionFeedContent(comicDetail.getBaseFilename()));
     return result;
+  }
+
+  /**
+   * Generates a unique identifier for the given type and name.
+   *
+   * @param type the type
+   * @param name the name
+   * @return the identifier
+   */
+  public Long createIdForEntry(@NonNull final ComicTagType type, @NonNull final String name) {
+    return createIdForEntry(type.getOpdsValue(), name);
   }
 
   /**

--- a/comixed-opds/src/main/java/org/comixedproject/opds/model/CollectionType.java
+++ b/comixed-opds/src/main/java/org/comixedproject/opds/model/CollectionType.java
@@ -1,13 +1,24 @@
 package org.comixedproject.opds.model;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.comixedproject.model.comicbooks.ComicTagType;
+
 /**
  * <code>CollectionType</code> names the types of collections.
  *
  * @author Darryl L. Pierce
  */
+@AllArgsConstructor
 public enum CollectionType {
-  characters,
-  teams,
-  locations,
-  stories;
+  characters("CHARACTER", 13, ComicTagType.CHARACTER, "Characters", "characters"),
+  teams("TEAM", 14, ComicTagType.TEAM, "Teams", "teams"),
+  locations("LOCATION", 15, ComicTagType.LOCATION, "Locations", "locations"),
+  stories("STORIES", 16, ComicTagType.STORY, "Stories", "stories");
+
+  @Getter private String opdsIdValue;
+  @Getter private Integer opdsIdKey;
+  @Getter private ComicTagType comicTagType;
+  @Getter private String opdsNavigationFeedTitle;
+  @Getter private String opdsPathValue;
 }

--- a/comixed-opds/src/main/java/org/comixedproject/opds/rest/OPDSSeriesController.java
+++ b/comixed-opds/src/main/java/org/comixedproject/opds/rest/OPDSSeriesController.java
@@ -23,7 +23,6 @@ import java.security.Principal;
 import lombok.NonNull;
 import lombok.extern.log4j.Log4j2;
 import org.comixedproject.opds.OPDSUtils;
-import org.comixedproject.opds.model.OPDSAcquisitionFeed;
 import org.comixedproject.opds.model.OPDSNavigationFeed;
 import org.comixedproject.opds.service.OPDSAcquisitionService;
 import org.comixedproject.opds.service.OPDSNavigationService;
@@ -59,7 +58,7 @@ public class OPDSSeriesController {
   public OPDSNavigationFeed getRootFeedForSeries(
       final Principal principal, @RequestParam(name = "unread") final boolean unread) {
     final String email = principal.getName();
-    log.info("Getting publisher root feed: email={} unread={}", email, unread);
+    log.info("Getting series root feed: email={} unread={}", email, unread);
     return this.opdsNavigationService.getRootFeedForSeries(email, unread);
   }
 
@@ -75,41 +74,13 @@ public class OPDSSeriesController {
   @PreAuthorize("hasRole('READER')")
   @Timed(value = "comixed.opds.collections.series.get-volumes")
   @ResponseBody
-  public OPDSNavigationFeed getVolumesFeedForSeries(
+  public OPDSNavigationFeed getPublishersFeedForSeries(
       final Principal principal,
       @PathVariable("name") @NonNull final String name,
       @RequestParam(name = "unread", defaultValue = "false") final boolean unread) {
     final String seriesName = this.opdsUtils.urlDecodeString(name);
     final String email = principal.getName();
     log.info("Getting volumes feed: series={} email={} unread={}", seriesName, email, unread);
-    return this.opdsNavigationService.getVolumesFeedForSeries(seriesName, email, unread);
-  }
-
-  /**
-   * Returns the acquisition feed of comics for a given series and volume.
-   *
-   * @param principal the user principal
-   * @param series the series name
-   * @param volume the volume
-   * @param unread the unread flag
-   * @return the acquisition feed
-   */
-  @GetMapping(
-      value = "/opds/collections/series/{name}/volumes/{volume}",
-      produces = MediaType.APPLICATION_XML_VALUE)
-  @PreAuthorize("hasRole('READER')")
-  @Timed(value = "comixed.opds.series.get-comics")
-  @ResponseBody
-  public OPDSAcquisitionFeed getComicFeedForSeriesAndVolumes(
-      final Principal principal,
-      @PathVariable("name") @NonNull final String series,
-      @PathVariable("volume") @NonNull final String volume,
-      @RequestParam(name = "unread", defaultValue = "false") final boolean unread) {
-    final String email = principal.getName();
-    final String seriesName = this.opdsUtils.urlDecodeString(series);
-    final String volumeName = this.opdsUtils.urlDecodeString(volume);
-    log.info("Getting acquisition feed for series and volume: {} v{}", seriesName, volumeName);
-    return this.opdsAcquisitionService.getComicFeedForSeriesAndVolumes(
-        seriesName, volumeName, email, unread);
+    return this.opdsNavigationService.getPublishersFeedForSeries(seriesName, email, unread);
   }
 }

--- a/comixed-opds/src/test/java/org/comixedproject/opds/rest/OPDSSeriesControllerTest.java
+++ b/comixed-opds/src/test/java/org/comixedproject/opds/rest/OPDSSeriesControllerTest.java
@@ -77,46 +77,18 @@ public class OPDSSeriesControllerTest {
     Mockito.when(opdsUtils.urlDecodeString(Mockito.anyString()))
         .thenReturn(TEST_SERIES_NAME_DECODED);
     Mockito.when(
-            opdsNavigationService.getVolumesFeedForSeries(
+            opdsNavigationService.getPublishersFeedForSeries(
                 Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean()))
         .thenReturn(opdsNavigationFeed);
 
     final OPDSNavigationFeed result =
-        controller.getVolumesFeedForSeries(principal, TEST_SERIES_NAME_ENCODED, TEST_UNREAD);
+        controller.getPublishersFeedForSeries(principal, TEST_SERIES_NAME_ENCODED, TEST_UNREAD);
 
     assertNotNull(result);
     assertSame(opdsNavigationFeed, result);
 
     Mockito.verify(opdsUtils, Mockito.times(1)).urlDecodeString(TEST_SERIES_NAME_ENCODED);
     Mockito.verify(opdsNavigationService, Mockito.times(1))
-        .getVolumesFeedForSeries(TEST_SERIES_NAME_DECODED, TEST_EMAIL, TEST_UNREAD);
-  }
-
-  @Test
-  public void testGetComicFeedForSeriesAndVolume() {
-    Mockito.when(opdsUtils.urlDecodeString(TEST_SERIES_NAME_ENCODED))
-        .thenReturn(TEST_SERIES_NAME_DECODED);
-    Mockito.when(opdsUtils.urlDecodeString(TEST_VOLUME_NAME_ENCODED))
-        .thenReturn(TEST_VOLUME_NAME_DECODED);
-    Mockito.when(
-            opdsAcquisitionService.getComicFeedForSeriesAndVolumes(
-                Mockito.anyString(),
-                Mockito.anyString(),
-                Mockito.anyString(),
-                Mockito.anyBoolean()))
-        .thenReturn(opdsAcquisitionFeed);
-
-    final OPDSAcquisitionFeed result =
-        controller.getComicFeedForSeriesAndVolumes(
-            principal, TEST_SERIES_NAME_ENCODED, TEST_VOLUME_NAME_ENCODED, TEST_UNREAD);
-
-    assertNotNull(result);
-    assertSame(opdsAcquisitionFeed, result);
-
-    Mockito.verify(opdsUtils, Mockito.times(1)).urlDecodeString(TEST_SERIES_NAME_ENCODED);
-    Mockito.verify(opdsUtils, Mockito.times(1)).urlDecodeString(TEST_VOLUME_NAME_ENCODED);
-    Mockito.verify(opdsAcquisitionService, Mockito.times(1))
-        .getComicFeedForSeriesAndVolumes(
-            TEST_SERIES_NAME_DECODED, TEST_VOLUME_NAME_DECODED, TEST_EMAIL, TEST_UNREAD);
+        .getPublishersFeedForSeries(TEST_SERIES_NAME_DECODED, TEST_EMAIL, TEST_UNREAD);
   }
 }

--- a/comixed-opds/src/test/java/org/comixedproject/opds/service/OPDSAcquisitionServiceTest.java
+++ b/comixed-opds/src/test/java/org/comixedproject/opds/service/OPDSAcquisitionServiceTest.java
@@ -22,10 +22,6 @@ import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
-import static org.comixedproject.opds.service.OPDSAcquisitionService.TAG_TYPE_CHARACTER;
-import static org.comixedproject.opds.service.OPDSAcquisitionService.TAG_TYPE_LOCATION;
-import static org.comixedproject.opds.service.OPDSAcquisitionService.TAG_TYPE_STORY;
-import static org.comixedproject.opds.service.OPDSAcquisitionService.TAG_TYPE_TEAM;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,6 +29,7 @@ import junit.framework.TestCase;
 import org.apache.commons.lang.math.RandomUtils;
 import org.comixedproject.model.comicbooks.ComicBook;
 import org.comixedproject.model.comicbooks.ComicDetail;
+import org.comixedproject.model.comicbooks.ComicTagType;
 import org.comixedproject.model.lists.ReadingList;
 import org.comixedproject.opds.OPDSException;
 import org.comixedproject.opds.OPDSUtils;
@@ -94,7 +91,7 @@ public class OPDSAcquisitionServiceTest {
   public void testGetEntriesForCollectionFeedForCharacter() {
     Mockito.when(
             comicDetailService.getAllComicsForTag(
-                Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean()))
+                Mockito.any(ComicTagType.class), Mockito.anyString(), Mockito.anyBoolean()))
         .thenReturn(comicDetailList);
 
     final OPDSAcquisitionFeed result =
@@ -105,14 +102,14 @@ public class OPDSAcquisitionServiceTest {
     assertFalse(result.getEntries().isEmpty());
 
     Mockito.verify(comicDetailService, Mockito.times(1))
-        .getAllComicsForTag(TAG_TYPE_CHARACTER, TEST_EMAIL, TEST_UNREAD);
+        .getAllComicsForTag(ComicTagType.CHARACTER, TEST_EMAIL, TEST_UNREAD);
   }
 
   @Test
   public void testGetEntriesForCollectionFeedForTeam() {
     Mockito.when(
             comicDetailService.getAllComicsForTag(
-                Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean()))
+                Mockito.any(ComicTagType.class), Mockito.anyString(), Mockito.anyBoolean()))
         .thenReturn(comicDetailList);
 
     final OPDSAcquisitionFeed result =
@@ -123,14 +120,14 @@ public class OPDSAcquisitionServiceTest {
     assertFalse(result.getEntries().isEmpty());
 
     Mockito.verify(comicDetailService, Mockito.times(1))
-        .getAllComicsForTag(TAG_TYPE_TEAM, TEST_EMAIL, TEST_UNREAD);
+        .getAllComicsForTag(ComicTagType.TEAM, TEST_EMAIL, TEST_UNREAD);
   }
 
   @Test
   public void testGetEntriesForCollectionFeedForLocation() {
     Mockito.when(
             comicDetailService.getAllComicsForTag(
-                Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean()))
+                Mockito.any(ComicTagType.class), Mockito.anyString(), Mockito.anyBoolean()))
         .thenReturn(comicDetailList);
 
     final OPDSAcquisitionFeed result =
@@ -141,14 +138,14 @@ public class OPDSAcquisitionServiceTest {
     assertFalse(result.getEntries().isEmpty());
 
     Mockito.verify(comicDetailService, Mockito.times(1))
-        .getAllComicsForTag(TAG_TYPE_LOCATION, TEST_EMAIL, TEST_UNREAD);
+        .getAllComicsForTag(ComicTagType.LOCATION, TEST_EMAIL, TEST_UNREAD);
   }
 
   @Test
   public void testGetEntriesForCollectionFeedForStory() {
     Mockito.when(
             comicDetailService.getAllComicsForTag(
-                Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean()))
+                Mockito.any(ComicTagType.class), Mockito.anyString(), Mockito.anyBoolean()))
         .thenReturn(comicDetailList);
 
     final OPDSAcquisitionFeed result =
@@ -159,7 +156,7 @@ public class OPDSAcquisitionServiceTest {
     assertFalse(result.getEntries().isEmpty());
 
     Mockito.verify(comicDetailService, Mockito.times(1))
-        .getAllComicsForTag(TAG_TYPE_STORY, TEST_EMAIL, TEST_UNREAD);
+        .getAllComicsForTag(ComicTagType.STORY, TEST_EMAIL, TEST_UNREAD);
   }
 
   @Test
@@ -182,26 +179,6 @@ public class OPDSAcquisitionServiceTest {
     Mockito.verify(comicDetailService, Mockito.times(1))
         .getAllComicBooksForPublisherAndSeriesAndVolume(
             TEST_PUBLISHER_NAME, TEST_SERIES_NAME, TEST_VOLUME, TEST_EMAIL, TEST_UNREAD);
-  }
-
-  @Test
-  public void testGetComicFeedsForSeriesAndVolume() {
-    Mockito.when(
-            comicDetailService.getAllComicsForSeriesAndVolume(
-                Mockito.anyString(),
-                Mockito.anyString(),
-                Mockito.anyString(),
-                Mockito.anyBoolean()))
-        .thenReturn(comicDetailList);
-
-    final OPDSAcquisitionFeed result =
-        service.getComicFeedForSeriesAndVolumes(
-            TEST_SERIES_NAME, TEST_VOLUME, TEST_EMAIL, TEST_UNREAD);
-
-    Assertions.assertNotNull(result);
-
-    Mockito.verify(comicDetailService, Mockito.times(1))
-        .getAllComicsForSeriesAndVolume(TEST_SERIES_NAME, TEST_VOLUME, TEST_EMAIL, TEST_UNREAD);
   }
 
   @Test(expected = OPDSException.class)

--- a/comixed-opds/src/test/java/org/comixedproject/opds/service/OPDSNavigationServiceTest.java
+++ b/comixed-opds/src/test/java/org/comixedproject/opds/service/OPDSNavigationServiceTest.java
@@ -20,10 +20,6 @@ package org.comixedproject.opds.service;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
-import static org.comixedproject.opds.service.OPDSAcquisitionService.TAG_TYPE_CHARACTER;
-import static org.comixedproject.opds.service.OPDSAcquisitionService.TAG_TYPE_LOCATION;
-import static org.comixedproject.opds.service.OPDSAcquisitionService.TAG_TYPE_STORY;
-import static org.comixedproject.opds.service.OPDSAcquisitionService.TAG_TYPE_TEAM;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -35,6 +31,7 @@ import junit.framework.TestCase;
 import org.apache.commons.lang.math.RandomUtils;
 import org.comixedproject.model.comicbooks.ComicBook;
 import org.comixedproject.model.comicbooks.ComicDetail;
+import org.comixedproject.model.comicbooks.ComicTagType;
 import org.comixedproject.model.lists.ReadingList;
 import org.comixedproject.opds.OPDSException;
 import org.comixedproject.opds.OPDSUtils;
@@ -205,25 +202,25 @@ public class OPDSNavigationServiceTest {
   @Test
   public void testGetVolumeFeedForSeries() {
     Mockito.when(
-            comicDetailService.getAllVolumesForSeries(
+            comicDetailService.getAllPublishersForSeries(
                 Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean()))
         .thenReturn(collectionSet);
 
     final OPDSNavigationFeed result =
-        service.getVolumesFeedForSeries(TEST_COLLECTION_ENTRY_NAME, TEST_EMAIL, TEST_UNREAD);
+        service.getPublishersFeedForSeries(TEST_COLLECTION_ENTRY_NAME, TEST_EMAIL, TEST_UNREAD);
 
     assertNotNull(result);
     assertTrue(result.getEntries().get(0).getTitle().contains(TEST_COLLECTION_ENTRY_NAME));
 
     Mockito.verify(comicDetailService, Mockito.times(1))
-        .getAllVolumesForSeries(TEST_COLLECTION_ENTRY_NAME, TEST_EMAIL, TEST_UNREAD);
+        .getAllPublishersForSeries(TEST_COLLECTION_ENTRY_NAME, TEST_EMAIL, TEST_UNREAD);
   }
 
   @Test
   public void testGetCollectionFeedForCharacter() {
     Mockito.when(
             comicDetailService.getAllValuesForTag(
-                Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean()))
+                Mockito.any(ComicTagType.class), Mockito.anyString(), Mockito.anyBoolean()))
         .thenReturn(collectionSet);
 
     final OPDSNavigationFeed result =
@@ -233,14 +230,14 @@ public class OPDSNavigationServiceTest {
     assertTrue(result.getEntries().get(0).getTitle().contains(TEST_COLLECTION_ENTRY_NAME));
 
     Mockito.verify(comicDetailService, Mockito.times(1))
-        .getAllValuesForTag(TAG_TYPE_CHARACTER, TEST_EMAIL, TEST_UNREAD);
+        .getAllValuesForTag(ComicTagType.CHARACTER, TEST_EMAIL, TEST_UNREAD);
   }
 
   @Test
   public void testGetCollectionFeedForTeams() {
     Mockito.when(
             comicDetailService.getAllValuesForTag(
-                Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean()))
+                Mockito.any(ComicTagType.class), Mockito.anyString(), Mockito.anyBoolean()))
         .thenReturn(collectionSet);
 
     final OPDSNavigationFeed result =
@@ -250,14 +247,14 @@ public class OPDSNavigationServiceTest {
     assertTrue(result.getEntries().get(0).getTitle().contains(TEST_COLLECTION_ENTRY_NAME));
 
     Mockito.verify(comicDetailService, Mockito.times(1))
-        .getAllValuesForTag(TAG_TYPE_TEAM, TEST_EMAIL, TEST_UNREAD);
+        .getAllValuesForTag(ComicTagType.TEAM, TEST_EMAIL, TEST_UNREAD);
   }
 
   @Test
   public void testGetCollectionFeedForLocations() {
     Mockito.when(
             comicDetailService.getAllValuesForTag(
-                Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean()))
+                Mockito.any(ComicTagType.class), Mockito.anyString(), Mockito.anyBoolean()))
         .thenReturn(collectionSet);
 
     final OPDSNavigationFeed result =
@@ -267,14 +264,14 @@ public class OPDSNavigationServiceTest {
     assertTrue(result.getEntries().get(0).getTitle().contains(TEST_COLLECTION_ENTRY_NAME));
 
     Mockito.verify(comicDetailService, Mockito.times(1))
-        .getAllValuesForTag(TAG_TYPE_LOCATION, TEST_EMAIL, TEST_UNREAD);
+        .getAllValuesForTag(ComicTagType.LOCATION, TEST_EMAIL, TEST_UNREAD);
   }
 
   @Test
   public void testGetCollectionFeedForStory() {
     Mockito.when(
             comicDetailService.getAllValuesForTag(
-                Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean()))
+                Mockito.any(ComicTagType.class), Mockito.anyString(), Mockito.anyBoolean()))
         .thenReturn(collectionSet);
 
     final OPDSNavigationFeed result =
@@ -284,7 +281,7 @@ public class OPDSNavigationServiceTest {
     assertTrue(result.getEntries().get(0).getTitle().contains(TEST_COLLECTION_ENTRY_NAME));
 
     Mockito.verify(comicDetailService, Mockito.times(1))
-        .getAllValuesForTag(TAG_TYPE_STORY, TEST_EMAIL, TEST_UNREAD);
+        .getAllValuesForTag(ComicTagType.STORY, TEST_EMAIL, TEST_UNREAD);
   }
 
   @Test(expected = OPDSException.class)

--- a/comixed-repositories/src/main/java/org/comixedproject/repositories/comicbooks/ComicDetailRepository.java
+++ b/comixed-repositories/src/main/java/org/comixedproject/repositories/comicbooks/ComicDetailRepository.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import org.comixedproject.model.comicbooks.ComicDetail;
+import org.comixedproject.model.comicbooks.ComicTagType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -53,7 +54,7 @@ public interface ComicDetailRepository extends JpaRepository<ComicDetail, Long> 
    * @return the publishers
    */
   @Query(
-      "SELECT DISTINCT d.publisher FROM ComicDetail d WHERE d NOT IN (SELECT r.comicDetail FROM LastRead r WHERE r.user.email = :email)")
+      "SELECT DISTINCT d.publisher FROM ComicDetail d WHERE d.publisher IS NOT NULL AND d NOT IN (SELECT r.comicDetail FROM LastRead r WHERE r.user.email = :email)")
   Set<String> getAllUnreadPublishers(@Param("email") String email);
 
   /**
@@ -61,7 +62,7 @@ public interface ComicDetailRepository extends JpaRepository<ComicDetail, Long> 
    *
    * @return the publishers
    */
-  @Query("SELECT DISTINCT d.publisher FROM ComicDetail d")
+  @Query("SELECT DISTINCT d.publisher FROM ComicDetail d WHERE d.publisher IS NOT NULL")
   Set<String> getAllPublishers();
 
   /**
@@ -121,7 +122,7 @@ public interface ComicDetailRepository extends JpaRepository<ComicDetail, Long> 
    * @return the series
    */
   @Query(
-      "SELECT DISTINCT d.series FROM ComicDetail d WHERE d NOT IN (SELECT r.comicDetail FROM LastRead r WHERE r.user.email = :email)")
+      "SELECT DISTINCT d.series FROM ComicDetail d WHERE d.series IS NOT NULL AND d NOT IN (SELECT r.comicDetail FROM LastRead r WHERE r.user.email = :email)")
   Set<String> getAllUnreadSeries(@Param("email") String email);
 
   /**
@@ -129,11 +130,11 @@ public interface ComicDetailRepository extends JpaRepository<ComicDetail, Long> 
    *
    * @return the series
    */
-  @Query("SELECT DISTINCT d.series FROM ComicDetail d")
+  @Query("SELECT DISTINCT d.series FROM ComicDetail d WHERE d.series IS NOT NULL")
   Set<String> getAllSeries();
 
   /**
-   * Returns the set of volumes for the given series with comics that have not been read by the
+   * Returns the set of publishers for the given series with comics that have not been read by the
    * specified user.
    *
    * @param series the series
@@ -141,44 +142,18 @@ public interface ComicDetailRepository extends JpaRepository<ComicDetail, Long> 
    * @return the volumes
    */
   @Query(
-      "SELECT DISTINCT d.volume FROM ComicDetail d WHERE d.series = :series AND d NOT IN (SELECT r.comicDetail FROM LastRead r WHERE r.user.email = :email)")
-  Set<String> getAllUnreadVolumesForSeries(
+      "SELECT DISTINCT d.publisher FROM ComicDetail d WHERE d.series = :series AND d NOT IN (SELECT r.comicDetail FROM LastRead r WHERE r.user.email = :email)")
+  Set<String> getAllUnreadPublishersForSeries(
       @Param("series") String series, @Param("email") String email);
 
   /**
-   * Returns the set of volumes for the given series.
+   * Returns the set of publishers for the given series.
    *
    * @param series the series
    * @return the volumes
    */
-  @Query("SELECT DISTINCT d.volume FROM ComicDetail d WHERE d.series = :series")
-  Set<String> getAllVolumesForSeries(@Param("series") String series);
-
-  /**
-   * Returns all records for the given series and volume that do not have a read entry for the given
-   * user.
-   *
-   * @param series the series
-   * @param volume the volume
-   * @param email the email
-   * @return the matching records
-   */
-  @Query(
-      "SELECT d FROM ComicDetail d WHERE d.series = :series AND d.volume = :volume AND d.comicBook.id NOT IN (SELECT r.comicDetail.id FROM LastRead r WHERE r.user.email = :email) ORDER BY d.coverDate")
-  List<ComicDetail> getAllUnreadForSeriesAndVolume(
-      @Param("series") String series, @Param("volume") String volume, @Param("email") String email);
-
-  /**
-   * Returns all records for the given series and volume.
-   *
-   * @param series the series
-   * @param volume the volume
-   * @return the matching records
-   */
-  @Query(
-      "SELECT d FROM ComicDetail d WHERE d.series = :series AND d.volume = :volume ORDER BY d.coverDate")
-  List<ComicDetail> getAllForSeriesAndVolume(
-      @Param("series") String series, @Param("volume") String volume);
+  @Query("SELECT DISTINCT d.publisher FROM ComicDetail d WHERE d.series = :series")
+  Set<String> getAllPublishersForSeries(@Param("series") String series);
 
   /**
    * Returns all records for the given publisher, series, and volume that do not have a read entry
@@ -223,7 +198,7 @@ public interface ComicDetailRepository extends JpaRepository<ComicDetail, Long> 
   @Query(
       "SELECT DISTINCT t.value FROM ComicTag t WHERE t.type = :tagType AND t.comicDetail NOT IN (SELECT r.comicDetail FROM LastRead r WHERE r.user.email = :email)")
   Set<String> getAllUnreadValuesForTagType(
-      @Param("tagType") String tagType, @Param("email") String email);
+      @Param("tagType") ComicTagType tagType, @Param("email") String email);
 
   /**
    * Returns all comics with the given tag type.
@@ -232,7 +207,7 @@ public interface ComicDetailRepository extends JpaRepository<ComicDetail, Long> 
    * @return the matching records
    */
   @Query("SELECT DISTINCT t.value FROM ComicTag t WHERE t.type = :tagType")
-  Set<String> getAllValuesForTagType(@Param("tagType") String tagType);
+  Set<String> getAllValuesForTagType(@Param("tagType") ComicTagType tagType);
 
   /**
    * Returns all years with comics that do not have a read entry for the given user.
@@ -241,7 +216,7 @@ public interface ComicDetailRepository extends JpaRepository<ComicDetail, Long> 
    * @return the matching years
    */
   @Query(
-      "SELECT DISTINCT YEAR(d.coverDate) FROM ComicDetail d WHERE d NOT IN (SELECT r.comicDetail FROM LastRead r WHERE r.user.email = :email)")
+      "SELECT DISTINCT YEAR(d.coverDate) FROM ComicDetail d WHERE d.coverDate IS NOT NULL AND d NOT IN (SELECT r.comicDetail FROM LastRead r WHERE r.user.email = :email)")
   Set<Integer> getAllUnreadYears(@Param("email") String email);
 
   /**
@@ -249,7 +224,7 @@ public interface ComicDetailRepository extends JpaRepository<ComicDetail, Long> 
    *
    * @return the years
    */
-  @Query("SELECT DISTINCT YEAR(d.coverDate) FROM ComicDetail d")
+  @Query("SELECT DISTINCT YEAR(d.coverDate) FROM ComicDetail d WHERE d.coverDate IS NOT NULL")
   Set<Integer> getAllYears();
 
   /**
@@ -260,7 +235,7 @@ public interface ComicDetailRepository extends JpaRepository<ComicDetail, Long> 
    * @return the matching weeks
    */
   @Query(
-      "SELECT DISTINCT d.coverDate FROM ComicDetail d WHERE year(d.coverDate) = :year AND d NOT IN (SELECT r.comicDetail from LastRead r WHERE r.user.email = :email)")
+      "SELECT DISTINCT d.coverDate FROM ComicDetail d WHERE d.coverDate IS NOT NULL AND year(d.coverDate) = :year AND d NOT IN (SELECT r.comicDetail from LastRead r WHERE r.user.email = :email)")
   Set<Date> getAllUnreadWeeksForYear(@Param("year") int year, @Param("email") String email);
 
   /**
@@ -269,7 +244,8 @@ public interface ComicDetailRepository extends JpaRepository<ComicDetail, Long> 
    * @param year the year
    * @return the matching weeks
    */
-  @Query("SELECT DISTINCT d.coverDate FROM ComicDetail d WHERE year(d.coverDate) = :year")
+  @Query(
+      "SELECT DISTINCT d.coverDate FROM ComicDetail d WHERE d.coverDate IS NOT NULL AND year(d.coverDate) = :year")
   Set<Date> getAllWeeksForYear(@Param("year") int year);
 
   /**
@@ -281,14 +257,14 @@ public interface ComicDetailRepository extends JpaRepository<ComicDetail, Long> 
    * @return the matching records
    */
   @Query(
-      "SELECT d FROM ComicDetail d WHERE d.coverDate IS NOT NULL AND d.coverDate >= :startDate AND d.coverDate <= :endDate AND d.comicBook.id NOT IN (SELECT r.comicDetail.id FROM LastRead r WHERE r.user.email = :email) ORDER BY d.comicBook")
+      "SELECT d FROM ComicDetail d WHERE d.coverDate IS NOT NULL AND d.coverDate IS NOT NULL AND d.coverDate >= :startDate AND d.coverDate <= :endDate AND d.comicBook.id NOT IN (SELECT r.comicDetail.id FROM LastRead r WHERE r.user.email = :email) ORDER BY d.comicBook")
   List<ComicDetail> getAllUnreadForYearAndWeek(
       @Param("startDate") Date startDate,
       @Param("endDate") Date endDate,
       @Param("email") String email);
 
   @Query(
-      "SELECT d FROM ComicDetail d WHERE d.coverDate IS NOT NULL AND d.coverDate >= :startDate AND d.coverDate <= :endDate ORDER BY d.comicBook")
+      "SELECT d FROM ComicDetail d WHERE d.coverDate IS NOT NULL AND d.coverDate IS NOT NULL AND d.coverDate >= :startDate AND d.coverDate <= :endDate ORDER BY d.comicBook")
   List<ComicDetail> getAllForYearAndWeek(
       @Param("startDate") Date startDate, @Param("endDate") Date endDate);
 
@@ -313,7 +289,7 @@ public interface ComicDetailRepository extends JpaRepository<ComicDetail, Long> 
   @Query(
       "SELECT d FROM ComicDetail d WHERE d IN (SELECT t.comicDetail FROM ComicTag t WHERE t.type = :tagType) AND d NOT IN (SELECT r.comicDetail from LastRead r WHERE r.user.email = :email)")
   List<ComicDetail> getAllUnreadComicsForTagType(
-      @Param("tagType") String tagType, @Param("email") String email);
+      @Param("tagType") ComicTagType tagType, @Param("email") String email);
 
   /**
    * Returns all comics with the given tag type.
@@ -323,5 +299,5 @@ public interface ComicDetailRepository extends JpaRepository<ComicDetail, Long> 
    */
   @Query(
       "SELECT d FROM ComicDetail d WHERE d IN (SELECT t.comicDetail FROM ComicTag t WHERE t.type = :tagType)")
-  List<ComicDetail> getAllComicsForTagType(@Param("tagType") String tagType);
+  List<ComicDetail> getAllComicsForTagType(@Param("tagType") ComicTagType tagType);
 }

--- a/comixed-services/src/main/java/org/comixedproject/service/comicbooks/ComicDetailService.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/comicbooks/ComicDetailService.java
@@ -27,6 +27,7 @@ import java.util.TimeZone;
 import java.util.stream.Collectors;
 import lombok.extern.log4j.Log4j2;
 import org.comixedproject.model.comicbooks.ComicDetail;
+import org.comixedproject.model.comicbooks.ComicTagType;
 import org.comixedproject.repositories.comicbooks.ComicDetailRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
@@ -152,7 +153,7 @@ public class ComicDetailService {
   }
 
   /**
-   * Returns the set of volumes for the given series. Filters out comics read by the user if the
+   * Returns the set of publishers for the given series. Filters out comics read by the user if the
    * flag is set.
    *
    * @param series the series name
@@ -160,37 +161,18 @@ public class ComicDetailService {
    * @param unread the unread flag
    * @return the volumes
    */
-  public Set<String> getAllVolumesForSeries(
+  public Set<String> getAllPublishersForSeries(
       final String series, final String email, final boolean unread) {
     if (unread) {
       log.debug(
-          "Loading all volumes for series with unread comics: series={} email={}", series, email);
-      return this.comicDetailRepository.getAllUnreadVolumesForSeries(series, email);
+          "Loading all publishers for series with unread comics: series={} email={}",
+          series,
+          email);
+      return this.comicDetailRepository.getAllUnreadPublishersForSeries(series, email);
     } else {
-      log.debug("Loading all volumes for series: {}", series);
-      return this.comicDetailRepository.getAllVolumesForSeries(series);
+      log.debug("Loading all publishers for series: {}", series);
+      return this.comicDetailRepository.getAllPublishersForSeries(series);
     }
-  }
-
-  /**
-   * Returns the list of entries for the given series and volume. Filters out comics read by the
-   * user if the flag is set.
-   *
-   * @param series the series
-   * @param volume the volume
-   * @param email the user email
-   * @param unread the unread flag
-   * @return the comic details
-   */
-  public List<ComicDetail> getAllComicsForSeriesAndVolume(
-      final String series, final String volume, final String email, final boolean unread) {
-    if (unread) {
-      log.debug("Loading unread issues: series={} volume={} email={}", series, volume, email);
-      return this.comicDetailRepository.getAllUnreadForSeriesAndVolume(series, volume, email);
-    }
-
-    log.debug("Loading all issues: series={} volume={}", series, volume);
-    return this.comicDetailRepository.getAllForSeriesAndVolume(series, volume);
   }
 
   /**
@@ -241,7 +223,7 @@ public class ComicDetailService {
    * @return the comic details
    */
   public Set<String> getAllValuesForTag(
-      final String tagType, final String email, final boolean unread) {
+      final ComicTagType tagType, final String email, final boolean unread) {
     if (unread) {
       log.debug("Loading all unread comics: tag type={} email={}", tagType, email);
       return this.comicDetailRepository.getAllUnreadValuesForTagType(tagType, email);
@@ -360,7 +342,7 @@ public class ComicDetailService {
    * @return the matching comics
    */
   public List<ComicDetail> getAllComicsForTag(
-      final String tagType, final String email, final boolean unread) {
+      final ComicTagType tagType, final String email, final boolean unread) {
     if (unread) {
       log.debug("Loading all unread comics for tag type: tag type={} email={}", tagType, email);
       return this.comicDetailRepository.getAllUnreadComicsForTagType(tagType, email);

--- a/comixed-services/src/test/java/org/comixedproject/service/comicbooks/ComicDetailServiceTest.java
+++ b/comixed-services/src/test/java/org/comixedproject/service/comicbooks/ComicDetailServiceTest.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.comixedproject.model.comicbooks.ComicDetail;
+import org.comixedproject.model.comicbooks.ComicTagType;
 import org.comixedproject.repositories.comicbooks.ComicDetailRepository;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,7 +50,7 @@ public class ComicDetailServiceTest {
   private static final String TEST_PUBLISHER = "THe Publisher Name";
   private static final String TEST_SERIES = "The Series Name";
   private static final String TEST_VOLUME = "2023";
-  private static final String TEST_TAG = "CHARACTERS";
+  private static final ComicTagType TEST_TAG = ComicTagType.CHARACTER;
   private static final int TEST_YEAR = 2023;
   private static final int TEST_WEEK = 17;
   private static final String TEST_SEARCH_TERM = "Random text...";
@@ -222,66 +223,32 @@ public class ComicDetailServiceTest {
   }
 
   @Test
-  public void testGetAllVolumesForSeriesWithUnread() {
+  public void testGetAllPublishersForSeriesWithUnread() {
     Mockito.when(
-            comicDetailRepository.getAllUnreadVolumesForSeries(
+            comicDetailRepository.getAllUnreadPublishersForSeries(
                 Mockito.anyString(), Mockito.anyString()))
-        .thenReturn(volumeList);
+        .thenReturn(publisherList);
 
-    final Set<String> result = service.getAllVolumesForSeries(TEST_SERIES, TEST_EMAIL, true);
+    final Set<String> result = service.getAllPublishersForSeries(TEST_SERIES, TEST_EMAIL, true);
 
     assertNotNull(result);
-    assertSame(volumeList, result);
+    assertSame(publisherList, result);
 
     Mockito.verify(comicDetailRepository, Mockito.times(1))
-        .getAllUnreadVolumesForSeries(TEST_SERIES, TEST_EMAIL);
+        .getAllUnreadPublishersForSeries(TEST_SERIES, TEST_EMAIL);
   }
 
   @Test
-  public void testGetAllVolumesForSeries() {
-    Mockito.when(comicDetailRepository.getAllVolumesForSeries(Mockito.anyString()))
-        .thenReturn(volumeList);
+  public void testGetAllPublishersForSeries() {
+    Mockito.when(comicDetailRepository.getAllPublishersForSeries(Mockito.anyString()))
+        .thenReturn(publisherList);
 
-    final Set<String> result = service.getAllVolumesForSeries(TEST_SERIES, TEST_EMAIL, false);
-
-    assertNotNull(result);
-    assertSame(volumeList, result);
-
-    Mockito.verify(comicDetailRepository, Mockito.times(1)).getAllVolumesForSeries(TEST_SERIES);
-  }
-
-  @Test
-  public void testGetAllComicsForSeriesAndVolumesWithUnread() {
-    Mockito.when(
-            comicDetailRepository.getAllUnreadForSeriesAndVolume(
-                Mockito.anyString(), Mockito.anyString(), Mockito.anyString()))
-        .thenReturn(comicDetailList);
-
-    final List<ComicDetail> result =
-        service.getAllComicsForSeriesAndVolume(TEST_SERIES, TEST_VOLUME, TEST_EMAIL, true);
+    final Set<String> result = service.getAllPublishersForSeries(TEST_SERIES, TEST_EMAIL, false);
 
     assertNotNull(result);
-    assertSame(comicDetailList, result);
+    assertSame(publisherList, result);
 
-    Mockito.verify(comicDetailRepository, Mockito.times(1))
-        .getAllUnreadForSeriesAndVolume(TEST_SERIES, TEST_VOLUME, TEST_EMAIL);
-  }
-
-  @Test
-  public void testGetAllComicsForSeriesAndVolumes() {
-    Mockito.when(
-            comicDetailRepository.getAllForSeriesAndVolume(
-                Mockito.anyString(), Mockito.anyString()))
-        .thenReturn(comicDetailList);
-
-    final List<ComicDetail> result =
-        service.getAllComicsForSeriesAndVolume(TEST_SERIES, TEST_VOLUME, TEST_EMAIL, false);
-
-    assertNotNull(result);
-    assertSame(comicDetailList, result);
-
-    Mockito.verify(comicDetailRepository, Mockito.times(1))
-        .getAllForSeriesAndVolume(TEST_SERIES, TEST_VOLUME);
+    Mockito.verify(comicDetailRepository, Mockito.times(1)).getAllPublishersForSeries(TEST_SERIES);
   }
 
   @Test
@@ -325,7 +292,7 @@ public class ComicDetailServiceTest {
   public void testGetAllValuesForTagsWithUnread() {
     Mockito.when(
             comicDetailRepository.getAllUnreadValuesForTagType(
-                Mockito.anyString(), Mockito.anyString()))
+                Mockito.any(ComicTagType.class), Mockito.anyString()))
         .thenReturn(tagList);
 
     final Set<String> result = service.getAllValuesForTag(TEST_TAG, TEST_EMAIL, true);
@@ -339,7 +306,7 @@ public class ComicDetailServiceTest {
 
   @Test
   public void testGetAllValuesForTags() {
-    Mockito.when(comicDetailRepository.getAllValuesForTagType(Mockito.anyString()))
+    Mockito.when(comicDetailRepository.getAllValuesForTagType(Mockito.any(ComicTagType.class)))
         .thenReturn(tagList);
 
     final Set<String> result = service.getAllValuesForTag(TEST_TAG, TEST_EMAIL, false);
@@ -463,7 +430,7 @@ public class ComicDetailServiceTest {
   public void testGetComicsForTagWithUnread() {
     Mockito.when(
             comicDetailRepository.getAllUnreadComicsForTagType(
-                Mockito.anyString(), Mockito.anyString()))
+                Mockito.any(ComicTagType.class), Mockito.anyString()))
         .thenReturn(comicDetailList);
 
     final List<ComicDetail> result = service.getAllComicsForTag(TEST_TAG, TEST_EMAIL, true);
@@ -477,7 +444,7 @@ public class ComicDetailServiceTest {
 
   @Test
   public void testGetComicsForTag() {
-    Mockito.when(comicDetailRepository.getAllComicsForTagType(Mockito.anyString()))
+    Mockito.when(comicDetailRepository.getAllComicsForTagType(Mockito.any(ComicTagType.class)))
         .thenReturn(comicDetailList);
 
     final List<ComicDetail> result = service.getAllComicsForTag(TEST_TAG, TEST_EMAIL, false);


### PR DESCRIPTION
Rather than having top-level series go to volumes, this changes the OPDS navigation to go from series to publishers. Then, the next level converges with the top-level publishers feed.

Closes #1494 

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

