### PR TITLE
Changed comic overview to an editing form for comic details [#1480]

### DIFF
--- a/comixed-services/src/main/java/org/comixedproject/service/comicbooks/ComicBookService.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/comicbooks/ComicBookService.java
@@ -178,6 +178,8 @@ public class ComicBookService implements InitializingBean, ComicStateChangeListe
     comic.setSortName(update.getSortName());
     comic.getComicDetail().setTitle(update.getComicDetail().getTitle());
     comic.getComicDetail().setDescription(update.getComicDetail().getDescription());
+    comic.getComicDetail().setCoverDate(update.getComicDetail().getCoverDate());
+    comic.getComicDetail().setStoreDate(update.getComicDetail().getStoreDate());
 
     this.imprintService.update(comic);
 

--- a/comixed-services/src/main/java/org/comixedproject/service/metadata/MetadataService.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/metadata/MetadataService.java
@@ -272,14 +272,20 @@ public class MetadataService {
       comicBook.getComicDetail().setSeries(issueDetails.getSeries());
       comicBook.getComicDetail().setVolume(issueDetails.getVolume());
       comicBook.getComicDetail().setIssueNumber(issueDetails.getIssueNumber());
-      if (issueDetails.getCoverDate() != null)
+      if (issueDetails.getCoverDate() != null) {
         comicBook
             .getComicDetail()
             .setCoverDate(this.adjustForTimezone(issueDetails.getCoverDate()));
-      if (issueDetails.getStoreDate() != null)
+      } else {
+        comicBook.getComicDetail().setCoverDate(null);
+      }
+      if (issueDetails.getStoreDate() != null) {
         comicBook
             .getComicDetail()
             .setStoreDate(this.adjustForTimezone(issueDetails.getStoreDate()));
+      } else {
+        comicBook.getComicDetail().setStoreDate(null);
+      }
       comicBook.getComicDetail().setTitle(issueDetails.getTitle());
       comicBook.getComicDetail().setDescription(issueDetails.getDescription());
       final ComicDetail detail = comicBook.getComicDetail();

--- a/comixed-services/src/test/java/org/comixedproject/service/comicbooks/ComicBookServiceTest.java
+++ b/comixed-services/src/test/java/org/comixedproject/service/comicbooks/ComicBookServiceTest.java
@@ -86,6 +86,8 @@ public class ComicBookServiceTest {
   private static final String TEST_TITLE = "The Issue Title";
   private static final String TEST_DESCRIPTION = "This description of the issue";
   private static final Date TEST_COVER_DATE = new Date();
+  private static final Date TEST_STORE_DATE =
+      new Date(System.currentTimeMillis() - 30L * 24L * 60L * 60L * 24L);
   private static final int TEST_PAGE = Math.abs(RandomUtils.nextInt());
   private static final ComicState TEST_STATE = ComicState.CHANGED;
   private static final String TEST_CHARACTER = "Manlyman";
@@ -158,8 +160,8 @@ public class ComicBookServiceTest {
     currentComicBook.getComicDetail().setSeries(TEST_SERIES);
     currentComicBook.getComicDetail().setVolume(TEST_VOLUME);
     currentComicBook.getComicDetail().setIssueNumber(TEST_CURRENT_ISSUE_NUMBER);
-    currentComicBook.getComicDetail().setCoverDate(new Date(System.currentTimeMillis()));
     currentComicBook.getComicDetail().setCoverDate(TEST_COVER_DATE);
+    currentComicBook.getComicDetail().setStoreDate(TEST_STORE_DATE);
 
     nextComicBook.setComicDetail(
         new ComicDetail(nextComicBook, TEST_COMIC_FILENAME, ArchiveType.CBZ));
@@ -395,6 +397,8 @@ public class ComicBookServiceTest {
     Mockito.when(incomingComicBook.getSortName()).thenReturn(TEST_SORTABLE_NAME);
     Mockito.when(incomingComicDetail.getTitle()).thenReturn(TEST_TITLE);
     Mockito.when(incomingComicDetail.getDescription()).thenReturn(TEST_DESCRIPTION);
+    Mockito.when(incomingComicDetail.getCoverDate()).thenReturn(TEST_COVER_DATE);
+    Mockito.when(incomingComicDetail.getStoreDate()).thenReturn(TEST_STORE_DATE);
 
     final ComicBook result = service.updateComic(TEST_COMIC_BOOK_ID, incomingComicBook);
 
@@ -411,6 +415,8 @@ public class ComicBookServiceTest {
     Mockito.verify(comicBook, Mockito.times(1)).setSortName(TEST_SORTABLE_NAME);
     Mockito.verify(comicDetail, Mockito.times(1)).setTitle(TEST_TITLE);
     Mockito.verify(comicDetail, Mockito.times(1)).setDescription(TEST_DESCRIPTION);
+    Mockito.verify(comicDetail, Mockito.times(1)).setCoverDate(TEST_COVER_DATE);
+    Mockito.verify(comicDetail, Mockito.times(1)).setStoreDate(TEST_STORE_DATE);
     Mockito.verify(comicStateHandler, Mockito.times(1))
         .fireEvent(comicBook, ComicEvent.detailsUpdated);
     Mockito.verify(imprintService, Mockito.times(1)).update(comicBook);

--- a/comixed-webui/src/app/admin/components/filename-scraping-rules-configuration/filename-scraping-rules-configuration.component.html
+++ b/comixed-webui/src/app/admin/components/filename-scraping-rules-configuration/filename-scraping-rules-configuration.component.html
@@ -30,7 +30,7 @@
       {{ "filename-scraping-rules.label.rule-name" | translate }}
     </mat-header-cell>
     <mat-cell *matCellDef="let entry">
-      <mat-form-field class="cx-width-100" appearance="fill">
+      <mat-form-field class="cx-width-100" appearance="standard">
         <input
           id="name-input"
           #nameInput
@@ -47,7 +47,7 @@
       {{ "filename-scraping-rules.label.rule-value" | translate }}
     </mat-header-cell>
     <mat-cell *matCellDef="let entry">
-      <mat-form-field class="cx-width-100" appearance="fill">
+      <mat-form-field class="cx-width-100" appearance="standard">
         <input
           id="rule-input"
           #ruleInput
@@ -64,7 +64,7 @@
       {{ "filename-scraping-rules.label.series-position" | translate }}
     </mat-header-cell>
     <mat-cell *matCellDef="let entry">
-      <mat-form-field class="cx-width-100" appearance="fill">
+      <mat-form-field class="cx-width-100" appearance="standard">
         <input
           id="series-position-input"
           #seriesPositionInput
@@ -81,7 +81,7 @@
       {{ "filename-scraping-rules.label.volume-position" | translate }}
     </mat-header-cell>
     <mat-cell *matCellDef="let entry">
-      <mat-form-field class="cx-width-100" appearance="fill">
+      <mat-form-field class="cx-width-100" appearance="standard">
         <input
           id="volume-position-input"
           #volumePositionInput
@@ -98,7 +98,7 @@
       {{ "filename-scraping-rules.label.issue-number-position" | translate }}
     </mat-header-cell>
     <mat-cell *matCellDef="let entry">
-      <mat-form-field class="cx-width-100" appearance="fill">
+      <mat-form-field class="cx-width-100" appearance="standard">
         <input
           id="issue-number-input"
           #issueNumberInput
@@ -116,7 +116,7 @@
       {{ "filename-scraping-rules.label.cover-date-position" | translate }}
     </mat-header-cell>
     <mat-cell *matCellDef="let entry">
-      <mat-form-field class="cx-width-100" appearance="fill">
+      <mat-form-field class="cx-width-100" appearance="standard">
         <input
           id="cover-date-position-input"
           #coverDatePositionInput
@@ -136,7 +136,7 @@
       {{ "filename-scraping-rules.label.cover-date-format" | translate }}
     </mat-header-cell>
     <mat-cell *matCellDef="let entry">
-      <mat-form-field class="cx-width-100" appearance="fill">
+      <mat-form-field class="cx-width-100" appearance="standard">
         <input
           id="date-format-input"
           #dateFormatInput

--- a/comixed-webui/src/app/admin/components/library-configuration/library-configuration.component.html
+++ b/comixed-webui/src/app/admin/components/library-configuration/library-configuration.component.html
@@ -11,7 +11,7 @@
 </mat-toolbar>
 
 <form [formGroup]="libraryConfigurationForm">
-  <mat-form-field class="cx-width-100" appearance="fill">
+  <mat-form-field class="cx-width-100" appearance="standard">
     <mat-checkbox
       id="delete-empty-directories-checkbox"
       color="primary"
@@ -21,7 +21,7 @@
     </mat-checkbox>
     <input hidden matInput />
   </mat-form-field>
-  <mat-form-field class="cx-width-100" appearance="fill">
+  <mat-form-field class="cx-width-100" appearance="standard">
     <mat-label>
       {{ "configuration.label.root-directory" | translate }}
     </mat-label>
@@ -65,7 +65,7 @@
       </table>
     </mat-expansion-panel>
   </div>
-  <mat-form-field class="cx-width-100" appearance="fill">
+  <mat-form-field class="cx-width-100" appearance="standard">
     <mat-label>
       {{ "configuration.label.comic-renaming-rule" | translate }}
     </mat-label>
@@ -112,7 +112,7 @@
       </table>
     </mat-expansion-panel>
   </div>
-  <mat-form-field class="cx-width-100" appearance="fill">
+  <mat-form-field class="cx-width-100" appearance="standard">
     <mat-label>
       {{ "configuration.label.page-renaming-rule" | translate }}
     </mat-label>

--- a/comixed-webui/src/app/admin/components/metadata-source-detail/metadata-source-detail.component.html
+++ b/comixed-webui/src/app/admin/components/metadata-source-detail/metadata-source-detail.component.html
@@ -1,5 +1,5 @@
 <form [formGroup]="sourceForm">
-  <mat-form-field class="cx-width-100" appearance="fill" required>
+  <mat-form-field class="cx-width-100" appearance="standard" required>
     <mat-label>
       {{ "metadata-source.label.source-name" | translate }}
     </mat-label>
@@ -34,7 +34,7 @@
       </span>
     </mat-error>
   </mat-form-field>
-  <mat-form-field class="cx-width-100" appearance="fill" required>
+  <mat-form-field class="cx-width-100" appearance="standard" required>
     <mat-label>
       {{ "metadata-source.label.bean-name" | translate }}
     </mat-label>
@@ -87,7 +87,7 @@
         [formGroupName]="i"
       >
         <td>
-          <mat-form-field class="cx-width-100" appearance="fill" required>
+          <mat-form-field class="cx-width-100" appearance="standard" required>
             <mat-icon
               matPrefix
               color="warn"
@@ -109,7 +109,7 @@
           </mat-form-field>
         </td>
         <td>
-          <mat-form-field class="cx-width-100" appearance="fill" required>
+          <mat-form-field class="cx-width-100" appearance="standard" required>
             <input
               [id]="'property-value-' + i"
               matInput

--- a/comixed-webui/src/app/comic-books/comic-books.module.ts
+++ b/comixed-webui/src/app/comic-books/comic-books.module.ts
@@ -84,6 +84,8 @@ import { VolumeMetadataTableComponent } from '@app/comic-books/components/volume
 import { VolumeMetadataTitlePipe } from '@app/comic-books/pipes/volume-metadata-title.pipe';
 import { ComicDetailListViewComponent } from './components/comic-detail-list-view/comic-detail-list-view.component';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule } from '@angular/material/core';
 
 @NgModule({
   declarations: [
@@ -146,7 +148,9 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
     FlexModule,
     MatBadgeModule,
     DragDropModule,
-    MatCheckboxModule
+    MatCheckboxModule,
+    MatDatepickerModule,
+    MatNativeDateModule
   ],
   exports: [
     CommonModule,

--- a/comixed-webui/src/app/comic-books/components/comic-edit/comic-edit.component.html
+++ b/comixed-webui/src/app/comic-books/components/comic-edit/comic-edit.component.html
@@ -84,7 +84,7 @@
   </button>
 </mat-toolbar>
 <form *ngIf="!!comic" [formGroup]="comicForm">
-  <mat-form-field class="cx-width-50" appearance="fill">
+  <mat-form-field class="cx-width-50" appearance="standard">
     <mat-label>{{ "comic-book.label.metadata-source" | translate }}</mat-label>
     <mat-select
       [value]="metadataSource?.id || preferredMetadataSource?.id"
@@ -99,7 +99,7 @@
       </mat-option>
     </mat-select>
   </mat-form-field>
-  <mat-form-field class="cx-width-50" appearance="fill">
+  <mat-form-field class="cx-width-50" appearance="standard">
     <mat-label>
       {{ "comic-book.label.metadata-load-limit" | translate }}
     </mat-label>
@@ -117,7 +117,7 @@
       </mat-option>
     </mat-select>
   </mat-form-field>
-  <mat-form-field class="cx-width-100" appearance="fill">
+  <mat-form-field class="cx-width-100" appearance="standard">
     <mat-label>{{ "comic-book.label.publisher" | translate }}</mat-label>
     <input
       id="publisher-input"
@@ -126,7 +126,7 @@
       [placeholder]="'comic-book.placeholder.publisher' | translate"
     />
   </mat-form-field>
-  <mat-form-field class="cx-width-100" appearance="fill">
+  <mat-form-field class="cx-width-100" appearance="standard">
     <mat-label>{{ "comic-book.label.series" | translate }}</mat-label>
     <input
       id="series-input"
@@ -142,7 +142,7 @@
       {{ "validation.field-required" | translate }}
     </mat-error>
   </mat-form-field>
-  <mat-form-field class="cx-width-33" appearance="fill">
+  <mat-form-field class="cx-width-33" appearance="standard">
     <mat-label>{{ "comic-book.label.volume" | translate }}</mat-label>
     <input
       id="volume-input"
@@ -154,7 +154,7 @@
       {{ "comic-book.hint.required-for-scraping" | translate }}
     </mat-hint>
   </mat-form-field>
-  <mat-form-field class="cx-width-33" appearance="fill">
+  <mat-form-field class="cx-width-33" appearance="standard">
     <mat-label>{{ "comic-book.label.issue-number" | translate }}</mat-label>
     <input
       id="issue-number-input"
@@ -170,7 +170,7 @@
       {{ "validation.field-required" | translate }}
     </mat-error>
   </mat-form-field>
-  <mat-form-field class="cx-width-34" appearance="fill">
+  <mat-form-field class="cx-width-34" appearance="standard">
     <mat-label>
       {{ "comic-book.label.metadata-source-id" | translate }}
     </mat-label>
@@ -201,7 +201,7 @@
       {{ "comic-book.hint.useful-for-scraping" | translate }}
     </mat-hint>
   </mat-form-field>
-  <mat-form-field class="cx-width-50" appearance="fill">
+  <mat-form-field class="cx-width-50" appearance="standard">
     <mat-label>{{ "comic-book.label.imprint" | translate }}</mat-label>
     <mat-select
       id="imprint-select"
@@ -216,15 +216,15 @@
       </mat-option>
     </mat-select>
   </mat-form-field>
-  <mat-form-field class="cx-width-50" appearance="fill">
+  <mat-form-field class="cx-width-50" appearance="standard">
     <mat-label>{{ "comic-book.label.sort-name" | translate }}</mat-label>
     <input id="sort-name-input" matInput formControlName="sortName" />
   </mat-form-field>
-  <mat-form-field class="cx-width-100" appearance="fill">
+  <mat-form-field class="cx-width-100" appearance="standard">
     <mat-label>{{ "comic-book.label.title" | translate }}</mat-label>
     <input id="title-input" matInput formControlName="title" />
   </mat-form-field>
-  <mat-form-field class="cx-width-100" appearance="fill">
+  <mat-form-field class="cx-width-100" appearance="standard">
     <mat-label>{{ "comic-book.label.description" | translate }}</mat-label>
     <textarea
       id="description-input"

--- a/comixed-webui/src/app/comic-books/components/comic-edit/comic-edit.component.spec.ts
+++ b/comixed-webui/src/app/comic-books/components/comic-edit/comic-edit.component.spec.ts
@@ -254,7 +254,7 @@ describe('ComicEditComponent', () => {
 
     it('fires an action', () => {
       expect(store.dispatch).toHaveBeenCalledWith(
-        updateComicBook({ comicBook: COMIC })
+        updateComicBook({ comicBook: component.encodeForm() })
       );
     });
   });

--- a/comixed-webui/src/app/comic-books/components/comic-edit/comic-edit.component.ts
+++ b/comixed-webui/src/app/comic-books/components/comic-edit/comic-edit.component.ts
@@ -59,6 +59,7 @@ import { MetadataSource } from '@app/comic-metadata/models/metadata-source';
 import { selectMetadataSourceList } from '@app/comic-metadata/selectors/metadata-source-list.selectors';
 import { loadMetadataSources } from '@app/comic-metadata/actions/metadata-source-list.actions';
 import { selectMetadataState } from '@app/comic-metadata/selectors/metadata.selectors';
+import { FileDetails } from '@app/comic-books/models/file-details';
 
 @Component({
   selector: 'cx-comic-edit',
@@ -257,8 +258,12 @@ export class ComicEditComponent implements OnInit, OnDestroy {
 
   onSaveChanges(): void {
     this.confirmationService.confirm({
-      title: this.translateService.instant('comic-book.save-changes.title'),
-      message: this.translateService.instant('comic-book.save-changes.message'),
+      title: this.translateService.instant(
+        'comic-book.save-changes.confirmation-title'
+      ),
+      message: this.translateService.instant(
+        'comic-book.save-changes.confirmation-message'
+      ),
       confirm: () => {
         const comic = this.encodeForm();
         this.logger.debug('Saving changes to comic:', comic);
@@ -336,12 +341,13 @@ export class ComicEditComponent implements OnInit, OnDestroy {
     );
   }
 
-  private encodeForm(): ComicBook {
+  encodeForm(): ComicBook {
     this.logger.trace('Encoding comic');
     return {
       ...this.comic,
       detail: {
         ...this.comic.detail,
+        id: undefined,
         publisher: this.comicForm.controls.publisher.value,
         imprint: this.comicForm.controls.imprint.value,
         series: this.comicForm.controls.series.value,
@@ -350,7 +356,8 @@ export class ComicEditComponent implements OnInit, OnDestroy {
         title: this.comicForm.controls.title.value,
         description: this.comicForm.controls.description.value
       },
-      sortName: this.comicForm.controls.sortName.value
+      sortName: this.comicForm.controls.sortName.value,
+      fileDetails: {} as FileDetails
     } as ComicBook;
   }
 }

--- a/comixed-webui/src/app/comic-books/components/comic-overview/comic-overview.component.html
+++ b/comixed-webui/src/app/comic-books/components/comic-overview/comic-overview.component.html
@@ -1,233 +1,96 @@
-<mat-grid-list cols="4" rowHeight="25px">
-  <mat-grid-tile class="cx-accent-light-background" colspan="4" rowspan="1">
-    {{ "comic-book.label.issue-details" | translate }}
-  </mat-grid-tile>
-  <mat-grid-tile class="cx-accent-light-background" colspan="1" rowspan="1">
-    <span class="cx-align-text-right cx-text-nowrap">
-      {{ "comic-book.label.publisher" | translate }}
-    </span>
-  </mat-grid-tile>
-  <mat-grid-tile colspan="3" rowspan="1">
-    <span
-      class="cx-width-100 cx-text-nowrap cx-align-text-left cx-padding-left-5"
-    >
-      <a
-        [routerLink]="[
-          '/library/collections/publishers',
-          comic.detail.publisher
-        ]"
-      >
-        {{ comic.detail.publisher }}
-      </a>
-    </span>
-  </mat-grid-tile>
-
-  <mat-grid-tile class="cx-accent-light-background" colspan="1" rowspan="1">
-    <span class="cx-align-text-right">
-      {{ "comic-book.label.series" | translate }}
-    </span>
-  </mat-grid-tile>
-  <mat-grid-tile colspan="3" rowspan="1">
-    <span
-      class="cx-width-100 cx-text-nowrap cx-align-text-left cx-padding-left-5"
-    >
-      <a
-        [routerLink]="[
-          '/library/collections/publishers',
-          comic.detail.publisher,
-          'series',
-          comic.detail.series,
-          'volumes',
-          comic.detail.volume
-        ]"
-      >
-        {{ comic.detail.series }}
-      </a>
-    </span>
-  </mat-grid-tile>
-
-  <mat-grid-tile class="cx-accent-light-background" colspan="1" rowspan="1">
-    <span class="cx-align-text-right">
-      {{ "comic-book.label.volume" | translate }}
-    </span>
-  </mat-grid-tile>
-  <mat-grid-tile colspan="3" rowspan="1">
-    <span
-      class="cx-width-100 cx-text-nowrap cx-align-text-left cx-padding-left-5"
-    >
-      {{ comic.detail.volume }}
-    </span>
-  </mat-grid-tile>
-
-  <mat-grid-tile class="cx-accent-light-background" colspan="1" rowspan="1">
-    <span class="cx-align-text-right">
-      {{ "comic-book.label.issue-number" | translate }}
-    </span>
-  </mat-grid-tile>
-  <mat-grid-tile colspan="3" rowspan="1">
-    <span
-      class="cx-width-100 cx-text-nowrap cx-align-text-left cx-padding-left-5"
-    >
-      {{ comic.detail.issueNumber }}
-    </span>
-  </mat-grid-tile>
-
-  <mat-grid-tile class="cx-accent-light-background" colspan="1" rowspan="1">
-    <span class="cx-align-text-right">
-      {{ "comic-book.label.cover-date" | translate }}
-    </span>
-  </mat-grid-tile>
-  <mat-grid-tile colspan="3" rowspan="1">
-    <span
-      class="cx-width-100 cx-text-nowrap cx-align-text-left cx-padding-left-5"
-    >
-      {{ comic.detail.coverDate | date: "MMMM yyyy" }}
-    </span>
-  </mat-grid-tile>
-
-  <mat-grid-tile class="cx-accent-light-background" colspan="1" rowspan="1">
-    <span class="cx-align-text-right">
-      {{ "comic-book.label.store-date" | translate }}
-    </span>
-  </mat-grid-tile>
-  <mat-grid-tile colspan="3" rowspan="1">
-    <span
-      class="cx-width-100 cx-text-nowrap cx-align-text-left cx-padding-left-5"
-    >
-      {{ comic.detail.storeDate | date: "longDate" }}
-    </span>
-  </mat-grid-tile>
-
-  <mat-grid-tile class="cx-accent-light-background" colspan="4" rowspan="1">
-    {{ "comic-book.label.file-details" | translate }}
-  </mat-grid-tile>
-
-  <mat-grid-tile class="cx-accent-light-background" colspan="1" rowspan="1">
-    <span class="cx-align-text-right">
-      {{ "comic-book.label.comic-state" | translate }}
-    </span>
-  </mat-grid-tile>
-  <mat-grid-tile colspan="3" rowspan="1">
-    <span
-      class="cx-width-100 cx-text-nowrap cx-align-text-left cx-padding-left-5"
-    >
-      {{ "comic-book.text.state-" + comic.detail.comicState | translate }}
-    </span>
-  </mat-grid-tile>
-
-  <mat-grid-tile class="cx-accent-light-background" colspan="1" rowspan="1">
-    <span class="cx-align-text-right">
-      {{ "comic-book.label.filename" | translate }}
-    </span>
-  </mat-grid-tile>
-  <mat-grid-tile colspan="3" rowspan="1">
-    <span
-      class="cx-width-100 cx-text-nowrap cx-align-text-left cx-padding-left-5"
-      [matTooltip]="comic.detail.filename"
-    >
-      {{ comic.detail.filename }}
-    </span>
-  </mat-grid-tile>
-
-  <mat-grid-tile class="cx-accent-light-background" colspan="1" rowspan="1">
-    <span class="cx-align-text-right">
-      {{ "comic-book.label.filesize" | translate }}
-    </span>
-  </mat-grid-tile>
-  <mat-grid-tile colspan="3" rowspan="1">
-    <span
-      class="cx-width-100 cx-text-nowrap cx-align-text-left cx-padding-left-5"
-    >
-      {{ "comic-book.text.filesize" | translate: { size: 0 } }}
-    </span>
-  </mat-grid-tile>
-
-  <mat-grid-tile class="cx-accent-light-background" colspan="1" rowspan="1">
-    <span class="cx-align-text-right">
-      {{ "comic-book.label.added-date" | translate }}
-    </span>
-  </mat-grid-tile>
-  <mat-grid-tile colspan="3" rowspan="1">
-    <span
-      class="cx-width-100 cx-text-nowrap cx-align-text-left cx-padding-left-5"
-    >
-      {{ comic.detail.addedDate | date: "medium" }}
-    </span>
-  </mat-grid-tile>
-
-  <mat-grid-tile
-    *ngIf="!!lastRead"
-    class="cx-accent-light-background"
-    colspan="1"
-    rowspan="1"
+<mat-toolbar *ngIf="isAdmin" class="cx-accent-light-background">
+  <button
+    id="save-comic-changes"
+    class="cx-toolbar-button cx-margin-left-5"
+    mat-icon-button
+    color="primary"
+    [matTooltip]="'comic-book.tooltip.save-changes' | translate"
+    [disabled]="!comicBookForm.valid"
+    (click)="onSaveChanges()"
   >
-    <span class="cx-align-text-right">
-      {{ "comic-book.label.last-read-date" | translate }}
-    </span>
-  </mat-grid-tile>
-  <mat-grid-tile *ngIf="!!lastRead" colspan="3" rowspan="1">
-    <span
-      class="cx-width-100 cx-text-nowrap cx-align-text-left cx-padding-left-5"
-    >
-      {{ lastRead.lastRead | date: "medium" }}
-    </span>
-  </mat-grid-tile>
-
-  <mat-grid-tile
-    *ngIf="comic.detail.notes?.length > 0"
-    class="cx-accent-light-background"
-    colspan="1"
-    rowspan="1"
+    <mat-icon>save</mat-icon>
+  </button>
+  <button
+    id="undo-comic-changes"
+    class="cx-toolbar-button cx-margin-left-5"
+    mat-icon-button
+    color="warn"
+    [matTooltip]="'comic-book.tooltip.undo-changes' | translate"
+    [disabled]="comicBookForm.untouched"
+    (click)="onUndoChanges()"
   >
-    <span class="cx-align-text-right">
-      {{ "comic-book.label.scraping-notes" | translate }}
-    </span>
-  </mat-grid-tile>
-  <mat-grid-tile *ngIf="comic.detail.notes?.length > 0" colspan="3" rowspan="1">
-    <span
-      class="cx-width-100 cx-text-nowrap cx-align-text-left cx-padding-left-5"
-    >
-      {{ comic.detail.notes }}
-    </span>
-  </mat-grid-tile>
+    <mat-icon>undo</mat-icon>
+  </button>
+</mat-toolbar>
 
-  <mat-grid-tile class="cx-accent-light-background" colspan="4" rowspan="1">
-    {{ "comic-book.label.other-details" | translate }}
-  </mat-grid-tile>
+<form class="cx-width-100" [formGroup]="comicBookForm">
+  <mat-form-field class="cx-width-100" appearance="standard" required>
+    <mat-label>{{ "comic-book.label.publisher" | translate }}</mat-label>
+    <input matInput formControlName="publisher" [readonly]="!isAdmin" />
+  </mat-form-field>
 
-  <mat-grid-tile
-    *ngIf="comic.sortName?.length > 0"
-    class="cx-accent-light-background"
-    colspan="1"
-    rowspan="1"
-  >
-    <span class="cx-align-text-right">
-      {{ "comic-book.label.sort-name" | translate }}
-    </span>
-  </mat-grid-tile>
-  <mat-grid-tile *ngIf="comic.sortName?.length > 0" colspan="3" rowspan="1">
-    <span
-      class="cx-width-100 cx-text-nowrap cx-align-text-left cx-padding-left-5"
-    >
-      {{ comic.sortName }}
-    </span>
-  </mat-grid-tile>
+  <mat-form-field class="cx-width-50" appearance="standard" required>
+    <mat-label>{{ "comic-book.label.series" | translate }}</mat-label>
+    <input matInput formControlName="series" [readonly]="!isAdmin" />
+  </mat-form-field>
 
-  <mat-grid-tile
-    *ngIf="!!comic.detail.imprint"
-    class="cx-accent-light-background"
-    colspan="1"
-    rowspan="1"
-  >
-    <span class="cx-align-text-right">
-      {{ "comic-book.label.imprint" | translate }}
-    </span>
-  </mat-grid-tile>
-  <mat-grid-tile *ngIf="!!comic.detail.imprint" colspan="3" rowspan="1">
-    <span
-      class="cx-width-100 cx-text-nowrap cx-align-text-left cx-padding-left-5"
-    >
-      {{ comic.detail.imprint }}
-    </span>
-  </mat-grid-tile>
-</mat-grid-list>
+  <mat-form-field class="cx-width-25" appearance="standard" required>
+    <mat-label>{{ "comic-book.label.volume" | translate }}</mat-label>
+    <input matInput formControlName="volume" [readonly]="!isAdmin" />
+  </mat-form-field>
+
+  <mat-form-field class="cx-width-25" appearance="standard" required>
+    <mat-label>{{ "comic-book.label.issue-number" | translate }}</mat-label>
+    <input matInput formControlName="issueNumber" [readonly]="!isAdmin" />
+  </mat-form-field>
+
+  <mat-form-field class="cx-width-25" appearance="standard">
+    <mat-label>{{ "comic-book.label.comic-state" | translate }}</mat-label>
+    <input matInput formControlName="comicState" readonly />
+  </mat-form-field>
+
+  <mat-form-field class="cx-width-25" appearance="standard">
+    <mat-label>{{ "comic-book.label.cover-date" | translate }}</mat-label>
+    <input
+      matInput
+      formControlName="coverDate"
+      [matDatepicker]="coverDatePicker"
+      [readonly]="!isAdmin"
+    />
+    <mat-datepicker-toggle
+      matSuffix
+      [for]="coverDatePicker"
+    ></mat-datepicker-toggle>
+    <mat-datepicker #coverDatePicker></mat-datepicker>
+  </mat-form-field>
+
+  <mat-form-field class="cx-width-25" appearance="standard">
+    <mat-label>{{ "comic-book.label.store-date" | translate }}</mat-label>
+    <input
+      matInput
+      formControlName="storeDate"
+      [matDatepicker]="storeDatePicker"
+      [readonly]="!isAdmin"
+    />
+    <mat-datepicker-toggle
+      matSuffix
+      [for]="storeDatePicker"
+    ></mat-datepicker-toggle>
+    <mat-datepicker #storeDatePicker></mat-datepicker>
+  </mat-form-field>
+
+  <mat-form-field class="cx-width-25" appearance="standard">
+    <mat-label>{{ "comic-book.label.filesize" | translate }}</mat-label>
+    <input matInput formControlName="fileSize" readonly />
+  </mat-form-field>
+
+  <mat-form-field class="cx-width-100" appearance="standard">
+    <mat-label>{{ "comic-book.label.filename" | translate }}</mat-label>
+    <input matInput formControlName="filename" readonly />
+  </mat-form-field>
+
+  <mat-form-field class="cx-width-100" appearance="standard">
+    <mat-label>{{ "comic-book.label.scraping-notes" | translate }}</mat-label>
+    <input matInput formControlName="scrapingNotes" [readonly]="!isAdmin" />
+  </mat-form-field>
+</form>

--- a/comixed-webui/src/app/comic-books/components/comic-overview/comic-overview.component.ts
+++ b/comixed-webui/src/app/comic-books/components/comic-overview/comic-overview.component.ts
@@ -20,6 +20,14 @@ import { Component, Input } from '@angular/core';
 import { ComicBook } from '@app/comic-books/models/comic-book';
 import { LastRead } from '@app/last-read/models/last-read';
 import { ComicBookState } from '@app/comic-books/models/comic-book-state';
+import { LoggerService } from '@angular-ru/cdk/logger';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { ConfirmationService } from '@tragically-slick/confirmation';
+import { TranslateService } from '@ngx-translate/core';
+import { Store } from '@ngrx/store';
+import { updateComicBook } from '@app/comic-books/actions/comic-book.actions';
+import { ComicDetail } from '@app/comic-books/models/comic-detail';
+import { FileDetails } from '@app/comic-books/models/file-details';
 
 @Component({
   selector: 'cx-comic-overview',
@@ -27,17 +35,110 @@ import { ComicBookState } from '@app/comic-books/models/comic-book-state';
   styleUrls: ['./comic-overview.component.scss']
 })
 export class ComicOverviewComponent {
-  @Input() comic: ComicBook;
   @Input() lastRead: LastRead;
   @Input() isAdmin = false;
 
+  comicBookForm: FormGroup;
+
+  constructor(
+    private logger: LoggerService,
+    private formBuilder: FormBuilder,
+    private store: Store<any>,
+    private confirmationService: ConfirmationService,
+    private translateService: TranslateService
+  ) {
+    this.logger.trace('Building comic book details form');
+    this.comicBookForm = this.formBuilder.group({
+      publisher: ['', Validators.required],
+      series: ['', Validators.required],
+      volume: ['', Validators.required],
+      issueNumber: ['', Validators.required],
+      coverDate: [''],
+      storeDate: [''],
+      comicState: [''],
+      filename: [''],
+      fileSize: [''],
+      addedToLibrary: [''],
+      scrapingNotes: ['']
+    });
+  }
+
+  private _comicBook: ComicBook;
+
+  get comicBook(): ComicBook {
+    return {
+      ...this._comicBook,
+      detail: {
+        ...this._comicBook.detail,
+        id: undefined,
+        publisher: this.comicBookForm.controls.publisher.value,
+        series: this.comicBookForm.controls.series.value,
+        volume: this.comicBookForm.controls.volume.value,
+        issueNumber: this.comicBookForm.controls.issueNumber.value,
+        coverDate: this.comicBookForm.controls.coverDate.value.getTime(),
+        storeDate: this.comicBookForm.controls.storeDate.value.getTime(),
+        notes: this.comicBookForm.controls.scrapingNotes.value
+      } as ComicDetail,
+      fileDetails: {} as FileDetails
+    } as ComicBook;
+  }
+
+  @Input() set comicBook(comic: ComicBook) {
+    this._comicBook = comic;
+    this.comicBookForm.controls.publisher.setValue(comic.detail.publisher);
+    this.comicBookForm.controls.series.setValue(comic.detail.series);
+    this.comicBookForm.controls.volume.setValue(comic.detail.volume);
+    this.comicBookForm.controls.issueNumber.setValue(comic.detail.issueNumber);
+    if (!!comic.detail.coverDate) {
+      this.comicBookForm.controls.coverDate.setValue(
+        new Date(comic.detail.coverDate)
+      );
+    } else {
+      this.comicBookForm.controls.coverDate.setValue(null);
+    }
+    if (!!comic.detail.storeDate) {
+      this.comicBookForm.controls.storeDate.setValue(
+        new Date(comic.detail.storeDate)
+      );
+    } else {
+      this.comicBookForm.controls.storeDate.setValue(null);
+    }
+    this.comicBookForm.controls.comicState.setValue(comic.detail.comicState);
+    this.comicBookForm.controls.filename.setValue(comic.detail.filename);
+    this.comicBookForm.controls.fileSize.setValue(0);
+    this.comicBookForm.controls.scrapingNotes.setValue(comic.detail.notes);
+    this.comicBookForm.markAsUntouched();
+  }
+
   get deleted(): boolean {
-    return this.comic.detail.comicState === ComicBookState.DELETED;
+    return this.comicBook.detail.comicState === ComicBookState.DELETED;
   }
 
   get comicChanged(): boolean {
     return (
-      !!this.comic && this.comic.detail.comicState === ComicBookState.CHANGED
+      !!this.comicBook &&
+      this.comicBook.detail.comicState === ComicBookState.CHANGED
     );
+  }
+
+  onSaveChanges(): void {
+    this.confirmationService.confirm({
+      title: this.translateService.instant(
+        'comic-book.save-changes.confirmation-title'
+      ),
+      message: this.translateService.instant(
+        'comic-book.save-changes.confirmation-message'
+      ),
+      confirm: () => {
+        const comicBook = this.comicBook;
+        this.logger.debug('Saving changes to comic:', comicBook);
+        this.store.dispatch(updateComicBook({ comicBook }));
+      }
+    });
+  }
+
+  onUndoChanges(): void {
+    this.logger.debug('Resetting comic book changes');
+    this.comicBook = this._comicBook;
   }
 }

--- a/comixed-webui/src/app/comic-books/components/issue-metadata-detail/issue-metadata-detail.component.spec.ts
+++ b/comixed-webui/src/app/comic-books/components/issue-metadata-detail/issue-metadata-detail.component.spec.ts
@@ -33,6 +33,7 @@ import {
 import { USER_READER } from '@app/user/user.fixtures';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { SCRAPING_ISSUE_1 } from '@app/comic-metadata/comic-metadata.fixtures';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('IssueMetadataDetailComponent', () => {
   const SCRAPING_ISSUE = SCRAPING_ISSUE_1;
@@ -53,6 +54,7 @@ describe('IssueMetadataDetailComponent', () => {
           IssueMetadataTitlePipe
         ],
         imports: [
+          NoopAnimationsModule,
           LoggerModule.forRoot(),
           TranslateModule.forRoot(),
           MatCardModule,

--- a/comixed-webui/src/app/comic-books/pages/comic-book-page/comic-book-page.component.html
+++ b/comixed-webui/src/app/comic-books/pages/comic-book-page/comic-book-page.component.html
@@ -168,7 +168,7 @@
     >
       <mat-tab [label]="'comic-book.label.comic-overview' | translate">
         <cx-comic-overview
-          [comic]="comicBook"
+          [comicBook]="comicBook"
           [lastRead]="lastRead"
           [isAdmin]="isAdmin"
         ></cx-comic-overview>

--- a/comixed-webui/src/app/comic-files/components/comic-file-toolbar/comic-file-toolbar.component.html
+++ b/comixed-webui/src/app/comic-files/components/comic-file-toolbar/comic-file-toolbar.component.html
@@ -53,7 +53,7 @@
 </mat-toolbar>
 <div *ngIf="showLookupForm" class="cx-width-100 cx-accent-l-background">
   <form [formGroup]="loadFilesForm">
-    <mat-form-field class="cx-width-25" appearance="fill">
+    <mat-form-field class="cx-width-25" appearance="standard">
       <mat-label>
         {{ "comic-files.label.maximum-files-to-fetch" | translate }}
       </mat-label>
@@ -70,7 +70,7 @@
         </mat-option>
       </mat-select>
     </mat-form-field>
-    <mat-form-field class="cx-width-75" appearance="fill">
+    <mat-form-field class="cx-width-75" appearance="standard">
       <mat-label>
         {{ "comic-files.label.root-directory" | translate }}
       </mat-label>

--- a/comixed-webui/src/app/comic-pages/pages/blocked-hash-detail-page/blocked-hash-detail-page.component.html
+++ b/comixed-webui/src/app/comic-pages/pages/blocked-hash-detail-page/blocked-hash-detail-page.component.html
@@ -48,7 +48,7 @@
       {{ "blocked-hash.page-title" | translate: { hash: hash } }}
     </mat-card-title>
     <mat-card-content>
-      <mat-form-field class="cx-width-100" appearance="fill">
+      <mat-form-field class="cx-width-100" appearance="standard">
         <mat-label>{{ "blocked-hash.label.label" | translate }}</mat-label>
         <tsm-edit-in-place
           [displayTemplate]="displayLabel"
@@ -69,7 +69,7 @@
         </tsm-edit-in-place>
         <input matInput hidden />
       </mat-form-field>
-      <mat-form-field class="cx-width-100" appearance="fill">
+      <mat-form-field class="cx-width-100" appearance="standard">
         <mat-label>{{ "blocked-hash.label.hash" | translate }}</mat-label>
         <input
           id="hash-input"

--- a/comixed-webui/src/app/components/collections-chart/collections-chart.component.html
+++ b/comixed-webui/src/app/components/collections-chart/collections-chart.component.html
@@ -25,7 +25,7 @@
     ></ngx-charts-bar-horizontal>
   </div>
   <div class="cx-grow-0">
-    <mat-form-field class="cx-width-100" appearance="fill">
+    <mat-form-field class="cx-width-100" appearance="standard">
       <mat-label>
         {{ "home.label.select-collection-type" | translate }}
       </mat-label>

--- a/comixed-webui/src/app/library/components/edit-multiple-comics/edit-multiple-comics.component.html
+++ b/comixed-webui/src/app/library/components/edit-multiple-comics/edit-multiple-comics.component.html
@@ -16,7 +16,7 @@
   </div>
 
   <form [formGroup]="detailsForm">
-    <mat-form-field class="cx-width-100" appearance="fill">
+    <mat-form-field class="cx-width-100" appearance="standard">
       <mat-label>{{ "comic-book.label.publisher" | translate }}</mat-label>
       <input
         id="publisher-input"
@@ -25,7 +25,7 @@
         [placeholder]="'comic-book.placeholder.publisher' | translate"
       />
     </mat-form-field>
-    <mat-form-field class="cx-width-100" appearance="fill">
+    <mat-form-field class="cx-width-100" appearance="standard">
       <mat-label>{{ "comic-book.label.series" | translate }}</mat-label>
       <input
         id="series-input"
@@ -38,7 +38,7 @@
         {{ "validation.field-required" | translate }}
       </mat-error>
     </mat-form-field>
-    <mat-form-field class="cx-width-25" appearance="fill">
+    <mat-form-field class="cx-width-25" appearance="standard">
       <mat-label>{{ "comic-book.label.volume" | translate }}</mat-label>
       <input
         id="volume-input"
@@ -47,7 +47,7 @@
         [placeholder]="'comic-book.placeholder.volume' | translate"
       />
     </mat-form-field>
-    <mat-form-field class="cx-width-25" appearance="fill">
+    <mat-form-field class="cx-width-25" appearance="standard">
       <mat-label>{{ "comic-book.label.issue-number" | translate }}</mat-label>
       <input
         id="issue-number-input"
@@ -60,7 +60,7 @@
         {{ "validation.field-required" | translate }}
       </mat-error>
     </mat-form-field>
-    <mat-form-field class="cx-width-50" appearance="fill">
+    <mat-form-field class="cx-width-50" appearance="standard">
       <mat-label>{{ "comic-book.label.imprint" | translate }}</mat-label>
       <mat-select
         id="imprint-select"

--- a/comixed-webui/src/app/user/components/edit-account-bar/edit-account-bar.component.html
+++ b/comixed-webui/src/app/user/components/edit-account-bar/edit-account-bar.component.html
@@ -28,7 +28,7 @@
 
   <div class="cx-width-100 cx-padding-left-15">
     <form [formGroup]="userForm">
-      <mat-form-field class="cx-width-100 cx-padding-5" appearance="fill">
+      <mat-form-field class="cx-width-100 cx-padding-5" appearance="standard">
         <mat-label>
           {{ "user.edit-current-user.label.email" | translate }}
         </mat-label>
@@ -48,7 +48,7 @@
           </span>
         </mat-error>
       </mat-form-field>
-      <mat-form-field class="cx-width-100 cx-padding-5" appearance="fill">
+      <mat-form-field class="cx-width-100 cx-padding-5" appearance="standard">
         <mat-label>
           {{ "user.edit-current-user.label.password" | translate }}
         </mat-label>
@@ -80,7 +80,7 @@
           </span>
         </mat-error>
       </mat-form-field>
-      <mat-form-field class="cx-width-100 cx-padding-5" appearance="fill">
+      <mat-form-field class="cx-width-100 cx-padding-5" appearance="standard">
         <mat-label>
           {{ "user.edit-current-user.label.password-verify" | translate }}
         </mat-label>
@@ -99,7 +99,7 @@
           </span>
         </mat-error>
       </mat-form-field>
-      <mat-form-field class="cx-width-100 cx-padding-5" appearance="fill">
+      <mat-form-field class="cx-width-100 cx-padding-5" appearance="standard">
         <mat-label>
           {{ "user.preference.label.max-records" | translate }}
         </mat-label>

--- a/comixed-webui/src/assets/i18n/en/comic-books.json
+++ b/comixed-webui/src/assets/i18n/en/comic-books.json
@@ -78,8 +78,8 @@
     "save-changes": {
       "effect-failure": "Failed to save changes.",
       "effect-success": "Changes saved.",
-      "message": "Are you sure you want to manual changes to this comic?",
-      "title": "Save Changes To Comic"
+      "confirmation-message": "Are you sure you want to manual changes to this comic?",
+      "confirmation-title": "Save Changes To Comic"
     },
     "save-page-order": {
       "confirmation-message": "Are you sure you want to save the new page ordering?",


### PR DESCRIPTION
If the user is an admin, then they can edit the details for the comic.

Also standarized all form fields to use "standard" layout, and fixed the comic book updating to set null cover and store dates if no value was received while scraping.

Closes #1480 

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

