### PR TITLE
Changed marking blocked pages for deletion [#1516]

### DIFF
--- a/comixed-webui/src/app/comic-pages/components/blocked-hash-toolbar/blocked-hash-toolbar.component.html
+++ b/comixed-webui/src/app/comic-pages/components/blocked-hash-toolbar/blocked-hash-toolbar.component.html
@@ -8,38 +8,8 @@
 
   <div class="cx-spacer"></div>
 
-  <button
-    id="set-deleted-button"
-    mat-icon-button
-    color="primary"
-    [matTooltip]="'blocked-hash-list.tooltip.set-deleted' | translate"
-    [disabled]="!hasSelections"
-    (click)="markSelected.emit()"
-  >
-    <mat-icon>flag</mat-icon>
-  </button>
-  <button
-    id="clear-deleted-button"
-    mat-icon-button
-    color="primary"
-    [matTooltip]="'blocked-hash-list.tooltip.clear-deleted' | translate"
-    [disabled]="!hasSelections"
-    (click)="clearSelected.emit()"
-  >
-    <mat-icon>outlined_flag</mat-icon>
-  </button>
   <mat-divider vertical="true"></mat-divider>
-  <button
-    id="delete-entries"
-    mat-icon-button
-    color="warn"
-    [matTooltip]="'blocked-hash-list.tooltip.delete-entries' | translate"
-    [disabled]="!hasSelections"
-    (click)="deleteSelected.emit()"
-  >
-    <mat-icon>delete</mat-icon>
-  </button>
-  <mat-divider vertical="true"></mat-divider>
+
   <button
     id="upload-button"
     mat-icon-button

--- a/comixed-webui/src/app/comic-pages/components/blocked-hash-toolbar/blocked-hash-toolbar.component.ts
+++ b/comixed-webui/src/app/comic-pages/components/blocked-hash-toolbar/blocked-hash-toolbar.component.ts
@@ -34,12 +34,8 @@ import { PAGE_SIZE_DEFAULT } from '@app/core';
 export class BlockedHashToolbarComponent {
   @ViewChild('MatPagination') paginator: MatPaginator;
 
-  @Input() hasSelections = false;
   @Input() pageSize = PAGE_SIZE_DEFAULT;
 
-  @Output() markSelected = new EventEmitter<void>();
-  @Output() clearSelected = new EventEmitter<void>();
-  @Output() deleteSelected = new EventEmitter<void>();
   @Output() uploadFile = new EventEmitter<File>();
   @Output() downloadFile = new EventEmitter<void>();
 

--- a/comixed-webui/src/app/comic-pages/pages/blocked-hash-detail-page/blocked-hash-detail-page.component.html
+++ b/comixed-webui/src/app/comic-pages/pages/blocked-hash-detail-page/blocked-hash-detail-page.component.html
@@ -1,72 +1,52 @@
-<form *ngIf="!!blockedPage" [formGroup]="blockedPageForm">
-  <mat-toolbar *ngIf="isAdmin" class="cx-primary-light-background">
-    <button
-      id="go-back-button"
-      mat-icon-button
-      class="cx-primary-light-background"
-      (click)="onGoBack()"
+<mat-toolbar *ngIf="isAdmin" class="cx-primary-light-background">
+  <button
+    id="go-back-button"
+    mat-icon-button
+    class="cx-primary-light-background"
+    (click)="onGoBack()"
+  >
+    <mat-icon>arrow_back</mat-icon>
+  </button>
+  <div class="cx-spacer"></div>
+  <button
+    id="save-button"
+    mat-icon-button
+    class="cx-toolbar-button"
+    color="primary"
+    [disabled]="!blockedPageForm.valid || !blockedPageForm.dirty"
+    (click)="onSave()"
+  >
+    <mat-icon>save</mat-icon>
+  </button>
+  <button
+    id="reset-button"
+    mat-icon-button
+    class="cx-toolbar-button"
+    color="warn"
+    [disabled]="!blockedPageForm.dirty"
+    (click)="onReset()"
+  >
+    <mat-icon>undo</mat-icon>
+  </button>
+</mat-toolbar>
+
+<div *ngIf="!!blockedPage" class="cx-horizontal-container cx-padding-5">
+  <div class="cx-grow-1">
+    <h2>{{ "blocked-hash.page-title" | translate: { hash: hash } }}</h2>
+
+    <form
+      *ngIf="!!blockedPage"
+      [formGroup]="blockedPageForm"
+      class="cx-padding-50 cx-border-primary-1"
     >
-      <mat-icon>arrow_back</mat-icon>
-    </button>
-    <div class="cx-spacer"></div>
-    <button
-      id="edit-button"
-      mat-raised-button
-      class="cx-toolbar-button"
-      color="primary"
-      [disabled]="editing"
-      (click)="onEdit()"
-    >
-      <mat-icon>edit</mat-icon>
-      <mat-label>{{ "button.edit" | translate }}</mat-label>
-    </button>
-    <button
-      id="save-button"
-      mat-raised-button
-      class="cx-toolbar-button"
-      color="accent"
-      [disabled]="!editing"
-      (click)="onSave()"
-    >
-      <mat-icon>save</mat-icon>
-      <mat-label>{{ "button.save" | translate }}</mat-label>
-    </button>
-    <button
-      id="reset-button"
-      mat-raised-button
-      class="cx-toolbar-button"
-      color="warn"
-      [disabled]="!blockedPageForm.dirty"
-      (click)="onReset()"
-    >
-      <mat-icon>save</mat-icon>
-      <mat-label>{{ "button.reset" | translate }}</mat-label>
-    </button>
-  </mat-toolbar>
-  <mat-card>
-    <mat-card-title>
-      {{ "blocked-hash.page-title" | translate: { hash: hash } }}
-    </mat-card-title>
-    <mat-card-content>
       <mat-form-field class="cx-width-100" appearance="standard">
         <mat-label>{{ "blocked-hash.label.label" | translate }}</mat-label>
-        <tsm-edit-in-place
-          [displayTemplate]="displayLabel"
-          [editingTemplate]="editLabel"
-          [editing]="editing"
-        >
-          <ng-template #displayLabel>
-            <span class="cx-width-100">{{ blockedPage.label }}</span>
-          </ng-template>
-          <ng-template #editLabel>
-            <input
-              id="label-input"
-              matInput
-              class="cx-width-100"
-              formControlName="label"
-            />
-          </ng-template>
-        </tsm-edit-in-place>
+        <input
+          id="label-input"
+          matInput
+          class="cx-width-100"
+          formControlName="label"
+        />
         <input matInput hidden />
       </mat-form-field>
       <mat-form-field class="cx-width-100" appearance="standard">
@@ -79,6 +59,17 @@
           formControlName="hash"
         />
       </mat-form-field>
-    </mat-card-content>
-  </mat-card>
-</form>
+    </form>
+  </div>
+
+  <div class="cx-grow-0 cx-width-25 cx-padding-5">
+    <img
+      [src]="blockedPage.hash | pageHashUrl"
+      width="100%"
+      height="auto"
+      [alt]="
+        'blocked-hash.text.hash-value' | translate: { hash: blockedPage.hash }
+      "
+    />
+  </div>
+</div>

--- a/comixed-webui/src/app/comic-pages/pages/blocked-hash-detail-page/blocked-hash-detail-page.component.spec.ts
+++ b/comixed-webui/src/app/comic-pages/pages/blocked-hash-detail-page/blocked-hash-detail-page.component.spec.ts
@@ -49,6 +49,7 @@ import {
   Confirmation,
   ConfirmationService
 } from '@tragically-slick/confirmation';
+import { PageHashUrlPipe } from '@app/comic-books/pipes/page-hash-url.pipe';
 
 describe('BlockedHashDetailPageComponent', () => {
   const ENTRIES = [BLOCKED_HASH_1, BLOCKED_HASH_3, BLOCKED_HASH_5];
@@ -70,7 +71,7 @@ describe('BlockedHashDetailPageComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        declarations: [BlockedHashDetailPageComponent],
+        declarations: [BlockedHashDetailPageComponent, PageHashUrlPipe],
         imports: [
           NoopAnimationsModule,
           RouterTestingModule.withRoutes([{ path: '**', redirectTo: '' }]),
@@ -123,7 +124,6 @@ describe('BlockedHashDetailPageComponent', () => {
 
   describe('when the blocked page is loaded', () => {
     beforeEach(() => {
-      component.editing = true;
       component.blockedPage = ENTRY;
     });
 
@@ -133,13 +133,8 @@ describe('BlockedHashDetailPageComponent', () => {
       );
     });
 
-    it('clears the editing flag', () => {
-      expect(component.editing).toBeFalse();
-    });
-
     describe('when the page label is null', () => {
       beforeEach(() => {
-        component.editing = true;
         store.setState({
           ...initialState,
           [BLOCKED_PAGE_DETAIL_FEATURE_KEY]: {
@@ -154,17 +149,6 @@ describe('BlockedHashDetailPageComponent', () => {
       it('uses an empty string for the label', () => {
         expect(component.blockedPageForm.controls.label.value).toEqual('');
       });
-    });
-  });
-
-  describe('editing the blocked page', () => {
-    beforeEach(() => {
-      component.editing = false;
-      component.onEdit();
-    });
-
-    it('sets the editing flag', () => {
-      expect(component.editing).toBeTrue();
     });
   });
 
@@ -194,7 +178,6 @@ describe('BlockedHashDetailPageComponent', () => {
         (confirmation: Confirmation) => confirmation.confirm()
       );
       component.blockedPage = ENTRY;
-      component.editing = true;
       component.blockedPageForm.controls.label.setValue(ENTRY.label.substr(1));
       component.onReset();
     });
@@ -207,10 +190,6 @@ describe('BlockedHashDetailPageComponent', () => {
       expect(component.blockedPageForm.controls.label.value).toEqual(
         ENTRY.label
       );
-    });
-
-    it('clears the editing flag', () => {
-      expect(component.editing).toBeFalse();
     });
   });
 

--- a/comixed-webui/src/app/comic-pages/pages/blocked-hash-detail-page/blocked-hash-detail-page.component.ts
+++ b/comixed-webui/src/app/comic-pages/pages/blocked-hash-detail-page/blocked-hash-detail-page.component.ts
@@ -50,7 +50,6 @@ export class BlockedHashDetailPageComponent implements OnDestroy {
   userSubscription: Subscription;
   isAdmin = false;
   hash = '';
-  editing = false;
 
   blockedPageForm: FormGroup;
 
@@ -105,18 +104,12 @@ export class BlockedHashDetailPageComponent implements OnDestroy {
     this.blockedPageForm.controls.hash.setValue(blockedPage.hash);
     this.blockedPageForm.updateValueAndValidity();
     this.blockedPageForm.markAsPristine();
-    this.editing = false;
   }
 
   ngOnDestroy(): void {
     this.paramsSubscription.unsubscribe();
     this.blockedPageSubscription.unsubscribe();
     this.userSubscription.unsubscribe();
-  }
-
-  onEdit(): void {
-    this.logger.debug('Enabling edit mode');
-    this.editing = true;
   }
 
   onSave(): void {
@@ -141,7 +134,6 @@ export class BlockedHashDetailPageComponent implements OnDestroy {
       confirm: () => {
         this.logger.debug('Resetting changes');
         this.blockedPage = this._blockedPage;
-        this.editing = false;
       }
     });
   }

--- a/comixed-webui/src/app/comic-pages/pages/blocked-hash-list-page/blocked-hash-list-page.component.html
+++ b/comixed-webui/src/app/comic-pages/pages/blocked-hash-list-page/blocked-hash-list-page.component.html
@@ -1,38 +1,83 @@
+<div
+  *ngIf="showPopup"
+  class="cx-hover cx-centered cx-width-25 cx-border-primary-1"
+>
+  <mat-card>
+    <mat-card-title class="cx-text-nowrap">
+      {{ currentBlockedHash.hash }}
+    </mat-card-title>
+    <mat-card-content class="cx-padding-5">
+      <img
+        [src]="currentBlockedHash.hash | pageHashUrl"
+        width="100%"
+        height="auto"
+        [alt]="
+          'blocked-hash.text.hash-value' | translate: { hash: blockedPage.hash }
+        "
+      />
+    </mat-card-content>
+  </mat-card>
+</div>
+
 <cx-blocked-hash-toolbar
-  [hasSelections]="hasSelections"
-  (markSelected)="onMarkSelectedForDeletion()"
-  (clearSelected)="onClearSelectedForDeletion()"
-  (deleteSelected)="onDeleteEntries()"
   (uploadFile)="onFileSelected($event)"
   (downloadFile)="onDownloadFile()"
 ></cx-blocked-hash-toolbar>
 
 <h2>
-  {{
-    "blocked-hash-list.page-title"
-      | translate: { selected: selectedHashes.length, count: entries.length }
-  }}
+  {{ "blocked-hash-list.page-title" | translate: { count: entries.length } }}
 </h2>
 
-<mat-paginator
-  [pageSizeOptions]="pageOptions"
-  [pageSize]="pageSize"
-></mat-paginator>
+<mat-toolbar class="cx-accent-light-background">
+  <mat-form-field class="cx-width-50" appearance="standard">
+    <input
+      matInput
+      #filterInput
+      id="volume-search-text-input"
+      [placeholder]="'blocked-hash-list.placeholder.filter-entries' | translate"
+      (keyup)="dataSource.filter = filterInput.value"
+    />
+  </mat-form-field>
+  <div class="cx-spacer"></div>
+  <mat-paginator
+    class="cx-accent-light-background cx-height-100"
+    showFirstLastButtons="true"
+    [pageSize]="queryParameterService.pageSize$ | async"
+    [pageSizeOptions]="pageOptions"
+    (page)="
+      queryParameterService.onPageChange(
+        $event.pageSize,
+        $event.pageIndex,
+        $event.previousPageIndex
+      )
+    "
+  ></mat-paginator>
+</mat-toolbar>
 
-<mat-table [dataSource]="dataSource" matSort>
-  <ng-container matColumnDef="selected">
-    <mat-header-cell mat-sort-header *matHeaderCellDef>
-      <mat-checkbox
-        [checked]="allSelected"
-        (change)="onSelectAll($event.checked)"
-      ></mat-checkbox>
-    </mat-header-cell>
+<mat-table
+  [dataSource]="dataSource"
+  matSort
+  [matSortActive]="queryParameterService.sortBy$ | async"
+  [matSortDirection]="queryParameterService.sortDirection$ | async"
+  (matSortChange)="
+    queryParameterService.onSortChange($event.active, $event.direction)
+  "
+>
+  <ng-container matColumnDef="thumbnail">
+    <mat-header-cell *matHeaderCellDef></mat-header-cell>
     <mat-cell *matCellDef="let entry">
-      <mat-checkbox
-        [checked]="entry.selected"
-        (click)="$event.stopImmediatePropagation()"
-        (change)="onSelectOne(entry, $event.checked)"
-      ></mat-checkbox>
+      <span class="cx-text-nowrap">
+        <img
+          [src]="entry.hash | pageHashUrl"
+          width="100%"
+          height="auto"
+          [alt]="
+            'blocked-hash.text.hash-value' | translate: { hash: entry.hash }
+          "
+          (mouseenter)="onShowPopup(true, entry)"
+          (mouseleave)="onShowPopup(false, null)"
+        />
+      </span>
     </mat-cell>
   </ng-container>
 
@@ -41,7 +86,7 @@
       {{ "blocked-hash-list.header.label" | translate }}
     </mat-header-cell>
     <mat-cell *matCellDef="let entry">
-      <span class="cx-text-nowrap">{{ entry.item.label }}</span>
+      <span class="cx-text-nowrap cx-padding-5">{{ entry.label }}</span>
     </mat-cell>
   </ng-container>
 
@@ -50,7 +95,7 @@
       {{ "blocked-hash-list.header.hash" | translate }}
     </mat-header-cell>
     <mat-cell *matCellDef="let entry">
-      <span class="cx-text-nowrap">{{ entry.item.hash }}</span>
+      <span class="cx-text-nowrap cx-padding-5">{{ entry.hash }}</span>
     </mat-cell>
   </ng-container>
 
@@ -59,7 +104,7 @@
       {{ "blocked-hash-list.header.comic-count" | translate }}
     </mat-header-cell>
     <mat-cell *matCellDef="let entry">
-      <span class="cx-text-nowrap">{{ entry.item.comicCount }}</span>
+      <span class="cx-text-nowrap">{{ entry.comicCount }}</span>
     </mat-cell>
   </ng-container>
 
@@ -69,14 +114,52 @@
     </mat-header-cell>
     <mat-cell *matCellDef="let entry">
       <span class="cx-text-nowrap">
-        {{ entry.item.createdOn | date: "medium" }}
+        {{ entry.createdOn | date: "medium" }}
       </span>
+    </mat-cell>
+  </ng-container>
+
+  <ng-container matColumnDef="action">
+    <mat-header-cell mat-sort-header *matHeaderCellDef></mat-header-cell>
+    <mat-cell *matCellDef="let entry">
+      <button
+        id="set-deleted-button"
+        mat-icon-button
+        color="primary"
+        [matTooltip]="'blocked-hash-list.tooltip.set-deleted' | translate"
+        (click)="
+          $event.stopPropagation(); onMarkSelectedForDeletion(entry, true)
+        "
+      >
+        <mat-icon>flag</mat-icon>
+      </button>
+      <button
+        id="clear-deleted-button"
+        mat-icon-button
+        color="primary"
+        [matTooltip]="'blocked-hash-list.tooltip.clear-deleted' | translate"
+        (click)="
+          $event.stopPropagation(); onMarkSelectedForDeletion(entry, false)
+        "
+      >
+        <mat-icon>outlined_flag</mat-icon>
+      </button>
+
+      <button
+        id="delete-entries"
+        mat-icon-button
+        color="warn"
+        [matTooltip]="'blocked-hash-list.tooltip.delete-entries' | translate"
+        (click)="$event.stopPropagation(); onDeleteEntry(entry)"
+      >
+        <mat-icon>delete</mat-icon>
+      </button>
     </mat-cell>
   </ng-container>
 
   <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
   <mat-row
     *matRowDef="let row; columns: displayedColumns"
-    [routerLink]="['/library', 'pages', 'blocked', row.item.hash]"
+    [routerLink]="['/library', 'pages', 'blocked', row.hash]"
   ></mat-row>
 </mat-table>

--- a/comixed-webui/src/app/comic-pages/pages/blocked-hash-list-page/blocked-hash-list-page.component.scss
+++ b/comixed-webui/src/app/comic-pages/pages/blocked-hash-list-page/blocked-hash-list-page.component.scss
@@ -4,6 +4,11 @@ mat-divider {
   height: 50%;
 }
 
+.mat-column-thumbnail {
+  width: $cx-column-small;
+  max-width: $cx-column-small;
+}
+
 .mat-column-selected {
   width: $cx-column-small;
   max-width: $cx-column-small;
@@ -25,4 +30,9 @@ mat-divider {
 .mat-column-created-on {
   width: $cx-column-large;
   max-width: $cx-column-large;
+}
+
+.mat-column-action {
+  width: $cx-column-smallish;
+  max-width: $cx-column-smallish;
 }

--- a/comixed-webui/src/assets/i18n/en/comic-pages.json
+++ b/comixed-webui/src/assets/i18n/en/comic-pages.json
@@ -25,6 +25,9 @@
     "set-state": {
       "effect-failure": "Failed to {blocked, select, true{block} other{unblock}} page hash.",
       "effect-success": "Successfully {blocked, select, true{blocked} other{unblocked}} page hash."
+    },
+    "text": {
+      "hash-value": "The hash value is {hash}"
     }
   },
   "blocked-hash-list": {
@@ -52,14 +55,17 @@
       "effect-failure": "Failed to {deleted, select, true{mark} other{clear}} the deletion flag.",
       "effect-success": "{deleted, select, true{Marked} other{Cleared}} for deletion."
     },
-    "page-title": "Blocked Hash List ({selected} of {count} Selected)",
+    "page-title": "Blocked Hash List ({count} Total)",
+    "placeholder": {
+      "filter-entries": "Enter text to filter the list of blocked hashes."
+    },
     "tab-title": "Blocked Hash List",
     "tooltip": {
-      "clear-deleted": "Clear selected pages from deletion.",
-      "delete-entries": "Delete selected blocked page entries.",
-      "download-file": "Download blocked pages file.",
-      "upload-file": "Upload a blocked pages file.",
-      "set-deleted": "Mark selected pages for deletion."
+      "clear-deleted": "Unmark pages with this hash for deletion.",
+      "delete-entries": "Delete this blocked hash entry.",
+      "download-file": "Download blocked hash file.",
+      "upload-file": "Upload a blocked hash file.",
+      "set-deleted": "Mark pages with this hash for deletion."
     },
     "upload-file": {
       "confirmation-message": "Are you sure you want to upload \"{filename}\"?",


### PR DESCRIPTION
Instead of a selection and toolbar activity, the pages with a given has are marked or unmarked as a group individually by that hash.

Closes #1516 

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

