### PR TITLE
Added URL encoding the collection name in the feed [#1552]

### DIFF
--- a/comixed-opds/src/main/java/org/comixedproject/opds/OPDSUtils.java
+++ b/comixed-opds/src/main/java/org/comixedproject/opds/OPDSUtils.java
@@ -49,6 +49,7 @@ public class OPDSUtils {
   public static final String OPDS_IMAGE_RELATION = "http://opds-spec.org/image";
   public static final String OPDS_IMAGE_THUMBNAIL = "http://opds-spec.org/image/thumbnail";
   public static final String MIME_TYPE_IMAGE = "image/*";
+  public static final String ENCODED_SLASH = "[SLASH]";
 
   @Autowired private FileTypeAdaptor fileTypeAdaptor;
   @Autowired private ComicBookAdaptor comicBookAdaptor;
@@ -92,7 +93,8 @@ public class OPDSUtils {
    */
   public String urlEncodeString(final String value) {
     try {
-      return URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
+      return URLEncoder.encode(
+          value.replace("/", ENCODED_SLASH), StandardCharsets.UTF_8.toString());
     } catch (UnsupportedEncodingException error) {
       log.error("Failed to encode string", error);
       return value;
@@ -107,7 +109,8 @@ public class OPDSUtils {
    */
   public String urlDecodeString(final String value) {
     try {
-      return URLDecoder.decode(value, StandardCharsets.UTF_8.toString());
+      return URLDecoder.decode(value, StandardCharsets.UTF_8.toString())
+          .replace(ENCODED_SLASH, "/");
     } catch (UnsupportedEncodingException error) {
       log.error("Failed to decode string", error);
       return value;

--- a/comixed-opds/src/main/java/org/comixedproject/opds/service/OPDSNavigationService.java
+++ b/comixed-opds/src/main/java/org/comixedproject/opds/service/OPDSNavigationService.java
@@ -426,11 +426,12 @@ public class OPDSNavigationService {
         this.comicDetailService.getAllValuesForTag(collectionType.getComicTagType(), email, unread)
             .stream()
             .map(
-                character ->
+                value ->
                     new CollectionFeedEntry(
-                        character,
+                        value,
                         this.opdsUtils.createIdForEntry(
-                            collectionType.getComicTagType(), character)))
+                            collectionType.getComicTagType(),
+                            this.opdsUtils.urlEncodeString(value))))
             .collect(Collectors.toUnmodifiableList()),
         unread);
   }


### PR DESCRIPTION
Since simply replacing "/" with "%2F" does *not* work, this approach was to replace "/" with a known string "[SLASH]". Then we look to replace such a value when decoding a string as well.

Closes #1552 

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

