### PR TITLE
Fixed the import count shown in the footer [#1576]

### DIFF
--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/listeners/ProcessedComicChunkListener.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/listeners/ProcessedComicChunkListener.java
@@ -38,21 +38,25 @@ public class ProcessedComicChunkListener extends AbstractComicProcessingListener
     implements ChunkListener {
   @Override
   public void beforeChunk(final ChunkContext context) {
-    // nothing to do
+    this.doPublishChunkState(context);
   }
 
   @Override
   public void afterChunk(final ChunkContext context) {
+    this.doPublishChunkState(context);
+  }
+
+  @Override
+  public void afterChunkError(final ChunkContext context) {
+    this.doPublishChunkState(context);
+  }
+
+  private void doPublishChunkState(ChunkContext context) {
     final ExecutionContext executionContext =
         context.getStepContext().getStepExecution().getJobExecution().getExecutionContext();
     log.trace("Publishing status after chunk");
     executionContext.putLong(
         PROCESSED_COMICS, context.getStepContext().getStepExecution().getWriteCount());
     this.doPublishState(executionContext);
-  }
-
-  @Override
-  public void afterChunkError(final ChunkContext context) {
-    // nothing to do
   }
 }

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/listeners/ProcessedComicBookChunkListenerTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/listeners/ProcessedComicBookChunkListenerTest.java
@@ -73,11 +73,53 @@ public class ProcessedComicBookChunkListenerTest {
   }
 
   @Test
+  public void testBeforeChunk() throws PublishingException {
+    Mockito.when(executionContext.containsKey(JOB_STARTED)).thenReturn(true);
+    Mockito.when(executionContext.containsKey(JOB_FINISHED)).thenReturn(false);
+
+    listener.beforeChunk(chunkContext);
+
+    final ProcessComicStatus status = processComicStatusArgumentCaptor.getValue();
+
+    assertNotNull(status);
+    assertTrue(status.isActive());
+    assertEquals(TEST_JOB_STARTED, status.getStarted());
+    assertEquals(TEST_STEP_NAME, status.getStepName());
+    assertEquals(TEST_TOTAL_COMICS, status.getTotal());
+    assertEquals(TEST_PROCESSED_COMICS, status.getProcessed());
+
+    Mockito.verify(publishProcessComicsStatusAction, Mockito.times(1)).publish(status);
+
+    Mockito.verify(executionContext, Mockito.times(1)).putLong(PROCESSED_COMICS, TEST_WRITE_COUNT);
+  }
+
+  @Test
   public void testAfterChunk() throws PublishingException {
     Mockito.when(executionContext.containsKey(JOB_STARTED)).thenReturn(true);
     Mockito.when(executionContext.containsKey(JOB_FINISHED)).thenReturn(false);
 
     listener.afterChunk(chunkContext);
+
+    final ProcessComicStatus status = processComicStatusArgumentCaptor.getValue();
+
+    assertNotNull(status);
+    assertTrue(status.isActive());
+    assertEquals(TEST_JOB_STARTED, status.getStarted());
+    assertEquals(TEST_STEP_NAME, status.getStepName());
+    assertEquals(TEST_TOTAL_COMICS, status.getTotal());
+    assertEquals(TEST_PROCESSED_COMICS, status.getProcessed());
+
+    Mockito.verify(publishProcessComicsStatusAction, Mockito.times(1)).publish(status);
+
+    Mockito.verify(executionContext, Mockito.times(1)).putLong(PROCESSED_COMICS, TEST_WRITE_COUNT);
+  }
+
+  @Test
+  public void testAfterChunkError() throws PublishingException {
+    Mockito.when(executionContext.containsKey(JOB_STARTED)).thenReturn(true);
+    Mockito.when(executionContext.containsKey(JOB_FINISHED)).thenReturn(false);
+
+    listener.afterChunkError(chunkContext);
 
     final ProcessComicStatus status = processComicStatusArgumentCaptor.getValue();
 

--- a/comixed-repositories/src/main/java/org/comixedproject/repositories/comicbooks/ComicBookRepository.java
+++ b/comixed-repositories/src/main/java/org/comixedproject/repositories/comicbooks/ComicBookRepository.java
@@ -497,13 +497,6 @@ public interface ComicBookRepository extends JpaRepository<ComicBook, Long> {
       @Param("volume") String volume);
 
   /**
-   * Returns the number of comics that are unscraped.
-   *
-   * @return the unscraped comic count
-   */
-  long countByMetadataIsNull();
-
-  /**
    * Returns the publishers state for the library.
    *
    * @return the publishers state

--- a/comixed-repositories/src/test/java/org/comixedproject/repositories/comicbooks/ComicBookRepositoryTest.java
+++ b/comixed-repositories/src/test/java/org/comixedproject/repositories/comicbooks/ComicBookRepositoryTest.java
@@ -290,13 +290,6 @@ public class ComicBookRepositoryTest {
   }
 
   @Test
-  public void testCountByMetadataIsNull() {
-    final long result = repository.countByMetadataIsNull();
-
-    assertTrue(result > 0L);
-  }
-
-  @Test
   public void testGetByPublisherAndYear() {
     final List<PublisherAndYearSegment> result = repository.getByPublisherAndYear();
 

--- a/comixed-services/src/main/java/org/comixedproject/service/comicbooks/ComicBookService.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/comicbooks/ComicBookService.java
@@ -683,11 +683,6 @@ public class ComicBookService implements InitializingBean, ComicStateChangeListe
     return this.comicBookRepository.count();
   }
 
-  public long getUnscrapedComicBookCount() {
-    log.trace("Getting unscraped comics count");
-    return this.comicBookRepository.countByMetadataIsNull();
-  }
-
   /**
    * Returns the total number of comics marked for deletion.
    *

--- a/comixed-services/src/main/java/org/comixedproject/service/library/RemoteLibraryStateService.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/library/RemoteLibraryStateService.java
@@ -75,7 +75,7 @@ public class RemoteLibraryStateService implements InitializingBean, ComicStateCh
     final RemoteLibraryState result =
         new RemoteLibraryState(
             this.comicBookService.getComicBookCount(),
-            this.comicBookService.getUnscrapedComicBookCount(),
+            this.comicBookService.getCountForState(ComicState.UNPROCESSED),
             this.comicBookService.getDeletedComicCount(),
             selectedIds);
     result.setPublishers(this.comicBookService.getPublishersState());

--- a/comixed-services/src/test/java/org/comixedproject/service/comicbooks/ComicBookServiceTest.java
+++ b/comixed-services/src/test/java/org/comixedproject/service/comicbooks/ComicBookServiceTest.java
@@ -1084,17 +1084,6 @@ public class ComicBookServiceTest {
   }
 
   @Test
-  public void testGetUnscrapedComicBookCount() {
-    Mockito.when(comicBookRepository.countByMetadataIsNull()).thenReturn(TEST_COMIC_COUNT);
-
-    final long result = service.getUnscrapedComicBookCount();
-
-    assertEquals(TEST_COMIC_COUNT, result);
-
-    Mockito.verify(comicBookRepository, Mockito.times(1)).countByMetadataIsNull();
-  }
-
-  @Test
   public void testGetDeletedComicBookCount() {
     Mockito.when(comicBookRepository.findForStateCount(Mockito.any())).thenReturn(TEST_COMIC_COUNT);
 


### PR DESCRIPTION
Now it shows the number of comics with the UNPROCESSED state, rather than the number of comics without a metadata source.

Closes #1576 

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

