### PR TITLE
Added redirecting the browser on library consolidation failure [#1558]

### DIFF
--- a/comixed-webui/src/app/core/services/alert.service.ts
+++ b/comixed-webui/src/app/core/services/alert.service.ts
@@ -20,6 +20,7 @@ import { Injectable } from '@angular/core';
 import { LoggerService } from '@angular-ru/cdk/logger';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { TranslateService } from '@ngx-translate/core';
+import { Router } from '@angular/router';
 
 export const INFO_MESSAGE_DURATION = 5000;
 export const ERROR_MESSAGE_DURATION = undefined;
@@ -36,7 +37,8 @@ export class AlertService {
   constructor(
     private logger: LoggerService,
     private translateService: TranslateService,
-    private snackbar: MatSnackBar
+    private snackbar: MatSnackBar,
+    private router: Router
   ) {}
 
   /** Shows an information alert. */
@@ -55,9 +57,9 @@ export class AlertService {
   }
 
   /** Shows an error alert. */
-  error(message: string): void {
+  error(message: string, routerLink: string | null = null): void {
     this.logger.trace('Showing error message:', message);
-    this.snackbar.open(
+    const alert = this.snackbar.open(
       message,
       this.translateService.instant('alert.error-action'),
       {
@@ -67,5 +69,18 @@ export class AlertService {
         panelClass: ['cx-error-alert']
       }
     );
+
+    if (!!routerLink) {
+      alert.afterOpened().subscribe(() => {
+        this.router
+          .navigateByUrl(routerLink)
+          .catch(error =>
+            this.logger.error(
+              'Failed to redirect to library configuration page',
+              error
+            )
+          );
+      });
+    }
   }
 }

--- a/comixed-webui/src/app/library/effects/consolidate-library.effects.spec.ts
+++ b/comixed-webui/src/app/library/effects/consolidate-library.effects.spec.ts
@@ -37,6 +37,7 @@ import {
 } from '@app/library/actions/consolidate-library.actions';
 import { hot } from 'jasmine-marbles';
 import { HttpErrorResponse } from '@angular/common/http';
+import { LIBRARY_CONSOLIDATION_CONFIG_URL } from '@app/library/library.constants';
 
 describe('ConsolidateLibraryEffects', () => {
   const COMICS = [COMIC_BOOK_1, COMIC_BOOK_3, COMIC_BOOK_5];
@@ -108,7 +109,10 @@ describe('ConsolidateLibraryEffects', () => {
 
       const expected = hot('-b', { b: outcome });
       expect(effects.consolidateLibrary$).toBeObservable(expected);
-      expect(alertService.error).toHaveBeenCalledWith(jasmine.any(String));
+      expect(alertService.error).toHaveBeenCalledWith(
+        jasmine.any(String),
+        LIBRARY_CONSOLIDATION_CONFIG_URL
+      );
     });
 
     it('fires an action on general failure', () => {

--- a/comixed-webui/src/app/library/effects/consolidate-library.effects.ts
+++ b/comixed-webui/src/app/library/effects/consolidate-library.effects.ts
@@ -30,6 +30,7 @@ import { LibraryService } from '@app/library/services/library.service';
 import { LoggerService } from '@angular-ru/cdk/logger';
 import { catchError, map, switchMap, tap } from 'rxjs/operators';
 import { of } from 'rxjs';
+import { LIBRARY_CONSOLIDATION_CONFIG_URL } from '@app/library/library.constants';
 
 @Injectable()
 export class ConsolidateLibraryEffects {
@@ -55,7 +56,8 @@ export class ConsolidateLibraryEffects {
             this.alertService.error(
               this.translateService.instant(
                 'library.consolidate.effect-failure'
-              )
+              ),
+              LIBRARY_CONSOLIDATION_CONFIG_URL
             );
             return of(startLibraryConsolidationFailed());
           })

--- a/comixed-webui/src/app/library/library.constants.ts
+++ b/comixed-webui/src/app/library/library.constants.ts
@@ -21,6 +21,8 @@ import { API_ROOT_URL } from '../core';
 export const UNKNOWN_VALUE_PLACEHOLDER = 'UNKNOWN';
 
 export const MISSING_COMIC_IMAGE_URL = '/assets/img/missing-comic-file.png';
+export const LIBRARY_CONSOLIDATION_CONFIG_URL = '/admin/configuration?tab=2';
+
 export const GET_COMIC_COVER_URL = `${API_ROOT_URL}/comics/\${id}/cover/content`;
 export const GET_PAGE_CONTENT_URL = `${API_ROOT_URL}/pages/\${id}/content`;
 

--- a/comixed-webui/src/assets/i18n/en/library.json
+++ b/comixed-webui/src/assets/i18n/en/library.json
@@ -94,7 +94,7 @@
     "consolidate": {
       "confirmation-message": "This process can take a long time and will move all comics based on the consolidation rules. Are you sure you want to continue?",
       "confirmation-title": "Consolidate Library",
-      "effect-failure": "Failed to start library consolidation.",
+      "effect-failure": "Failed to start library consolidation. Please verify your library confirmation and try again.",
       "effect-success": "Library consolidation started."
     },
     "context-menu": {


### PR DESCRIPTION
Added an optional URL to the AlertService.error API. If provided, then the browser is redirected to that URL when the error message is shown.

Closes #1558 

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

