### PR TITLE
Added hotkeys to the library page [#1545]

### DIFF
--- a/comixed-webui/src/app/library/pages/library-page/library-page.component.spec.ts
+++ b/comixed-webui/src/app/library/pages/library-page/library-page.component.spec.ts
@@ -552,23 +552,66 @@ describe('LibraryPageComponent', () => {
           selected: true
         };
       });
-      component.onSelectAll();
     });
 
-    it('fires an action', () => {
-      expect(store.dispatch).toHaveBeenCalledWith(
-        selectComicBooks({ ids: COMIC_BOOKS.map(comic => comic.id) })
-      );
+    describe('using a button click', () => {
+      beforeEach(() => {
+        component.onSelectAll();
+      });
+
+      it('fires an action', () => {
+        expect(store.dispatch).toHaveBeenCalledWith(
+          selectComicBooks({ ids: COMIC_BOOKS.map(comic => comic.id) })
+        );
+      });
+    });
+
+    describe('using a hotkey', () => {
+      const event = new KeyboardEvent('hotkey');
+
+      beforeEach(() => {
+        spyOn(event, 'preventDefault');
+        component.onHotkeySelectAll(event);
+      });
+
+      it('prevents event propagation', () => {
+        expect(event.preventDefault).toHaveBeenCalled();
+      });
+
+      it('fires an action', () => {
+        expect(store.dispatch).toHaveBeenCalledWith(
+          selectComicBooks({ ids: COMIC_BOOKS.map(comic => comic.id) })
+        );
+      });
     });
   });
 
   describe('deselecting all selected comic books', () => {
-    beforeEach(() => {
-      component.onDeselectAll();
+    describe('using a button', () => {
+      beforeEach(() => {
+        component.onDeselectAll();
+      });
+
+      it('fires an action', () => {
+        expect(store.dispatch).toHaveBeenCalledWith(clearSelectedComicBooks());
+      });
     });
 
-    it('fires an action', () => {
-      expect(store.dispatch).toHaveBeenCalledWith(clearSelectedComicBooks());
+    describe('using a hotkey', () => {
+      const event = new KeyboardEvent('hotkey');
+
+      beforeEach(() => {
+        spyOn(event, 'preventDefault');
+        component.onHotkeyDeselectAll(event);
+      });
+
+      it('prevents event propagation', () => {
+        expect(event.preventDefault).toHaveBeenCalled();
+      });
+
+      it('fires an action', () => {
+        expect(store.dispatch).toHaveBeenCalledWith(clearSelectedComicBooks());
+      });
     });
   });
 
@@ -578,17 +621,45 @@ describe('LibraryPageComponent', () => {
         (confirmation: Confirmation) => confirmation.confirm()
       );
       component.selectedIds = [COMIC_DETAIL_1.id];
-      component.onUpdateMetadata();
     });
 
-    it('confirms with the user', () => {
-      expect(confirmationService.confirm).toHaveBeenCalled();
+    describe('using a button', () => {
+      beforeEach(() => {
+        component.onUpdateMetadata();
+      });
+
+      it('confirms with the user', () => {
+        expect(confirmationService.confirm).toHaveBeenCalled();
+      });
+
+      it('fires an action', () => {
+        expect(store.dispatch).toHaveBeenCalledWith(
+          updateMetadata({ ids: [COMIC_DETAIL_1.id] })
+        );
+      });
     });
 
-    it('fires an action', () => {
-      expect(store.dispatch).toHaveBeenCalledWith(
-        updateMetadata({ ids: [COMIC_DETAIL_1.id] })
-      );
+    describe('using a button', () => {
+      const event = new KeyboardEvent('hotkey');
+
+      beforeEach(() => {
+        spyOn(event, 'preventDefault');
+        component.onHotkeyUpdateMetadata(event);
+      });
+
+      it('prevents event propagation', () => {
+        expect(event.preventDefault).toHaveBeenCalled();
+      });
+
+      it('confirms with the user', () => {
+        expect(confirmationService.confirm).toHaveBeenCalled();
+      });
+
+      it('fires an action', () => {
+        expect(store.dispatch).toHaveBeenCalledWith(
+          updateMetadata({ ids: [COMIC_DETAIL_1.id] })
+        );
+      });
     });
   });
 
@@ -598,17 +669,45 @@ describe('LibraryPageComponent', () => {
       spyOn(confirmationService, 'confirm').and.callFake(
         (confirmation: Confirmation) => confirmation.confirm()
       );
-      component.onPurgeLibrary();
     });
 
-    it('confirms with the user', () => {
-      expect(confirmationService.confirm).toHaveBeenCalled();
+    describe('using the button', () => {
+      beforeEach(() => {
+        component.onPurgeLibrary();
+      });
+
+      it('confirms with the user', () => {
+        expect(confirmationService.confirm).toHaveBeenCalled();
+      });
+
+      it('fires an action to purge the library', () => {
+        expect(store.dispatch).toHaveBeenCalledWith(
+          purgeLibrary({ ids: COMIC_BOOKS.map(comic => comic.id) })
+        );
+      });
     });
 
-    it('fires an action to purge the library', () => {
-      expect(store.dispatch).toHaveBeenCalledWith(
-        purgeLibrary({ ids: COMIC_BOOKS.map(comic => comic.id) })
-      );
+    describe('using a hotkey', () => {
+      const event = new KeyboardEvent('hotkey');
+
+      beforeEach(() => {
+        spyOn(event, 'preventDefault');
+        component.onHotKeyPurgeLibrary(event);
+      });
+
+      it('prevents event propagation', () => {
+        expect(event.preventDefault).toHaveBeenCalled();
+      });
+
+      it('confirms with the user', () => {
+        expect(confirmationService.confirm).toHaveBeenCalled();
+      });
+
+      it('fires an action to purge the library', () => {
+        expect(store.dispatch).toHaveBeenCalledWith(
+          purgeLibrary({ ids: COMIC_BOOKS.map(comic => comic.id) })
+        );
+      });
     });
   });
 
@@ -618,15 +717,41 @@ describe('LibraryPageComponent', () => {
         (confirmation: Confirmation) => confirmation.confirm()
       );
       component.selectedIds = IDS;
-      component.onScrapeComics();
     });
 
-    it('confirms with the user', () => {
-      expect(confirmationService.confirm).toHaveBeenCalled();
+    describe('using the button', () => {
+      beforeEach(() => {
+        component.onScrapeComics();
+      });
+
+      it('confirms with the user', () => {
+        expect(confirmationService.confirm).toHaveBeenCalled();
+      });
+
+      it('redirects the browsers to the scraping page', () => {
+        expect(router.navigate).toHaveBeenCalledWith(['/library', 'scrape']);
+      });
     });
 
-    it('redirects the browsers to the scraping page', () => {
-      expect(router.navigate).toHaveBeenCalledWith(['/library', 'scrape']);
+    describe('using a hotkey', () => {
+      const event = new KeyboardEvent('hotkey');
+
+      beforeEach(() => {
+        spyOn(event, 'preventDefault');
+        component.onHotKeyScrapeComics(event);
+      });
+
+      it('prevents event propagation', () => {
+        expect(event.preventDefault).toHaveBeenCalled();
+      });
+
+      it('confirms with the user', () => {
+        expect(confirmationService.confirm).toHaveBeenCalled();
+      });
+
+      it('redirects the browsers to the scraping page', () => {
+        expect(router.navigate).toHaveBeenCalledWith(['/library', 'scrape']);
+      });
     });
   });
 
@@ -637,17 +762,45 @@ describe('LibraryPageComponent', () => {
       );
       component.comicBooks = COMIC_BOOKS;
       component.selectedIds = IDS;
-      component.onRescanComics();
     });
 
-    it('confirms with the user', () => {
-      expect(confirmationService.confirm).toHaveBeenCalled();
+    describe('using the button', () => {
+      beforeEach(() => {
+        component.onRescanComics();
+      });
+
+      it('confirms with the user', () => {
+        expect(confirmationService.confirm).toHaveBeenCalled();
+      });
+
+      it('fires an action', () => {
+        expect(store.dispatch).toHaveBeenCalledWith(
+          rescanComics({ comicBooks: COMIC_BOOKS })
+        );
+      });
     });
 
-    it('fires an action', () => {
-      expect(store.dispatch).toHaveBeenCalledWith(
-        rescanComics({ comicBooks: COMIC_BOOKS })
-      );
+    describe('using a hotkey', () => {
+      const event = new KeyboardEvent('hotkey');
+
+      beforeEach(() => {
+        spyOn(event, 'preventDefault');
+        component.onHotKeyRescanComics(event);
+      });
+
+      it('prevents event propagation', () => {
+        expect(event.preventDefault).toHaveBeenCalled();
+      });
+
+      it('confirms with the user', () => {
+        expect(confirmationService.confirm).toHaveBeenCalled();
+      });
+
+      it('fires an action', () => {
+        expect(store.dispatch).toHaveBeenCalledWith(
+          rescanComics({ comicBooks: COMIC_BOOKS })
+        );
+      });
     });
   });
 
@@ -660,18 +813,43 @@ describe('LibraryPageComponent', () => {
     });
 
     describe('consolidating the entire library', () => {
-      beforeEach(() => {
-        component.onConsolidateEntireLibrary();
+      describe('using the button', () => {
+        beforeEach(() => {
+          component.onConsolidateEntireLibrary();
+        });
+
+        it('confirms with the user', () => {
+          expect(confirmationService.confirm).toHaveBeenCalled();
+        });
+
+        it('fires an action', () => {
+          expect(store.dispatch).toHaveBeenCalledWith(
+            startLibraryConsolidation({ ids: [] })
+          );
+        });
       });
 
-      it('confirms with the user', () => {
-        expect(confirmationService.confirm).toHaveBeenCalled();
-      });
+      describe('using a hotkey', () => {
+        const event = new KeyboardEvent('hotkey');
 
-      it('fires an action', () => {
-        expect(store.dispatch).toHaveBeenCalledWith(
-          startLibraryConsolidation({ ids: [] })
-        );
+        beforeEach(() => {
+          spyOn(event, 'preventDefault');
+          component.onHotkeyConsolidateEntireLibrary(event);
+        });
+
+        it('prevents event propagation', () => {
+          expect(event.preventDefault).toHaveBeenCalled();
+        });
+
+        it('confirms with the user', () => {
+          expect(confirmationService.confirm).toHaveBeenCalled();
+        });
+
+        it('fires an action', () => {
+          expect(store.dispatch).toHaveBeenCalledWith(
+            startLibraryConsolidation({ ids: [] })
+          );
+        });
       });
     });
 
@@ -696,22 +874,66 @@ describe('LibraryPageComponent', () => {
     describe('when off', () => {
       beforeEach(() => {
         component.unreadSwitch = false;
-        component.onToggleUnreadSwitch();
       });
 
-      it('turns it on', () => {
-        expect(component.unreadSwitch).toBeTrue();
+      describe('using the button', () => {
+        beforeEach(() => {
+          component.onToggleUnreadSwitch();
+        });
+
+        it('turns it on', () => {
+          expect(component.unreadSwitch).toBeTrue();
+        });
+      });
+
+      describe('using a hotkey', () => {
+        const event = new KeyboardEvent('hotkey');
+
+        beforeEach(() => {
+          spyOn(event, 'preventDefault');
+          component.onHotKeyToggleUnreadSwitch(event);
+        });
+
+        it('prevents event propagation', () => {
+          expect(event.preventDefault).toHaveBeenCalled();
+        });
+
+        it('turns it on', () => {
+          expect(component.unreadSwitch).toBeTrue();
+        });
       });
     });
 
     describe('when on', () => {
       beforeEach(() => {
         component.unreadSwitch = true;
-        component.onToggleUnreadSwitch();
       });
 
-      it('turns it off', () => {
-        expect(component.unreadSwitch).toBeFalse();
+      describe('using the button', () => {
+        beforeEach(() => {
+          component.onToggleUnreadSwitch();
+        });
+
+        it('turns it off', () => {
+          expect(component.unreadSwitch).toBeFalse();
+        });
+      });
+
+      describe('using a hotkey', () => {
+        const event = new KeyboardEvent('hotkey');
+
+        beforeEach(() => {
+          spyOn(event, 'preventDefault');
+          component.onHotKeyToggleUnreadSwitch(event);
+        });
+
+        it('prevents event propagation', () => {
+          expect(event.preventDefault).toHaveBeenCalled();
+        });
+
+        it('turns it off', () => {
+          expect(component.unreadSwitch).toBeFalse();
+        });
       });
     });
   });

--- a/comixed-webui/src/app/library/pages/library-page/library-page.component.ts
+++ b/comixed-webui/src/app/library/pages/library-page/library-page.component.ts
@@ -19,6 +19,7 @@
 import {
   AfterViewInit,
   Component,
+  HostListener,
   OnDestroy,
   OnInit,
   ViewChild
@@ -170,9 +171,9 @@ export class LibraryPageComponent implements OnInit, OnDestroy, AfterViewInit {
       .select(selectLibrarySelections)
       .subscribe(selectedIds => (this.selectedIds = selectedIds));
     this.userSubscription = this.store.select(selectUser).subscribe(user => {
-      this.logger.trace('Setting admin flag');
+      this.logger.debug('Setting admin flag');
       this.isAdmin = isAdmin(user);
-      this.logger.trace('Getting page size');
+      this.logger.debug('Getting page size');
       this.pageSize = getPageSize(user);
       this.showCovers =
         getUserPreference(
@@ -230,12 +231,12 @@ export class LibraryPageComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    this.logger.trace('Setting up pagination');
+    this.logger.debug('Setting up pagination');
     this.dataSource.paginator = this.paginator;
   }
 
   ngOnInit(): void {
-    this.logger.trace('Loading translations');
+    this.logger.debug('Loading translations');
     this.loadTranslations();
   }
 
@@ -247,6 +248,20 @@ export class LibraryPageComponent implements OnInit, OnDestroy, AfterViewInit {
     this.userSubscription.unsubscribe();
     this.langChangeSubscription.unsubscribe();
     this.readingListsSubscription.unsubscribe();
+  }
+
+  @HostListener('window:keydown.control.a', ['$event'])
+  onHotkeySelectAll(event: KeyboardEvent): void {
+    this.logger.debug('Select all hotkey pressed');
+    event.preventDefault();
+    this.onSelectAll();
+  }
+
+  @HostListener('window:keydown.shift.control.a', ['$event'])
+  onHotkeyDeselectAll(event: KeyboardEvent): void {
+    this.logger.debug('Deselect all hotkey pressed');
+    event.preventDefault();
+    this.onDeselectAll();
   }
 
   onSelectAll(): void {
@@ -263,8 +278,15 @@ export class LibraryPageComponent implements OnInit, OnDestroy, AfterViewInit {
     this.store.dispatch(clearSelectedComicBooks());
   }
 
+  @HostListener('window:keydown.shift.control.u', ['$event'])
+  onHotkeyUpdateMetadata(event: KeyboardEvent): void {
+    this.logger.debug('Update metadata hotkey pressed');
+    event.preventDefault();
+    this.onUpdateMetadata();
+  }
+
   onUpdateMetadata(): void {
-    this.logger.trace('Confirming with the user to update metadata');
+    this.logger.debug('Confirming with the user to update metadata');
     this.confirmationService.confirm({
       title: this.translateService.instant(
         'library.update-metadata.confirmation-title'
@@ -274,7 +296,7 @@ export class LibraryPageComponent implements OnInit, OnDestroy, AfterViewInit {
         { count: this.selectedIds.length }
       ),
       confirm: () => {
-        this.logger.trace('Firing action: update metadata');
+        this.logger.debug('Firing action: update metadata');
         this.store.dispatch(
           updateMetadata({
             ids: this.selectedIds
@@ -288,12 +310,26 @@ export class LibraryPageComponent implements OnInit, OnDestroy, AfterViewInit {
     this.doConsolidateLibrary(ids);
   }
 
+  @HostListener('window:keydown.shift.control.d', ['$event'])
+  onHotkeyConsolidateEntireLibrary(event: KeyboardEvent): void {
+    this.logger.debug('Consolidate library hotkey pressed');
+    event.preventDefault();
+    this.onConsolidateEntireLibrary();
+  }
+
   onConsolidateEntireLibrary(): void {
     this.doConsolidateLibrary([]);
   }
 
+  @HostListener('window:keydown.shift.control.p', ['$event'])
+  onHotKeyPurgeLibrary(event: KeyboardEvent): void {
+    this.logger.debug('Purge library otkey pressed');
+    event.preventDefault();
+    this.onPurgeLibrary();
+  }
+
   onPurgeLibrary(): void {
-    this.logger.trace('Confirming purging the library');
+    this.logger.debug('Confirming purging the library');
     this.confirmationService.confirm({
       title: this.translateService.instant(
         'library.purge-library.confirmation-title'
@@ -302,10 +338,17 @@ export class LibraryPageComponent implements OnInit, OnDestroy, AfterViewInit {
         'library.purge-library.confirmation-message'
       ),
       confirm: () => {
-        this.logger.trace('Firing action: purge library');
+        this.logger.debug('Firing action: purge library');
         this.store.dispatch(purgeLibrary({ ids: this.selectedIds }));
       }
     });
+  }
+
+  @HostListener('window:keydown.shift.control.s', ['$event'])
+  onHotKeyScrapeComics(event: KeyboardEvent): void {
+    this.logger.debug('Scrape comics hotkey pressed');
+    event.preventDefault();
+    this.onScrapeComics();
   }
 
   onScrapeComics(): void {
@@ -325,8 +368,15 @@ export class LibraryPageComponent implements OnInit, OnDestroy, AfterViewInit {
     });
   }
 
+  @HostListener('window:keydown.shift.control.r', ['$event'])
+  onHotKeyRescanComics(event: KeyboardEvent): void {
+    this.logger.debug('Rescan comics hotkey pressed');
+    event.preventDefault();
+    this.onRescanComics();
+  }
+
   onRescanComics(): void {
-    this.logger.trace('Confirming with the user to rescan the selected comics');
+    this.logger.debug('Confirming with the user to rescan the selected comics');
     this.confirmationService.confirm({
       title: this.translateService.instant(
         'library.rescan-comics.confirmation-title'
@@ -336,7 +386,7 @@ export class LibraryPageComponent implements OnInit, OnDestroy, AfterViewInit {
         { count: this.selectedIds.length }
       ),
       confirm: () => {
-        this.logger.trace('Firing action to rescan comics');
+        this.logger.debug('Firing action to rescan comics');
         this.store.dispatch(
           rescanComics({
             comicBooks: this.comicBooks.filter(comic =>
@@ -346,6 +396,13 @@ export class LibraryPageComponent implements OnInit, OnDestroy, AfterViewInit {
         );
       }
     });
+  }
+
+  @HostListener('window:keydown.control.e', ['$event'])
+  onHotKeyToggleUnreadSwitch(event: KeyboardEvent): void {
+    this.logger.debug('Toggle unread hotkey pressed');
+    event.preventDefault();
+    this.onToggleUnreadSwitch();
   }
 
   onToggleUnreadSwitch(): void {
@@ -364,7 +421,7 @@ export class LibraryPageComponent implements OnInit, OnDestroy, AfterViewInit {
         'library.consolidate.confirmation-message'
       ),
       confirm: () => {
-        this.logger.trace('Firing action: consolidate library');
+        this.logger.debug('Firing action: consolidate library');
         this.store.dispatch(startLibraryConsolidation({ ids }));
       }
     });
@@ -400,7 +457,7 @@ export class LibraryPageComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private loadTranslations(): void {
-    this.logger.trace('Setting page title');
+    this.logger.debug('Setting page title');
     if (this.unprocessedOnly) {
       this.titleService.setTitle(
         this.translateService.instant(

--- a/comixed-webui/src/assets/i18n/en/library.json
+++ b/comixed-webui/src/assets/i18n/en/library.json
@@ -191,15 +191,15 @@
       "effect-success": "Marked {count, plural, =1{one comic} other{# comics}} as {read, select, true{read} other{unread}}."
     },
     "tooltip": {
-      "consolidate-library": "Consolidate the library.",
-      "deselect-all": "Deselect all comics.",
-      "purge-library": "Remove deleted comics from library.",
-      "rescan-comics": "Rescan selected comics.",
-      "scrape-comics": "Start scraping comics",
-      "select-all": "Select all comics.",
-      "toggle-read-comics": "{enabled, select, true{Showing only unread comics.} other{Showing all comics.}}",
+      "consolidate-library": "Consolidate the library (shift+ctrl+d).",
+      "deselect-all": "Deselect all comics (shift+ctrl+a).",
+      "purge-library": "Remove deleted comics from library (shift+ctrl+p).",
+      "rescan-comics": "Rescan selected comics (shift+ctrl+r).",
+      "scrape-comics": "Start scraping comics (shift+ctrl+s).",
+      "select-all": "Select all comics (ctrl+a).",
+      "toggle-read-comics": "{enabled, select, true{Showing only unread comics} other{Showing all comics}} (ctrl+e).",
       "toggle-show-covers": "Toggle between cover and list views.",
-      "update-metadata": "Update metadata in selected comics."
+      "update-metadata": "Update metadata in selected comics (shift+ctrl+u)."
     },
     "update-metadata": {
       "confirmation-message": "Are you sure you want to update the metadata on {count, plural, =1{one comic} other{# comics}}?",


### PR DESCRIPTION
 * ctrl+a to select all comics.
 * shift+ctrl+a to deselect all comics.
 * shift+ctrl+u to update metadata on selected comics.
 * shift+ctrl+d to consolidate the entire library.
 * shift+ctrl+p to purge the library.
 * shift+ctrl+r to rescan the library.
 * ctrl+e to toggle read/unread comics.

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

