### PR TITLE
Added purging comics without a details record [#1737]

### DIFF
--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/processors/RemoveComicBooksWithoutDetailsProcessor.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/processors/RemoveComicBooksWithoutDetailsProcessor.java
@@ -1,0 +1,49 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2023, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.batch.comicbooks.processors;
+
+import lombok.extern.log4j.Log4j2;
+import org.comixedproject.model.comicbooks.ComicBook;
+import org.comixedproject.model.comicbooks.ComicDetail;
+import org.comixedproject.service.comicbooks.ComicBookService;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * <code>RemoveComicBooksWithoutDetailsProcessor</code> checks a {@link ComicBook} for its {@link
+ * ComicDetail} and, if not found, allows it to be marked for deletion.
+ *
+ * @author Darryl L. Pierce
+ */
+@Component
+@Log4j2
+public class RemoveComicBooksWithoutDetailsProcessor
+    implements ItemProcessor<ComicBook, ComicBook> {
+  @Autowired private ComicBookService comicBookService;
+
+  @Override
+  @Transactional
+  public ComicBook process(final ComicBook comicBook) {
+    log.debug("Deleting comic book: id={}", comicBook.getId());
+    this.comicBookService.deleteComic(comicBook);
+    return null;
+  }
+}

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/RemoveComicBooksWithoutDetailsReader.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/RemoveComicBooksWithoutDetailsReader.java
@@ -1,0 +1,45 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2023, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.batch.comicbooks.readers;
+
+import java.util.List;
+import lombok.extern.log4j.Log4j2;
+import org.comixedproject.model.comicbooks.ComicBook;
+import org.comixedproject.model.comicbooks.ComicDetail;
+import org.comixedproject.service.comicbooks.ComicBookService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * <code>RemoveComicBooksWithoutDetailsReader</code> returns comics that do not have a {@link
+ * ComicDetail} record but which are not already marked for deletion.
+ *
+ * @author Darryl L. Pierce
+ */
+@Component
+@Log4j2
+public class RemoveComicBooksWithoutDetailsReader extends AbstractComicReader {
+  @Autowired private ComicBookService comicBookService;
+
+  @Override
+  protected List<ComicBook> doLoadComics() {
+    log.debug("Loading comic books without details");
+    return this.comicBookService.getComicBooksWithoutDetails(this.getBatchChunkSize());
+  }
+}

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/processors/RemoveComicBooksWithoutDetailsProcessorTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/processors/RemoveComicBooksWithoutDetailsProcessorTest.java
@@ -1,0 +1,46 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2023, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.batch.comicbooks.processors;
+
+import static org.junit.Assert.*;
+
+import org.comixedproject.model.comicbooks.ComicBook;
+import org.comixedproject.service.comicbooks.ComicBookService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RemoveComicBooksWithoutDetailsProcessorTest {
+  @InjectMocks private RemoveComicBooksWithoutDetailsProcessor processor;
+  @Mock private ComicBookService comicBookService;
+  @Mock private ComicBook comicBook;
+
+  @Test
+  public void process() {
+    final ComicBook result = processor.process(comicBook);
+
+    assertNull(result);
+
+    Mockito.verify(comicBookService, Mockito.times(1)).deleteComic(comicBook);
+  }
+}

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/RemoveComicBooksWithoutDetailsReaderTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/RemoveComicBooksWithoutDetailsReaderTest.java
@@ -1,0 +1,96 @@
+/*
+ * ComiXed - A digital comic book library management application.
+ * Copyright (C) 2023, The ComiXed Project
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses>
+ */
+
+package org.comixedproject.batch.comicbooks.readers;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.assertSame;
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.comixedproject.model.comicbooks.ComicBook;
+import org.comixedproject.service.comicbooks.ComicBookService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RemoveComicBooksWithoutDetailsReaderTest {
+  private static final int MAX_RECORDS = 25;
+
+  @InjectMocks private RemoveComicBooksWithoutDetailsReader reader;
+  @Mock private ComicBookService comicBookService;
+  @Mock private ComicBook comicBook;
+
+  private final List<ComicBook> comicBookList = new ArrayList<>();
+
+  @Test
+  public void testReadNoneLoadedManyFound() {
+    for (int index = 0; index < MAX_RECORDS; index++) comicBookList.add(comicBook);
+
+    Mockito.when(comicBookService.getComicBooksWithoutDetails(Mockito.anyInt()))
+        .thenReturn(comicBookList);
+
+    final ComicBook result = reader.read();
+
+    assertNotNull(result);
+    assertSame(comicBook, result);
+    assertFalse(comicBookList.isEmpty());
+    assertEquals(MAX_RECORDS - 1, comicBookList.size());
+
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .getComicBooksWithoutDetails(reader.getBatchChunkSize());
+  }
+
+  @Test
+  public void testReadNoneRemaining() {
+    Mockito.when(comicBookService.getComicBooksWithoutDetails(Mockito.anyInt()))
+        .thenReturn(comicBookList);
+
+    reader.comicBookList = comicBookList;
+
+    final ComicBook result = reader.read();
+
+    assertNull(result);
+    assertNull(reader.comicBookList);
+
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .getComicBooksWithoutDetails(reader.getBatchChunkSize());
+  }
+
+  @Test
+  public void testReadNoneLoadedNoneFound() {
+    Mockito.when(comicBookService.getComicBooksWithoutDetails(Mockito.anyInt()))
+        .thenReturn(comicBookList);
+
+    final ComicBook result = reader.read();
+
+    assertNull(result);
+    assertNull(reader.comicBookList);
+
+    Mockito.verify(comicBookService, Mockito.times(1))
+        .getComicBooksWithoutDetails(reader.getBatchChunkSize());
+  }
+}

--- a/comixed-repositories/src/main/java/org/comixedproject/repositories/comicbooks/ComicBookRepository.java
+++ b/comixed-repositories/src/main/java/org/comixedproject/repositories/comicbooks/ComicBookRepository.java
@@ -595,4 +595,13 @@ public interface ComicBookRepository extends JpaRepository<ComicBook, Long> {
   @Query(
       "SELECT COUNT(c) FROM ComicBook c WHERE c.id NOT IN (SELECT s.comicBook.id FROM ComicMetadataSource s)")
   long getUnscrapedComicCount();
+
+  /**
+   * Returns a set of comic books without an associated comic detail record.
+   *
+   * @param batchChunkSize the batch chunk size
+   * @return the list of comic books
+   */
+  @Query("SELECT c FROM ComicBook c WHERE c.id NOT IN (SELECT d.comicBook.id FROM ComicDetail d)")
+  List<ComicBook> getComicBooksWithoutDetails(int batchChunkSize);
 }

--- a/comixed-services/src/main/java/org/comixedproject/service/comicbooks/ComicBookService.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/comicbooks/ComicBookService.java
@@ -836,4 +836,15 @@ public class ComicBookService implements InitializingBean, ComicStateChangeListe
     log.debug("Getting the count of unprocessed comics");
     return this.comicBookRepository.getUnscrapedComicCount();
   }
+
+  /**
+   * Returns a set of records without an associated {@link ComicDetail} record.
+   *
+   * @param batchChunkSize the batch chunk size
+   * @return the records
+   */
+  public List<ComicBook> getComicBooksWithoutDetails(final int batchChunkSize) {
+    log.debug("Loading ComicBook records without a ComicDetail: chunk size={}", batchChunkSize);
+    return this.comicBookRepository.getComicBooksWithoutDetails(batchChunkSize);
+  }
 }

--- a/comixed-services/src/test/java/org/comixedproject/service/comicbooks/ComicBookServiceTest.java
+++ b/comixed-services/src/test/java/org/comixedproject/service/comicbooks/ComicBookServiceTest.java
@@ -95,7 +95,17 @@ public class ComicBookServiceTest {
   private static final String TEST_STORY_NAME = "The Story Name";
   private static final long TEST_COMIC_COUNT = 239L;
   private static final String TEST_SEARCH_TERMS = "The search terms";
-
+  private static final int TEST_BATCH_CHUNK_SIZE = 25;
+  private final List<ComicBook> comicBookList = new ArrayList<>();
+  private final List<ComicDetail> comicDetailList = new ArrayList<>();
+  private final List<ComicBook> comicsBySeries = new ArrayList<>();
+  private final ComicBook previousComicBook = new ComicBook();
+  private final ComicBook currentComicBook = new ComicBook();
+  private final ComicBook nextComicBook = new ComicBook();
+  private final List<Long> idList = new ArrayList<>();
+  private final GregorianCalendar calendar = new GregorianCalendar();
+  private final Date now = new Date();
+  private final List<LastRead> lastReadList = new ArrayList<>();
   @InjectMocks private ComicBookService service;
   @Mock private ComicStateHandler comicStateHandler;
   @Mock private ComicBookRepository comicBookRepository;
@@ -118,20 +128,8 @@ public class ComicBookServiceTest {
   @Mock private List<PublisherAndYearSegment> byPublisherAndYearList;
   @Mock private List<Publisher> publisherWithSeriesCountList;
   @Mock private List<Series> publisherDetail;
-
   @Captor private ArgumentCaptor<Pageable> pageableCaptor;
   @Captor private ArgumentCaptor<PageRequest> pageRequestCaptor;
-
-  private final List<ComicBook> comicBookList = new ArrayList<>();
-  private final List<ComicDetail> comicDetailList = new ArrayList<>();
-  private final List<ComicBook> comicsBySeries = new ArrayList<>();
-  private final ComicBook previousComicBook = new ComicBook();
-  private final ComicBook currentComicBook = new ComicBook();
-  private final ComicBook nextComicBook = new ComicBook();
-  private final List<Long> idList = new ArrayList<>();
-  private final GregorianCalendar calendar = new GregorianCalendar();
-  private final Date now = new Date();
-  private final List<LastRead> lastReadList = new ArrayList<>();
 
   @Before
   public void setUp() throws ComiXedUserException {
@@ -1252,5 +1250,19 @@ public class ComicBookServiceTest {
     assertEquals(TEST_COMIC_COUNT, result);
 
     Mockito.verify(comicBookRepository, Mockito.times(1)).getUnscrapedComicCount();
+  }
+
+  @Test
+  public void testGetComicBooksWithoutDetails() {
+    Mockito.when(comicBookRepository.getComicBooksWithoutDetails(Mockito.anyInt()))
+        .thenReturn(comicBookList);
+
+    final List<ComicBook> result = service.getComicBooksWithoutDetails(TEST_BATCH_CHUNK_SIZE);
+
+    assertNotNull(result);
+    assertSame(comicBookList, result);
+
+    Mockito.verify(comicBookRepository, Mockito.times(1))
+        .getComicBooksWithoutDetails(TEST_BATCH_CHUNK_SIZE);
   }
 }


### PR DESCRIPTION
Added an initial step to the purge library batch process to look for and delete any comic book that does not have a comic detail record attached to it.

Closes #1737

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

