### PR TITLE
Added returning both read and unread counts [#1759]

### DIFF
--- a/comixed-model/src/main/java/org/comixedproject/model/net/comicbooks/LoadUnreadComicBookCountResponse.java
+++ b/comixed-model/src/main/java/org/comixedproject/model/net/comicbooks/LoadUnreadComicBookCountResponse.java
@@ -1,6 +1,6 @@
 /*
  * ComiXed - A digital comic book library management application.
- * Copyright (C) 2021, The ComiXed Project
+ * Copyright (C) 2023, The ComiXed Project
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,27 +16,25 @@
  * along with this program. If not, see <http://www.gnu.org/licenses>
  */
 
-import { createFeatureSelector, createSelector } from '@ngrx/store';
-import {
-  LAST_READ_LIST_FEATURE_KEY,
-  LastReadListState
-} from '../reducers/last-read-list.reducer';
+package org.comixedproject.model.net.comicbooks;
 
-export const selectLastReadListState = createFeatureSelector<LastReadListState>(
-  LAST_READ_LIST_FEATURE_KEY
-);
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
-export const selectComicBookLastReadEntries = createSelector(
-  selectLastReadListState,
-  state => state.entries
-);
+/**
+ * <code>LoadUnreadComicBookCountResponse</code> represents the payload when getting the library
+ * read state for a user.
+ *
+ * @author Darryl L. Pierce
+ */
+@AllArgsConstructor
+public class LoadUnreadComicBookCountResponse {
+  @JsonProperty("readCount")
+  @Getter
+  private long readCount;
 
-export const selectComicBookReadCount = createSelector(
-  selectLastReadListState,
-  state => state.readCount
-);
-
-export const selectComicBookUnreadCount = createSelector(
-  selectLastReadListState,
-  state => state.unreadCount
-);
+  @JsonProperty("unreadCount")
+  @Getter
+  private long unreadCount;
+}

--- a/comixed-model/src/main/resources/db/migrations/1.6/005_1759_add_unique_constraint_on_last_read_dates.xml
+++ b/comixed-model/src/main/resources/db/migrations/1.6/005_1759_add_unique_constraint_on_last_read_dates.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="005_1759_add_unique_constraint_on_last_read_dates.xml" author="mcpierce">
+
+        <sql>
+            DELETE
+            FROM LastReadDates
+            WHERE Id IN (SELECT b.Id
+                         FROM LastReadDates a
+                                  INNER JOIN LastReadDates b
+                                             ON a.ComicDetailId = b.ComicDetailId AND a.UserId = b.UserId
+                         WHERE a.Id > b.Id);
+        </sql>
+
+        <addUniqueConstraint constraintName="LastReadDateUniqueComicDetailAndUser" tableName="LastReadDates"
+                             columnNames="ComicDetailId,UserId"/>
+
+    </changeSet>
+</databaseChangeLog>

--- a/comixed-model/src/main/resources/db/migrations/1.6/changelog-1.6.xml
+++ b/comixed-model/src/main/resources/db/migrations/1.6/changelog-1.6.xml
@@ -11,5 +11,6 @@
   <include file="/db/migrations/1.6/003_1683_table_name_changes.xml"/>
   <include file="/db/migrations/1.6/004_1691_dropped_comic_file_details.xml"/>
   <include file="/db/migrations/1.6/005_1580_add_indices_to_support_comic_book_loading.xml"/>
+  <include file="/db/migrations/1.6/005_1759_add_unique_constraint_on_last_read_dates.xml"/>
 
 </databaseChangeLog>

--- a/comixed-rest/src/main/java/org/comixedproject/rest/library/LastReadController.java
+++ b/comixed-rest/src/main/java/org/comixedproject/rest/library/LastReadController.java
@@ -20,17 +20,16 @@ package org.comixedproject.rest.library;
 
 import static org.comixedproject.rest.comicbooks.ComicBookSelectionController.LIBRARY_SELECTIONS;
 
-import com.fasterxml.jackson.annotation.JsonView;
 import io.micrometer.core.annotation.Timed;
 import java.security.Principal;
 import java.util.List;
 import javax.servlet.http.HttpSession;
 import lombok.extern.log4j.Log4j2;
+import org.comixedproject.model.net.comicbooks.LoadUnreadComicBookCountResponse;
 import org.comixedproject.service.comicbooks.ComicBookSelectionException;
 import org.comixedproject.service.comicbooks.ComicBookSelectionService;
 import org.comixedproject.service.library.LastReadException;
 import org.comixedproject.service.library.LastReadService;
-import org.comixedproject.views.View;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -49,19 +48,21 @@ public class LastReadController {
   @Autowired private ComicBookSelectionService comicBookSelectionService;
 
   /**
-   * Loads the unread comic book count for a user.
+   * Loads the read and unread comic book count for a user.
    *
    * @param principal the user principal
-   * @return the unread comic book count
+   * @return the read and unread comic book counts
    * @throws LastReadException if an error occurs
    */
   @GetMapping(value = "/api/library/unread", produces = MediaType.APPLICATION_JSON_VALUE)
   @Timed(value = "comixed.last-read.get-all")
-  @JsonView(View.LastReadList.class)
-  public long getUnreadComicBookCount(final Principal principal) throws LastReadException {
+  public LoadUnreadComicBookCountResponse getUnreadComicBookCount(final Principal principal)
+      throws LastReadException {
     final String email = principal.getName();
     log.info("Loading unread comic book count for user: email={}", email);
-    return this.lastReadService.getUnreadCountForUser(email);
+    return new LoadUnreadComicBookCountResponse(
+        this.lastReadService.getReadCountForUser(email),
+        this.lastReadService.getUnreadCountForUser(email));
   }
 
   /**

--- a/comixed-services/src/main/java/org/comixedproject/service/library/LastReadService.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/library/LastReadService.java
@@ -151,7 +151,7 @@ public class LastReadService implements InitializingBean, ComicStateChangeListen
             .collect(Collectors.toSet());
     this.lastReadRepository.saveAll(
         ids.stream()
-            .filter(comicBookId -> existingIds.contains(comicBookId) == false)
+            .filter(comicBookId -> !existingIds.contains(comicBookId))
             .map(
                 comicBookId -> {
                   final ComicBook comicBook;
@@ -233,6 +233,11 @@ public class LastReadService implements InitializingBean, ComicStateChangeListen
     } catch (ComicBookException error) {
       throw new LastReadException("Failed to update comic book read state", error);
     }
+  }
+
+  public long getReadCountForUser(final String email) throws LastReadException {
+    log.debug("Getting the read comic book count for user: {}", email);
+    return this.lastReadRepository.loadCountForUser(this.doFindUser(email));
   }
 
   public long getUnreadCountForUser(final String email) throws LastReadException {

--- a/comixed-services/src/test/java/org/comixedproject/service/library/LastReadServiceTest.java
+++ b/comixed-services/src/test/java/org/comixedproject/service/library/LastReadServiceTest.java
@@ -291,6 +291,31 @@ public class LastReadServiceTest {
   }
 
   @Test(expected = LastReadException.class)
+  public void testLoadReadCountForUserInvalidUser() throws ComiXedUserException, LastReadException {
+    Mockito.when(userService.findByEmail(Mockito.anyString()))
+        .thenThrow(ComiXedUserException.class);
+
+    try {
+      service.getReadCountForUser(TEST_EMAIL);
+    } finally {
+      Mockito.verify(userService, Mockito.times(1)).findByEmail(TEST_EMAIL);
+    }
+  }
+
+  @Test
+  public void testLoadReadCountForUser() throws ComiXedUserException, LastReadException {
+    Mockito.when(lastReadRepository.loadCountForUser(Mockito.any(ComiXedUser.class)))
+        .thenReturn(TEST_READ_COUNT);
+
+    final long result = service.getReadCountForUser(TEST_EMAIL);
+
+    assertEquals(TEST_READ_COUNT, result);
+
+    Mockito.verify(userService, Mockito.times(1)).findByEmail(TEST_EMAIL);
+    Mockito.verify(lastReadRepository, Mockito.times(1)).loadCountForUser(user);
+  }
+
+  @Test(expected = LastReadException.class)
   public void testLoadUnreadCountForUserInvalidUser()
       throws ComiXedUserException, LastReadException {
     Mockito.when(userService.findByEmail(Mockito.anyString()))

--- a/comixed-webui/src/app/comic-books/actions/last-read-list.actions.ts
+++ b/comixed-webui/src/app/comic-books/actions/last-read-list.actions.ts
@@ -26,19 +26,13 @@ export const loadUnreadComicBookCount = createAction(
 export const loadUnreadComicBookCountSuccess = createAction(
   '[Last Read List] The last read count was loaded',
   props<{
+    readCount: number;
     unreadCount: number;
   }>()
 );
 
 export const loadUnreadComicBookCountFailure = createAction(
   '[Last Read List] Failed to load the last read count'
-);
-
-export const updateUnreadComicBookCount = createAction(
-  '[Last Read List] Updates the unread comic book count',
-  props<{
-    count: number;
-  }>()
 );
 
 export const setLastReadList = createAction(

--- a/comixed-webui/src/app/comic-books/effects/comic-books-read.effects.spec.ts
+++ b/comixed-webui/src/app/comic-books/effects/comic-books-read.effects.spec.ts
@@ -23,7 +23,10 @@ import { Observable, of, throwError } from 'rxjs';
 import { ComicBooksReadEffects } from './comic-books-read.effects';
 import { LastReadService } from '@app/comic-books/services/last-read.service';
 import { AlertService } from '@app/core/services/alert.service';
-import { COMIC_DETAIL_4 } from '@app/comic-books/comic-books.fixtures';
+import {
+  COMIC_DETAIL_4,
+  LAST_READ_2
+} from '@app/comic-books/comic-books.fixtures';
 import { LoggerModule } from '@angular-ru/cdk/logger';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
@@ -35,7 +38,7 @@ import {
 } from '@app/comic-books/actions/comic-books-read.actions';
 import { hot } from 'jasmine-marbles';
 import { HttpErrorResponse } from '@angular/common/http';
-import { LAST_READ_2 } from '@app/comic-books/comic-books.fixtures';
+import { loadUnreadComicBookCount } from '@app/comic-books/actions/last-read-list.actions';
 
 describe('ComicBooksReadEffects', () => {
   const COMIC = COMIC_DETAIL_4;
@@ -92,14 +95,15 @@ describe('ComicBooksReadEffects', () => {
         comicBookId: COMIC.comicId,
         read: READ
       });
-      const outcome = markSelectedComicBooksReadSuccess();
+      const outcome1 = markSelectedComicBooksReadSuccess();
+      const outcome2 = loadUnreadComicBookCount();
 
       actions$ = hot('-a', { a: action });
       lastReadService.setSingleReadState
         .withArgs({ comicBookId: COMIC.comicId, read: READ })
         .and.returnValue(of(serviceResponse));
 
-      const expected = hot('-b', { b: outcome });
+      const expected = hot('-(bc)', { b: outcome1, c: outcome2 });
       expect(effects.setSingleComicBookReadState$).toBeObservable(expected);
       expect(alertService.info).toHaveBeenCalledWith(jasmine.any(String));
     });
@@ -146,14 +150,15 @@ describe('ComicBooksReadEffects', () => {
       const action = markSelectedComicBooksRead({
         read: READ
       });
-      const outcome = markSelectedComicBooksReadSuccess();
+      const outcome1 = markSelectedComicBooksReadSuccess();
+      const outcome2 = loadUnreadComicBookCount();
 
       actions$ = hot('-a', { a: action });
       lastReadService.setSelectedReadState
         .withArgs({ read: READ })
         .and.returnValue(of(serviceResponse));
 
-      const expected = hot('-b', { b: outcome });
+      const expected = hot('-(bc)', { b: outcome1, c: outcome2 });
       expect(effects.setSelectedComicBooksReadState$).toBeObservable(expected);
       expect(alertService.info).toHaveBeenCalledWith(jasmine.any(String));
     });

--- a/comixed-webui/src/app/comic-books/effects/comic-books-read.effects.ts
+++ b/comixed-webui/src/app/comic-books/effects/comic-books-read.effects.ts
@@ -27,10 +27,10 @@ import {
   markSelectedComicBooksReadSuccess,
   markSingleComicBookRead
 } from '@app/comic-books/actions/comic-books-read.actions';
-import { catchError, map, switchMap, tap } from 'rxjs/operators';
+import { catchError, mergeMap, switchMap, tap } from 'rxjs/operators';
 import { AlertService } from '@app/core/services/alert.service';
 import { of } from 'rxjs';
-import { LastRead } from '@app/comic-books/models/last-read';
+import { loadUnreadComicBookCount } from '@app/comic-books/actions/last-read-list.actions';
 
 @Injectable()
 export class ComicBooksReadEffects {
@@ -59,7 +59,7 @@ export class ComicBooksReadEffects {
                 )
               )
             ),
-            map((response: LastRead) => markSelectedComicBooksReadSuccess()),
+            mergeMap(() => this.doSuccess()),
             catchError(error =>
               this.doServiceFailure(
                 error,
@@ -90,7 +90,7 @@ export class ComicBooksReadEffects {
               )
             )
           ),
-          map((response: LastRead) => markSelectedComicBooksReadSuccess()),
+          mergeMap(() => this.doSuccess()),
           catchError(error =>
             this.doServiceFailure(
               error,
@@ -126,5 +126,9 @@ export class ComicBooksReadEffects {
       this.translateService.instant('app.general-effect-failure')
     );
     return of(markSelectedComicBooksReadFailed());
+  }
+
+  private doSuccess() {
+    return [markSelectedComicBooksReadSuccess(), loadUnreadComicBookCount()];
   }
 }

--- a/comixed-webui/src/app/comic-books/effects/last-read-list.effects.spec.ts
+++ b/comixed-webui/src/app/comic-books/effects/last-read-list.effects.spec.ts
@@ -32,8 +32,10 @@ import {
 } from '@app/comic-books/actions/last-read-list.actions';
 import { hot } from 'jasmine-marbles';
 import { HttpErrorResponse } from '@angular/common/http';
+import { LoadUnreadComicBookCountResponse } from '@app/comic-books/models/net/load-unread-comic-book-count-response';
 
 describe('LastReadListEffects', () => {
+  const READ_COUNT = 129;
   const UNREAD_COUNT = 717;
 
   let actions$: Observable<any>;
@@ -77,9 +79,13 @@ describe('LastReadListEffects', () => {
 
   describe('loading the unread comic book count', () => {
     it('fires an action on success', () => {
-      const serviceResponse = UNREAD_COUNT;
+      const serviceResponse = {
+        readCount: READ_COUNT,
+        unreadCount: UNREAD_COUNT
+      } as LoadUnreadComicBookCountResponse;
       const action = loadUnreadComicBookCount();
       const outcome = loadUnreadComicBookCountSuccess({
+        readCount: READ_COUNT,
         unreadCount: UNREAD_COUNT
       });
 

--- a/comixed-webui/src/app/comic-books/effects/last-read-list.effects.ts
+++ b/comixed-webui/src/app/comic-books/effects/last-read-list.effects.ts
@@ -29,6 +29,7 @@ import {
 } from '@app/comic-books/actions/last-read-list.actions';
 import { catchError, map, switchMap, tap } from 'rxjs/operators';
 import { of } from 'rxjs';
+import { LoadUnreadComicBookCountResponse } from '@app/comic-books/models/net/load-unread-comic-book-count-response';
 
 @Injectable()
 export class LastReadListEffects {
@@ -39,9 +40,10 @@ export class LastReadListEffects {
       switchMap(action =>
         this.lastReadService.loadUnreadComicBookCount().pipe(
           tap(response => this.logger.debug('Response received:', response)),
-          map((response: number) =>
+          map((response: LoadUnreadComicBookCountResponse) =>
             loadUnreadComicBookCountSuccess({
-              unreadCount: response
+              readCount: response.readCount,
+              unreadCount: response.unreadCount
             })
           ),
           catchError(error => {

--- a/comixed-webui/src/app/comic-books/models/net/load-unread-comic-book-count-response.ts
+++ b/comixed-webui/src/app/comic-books/models/net/load-unread-comic-book-count-response.ts
@@ -1,6 +1,6 @@
 /*
  * ComiXed - A digital comic book library management application.
- * Copyright (C) 2021, The ComiXed Project
+ * Copyright (C) 2023, The ComiXed Project
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,27 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses>
  */
 
-import { createFeatureSelector, createSelector } from '@ngrx/store';
-import {
-  LAST_READ_LIST_FEATURE_KEY,
-  LastReadListState
-} from '../reducers/last-read-list.reducer';
-
-export const selectLastReadListState = createFeatureSelector<LastReadListState>(
-  LAST_READ_LIST_FEATURE_KEY
-);
-
-export const selectComicBookLastReadEntries = createSelector(
-  selectLastReadListState,
-  state => state.entries
-);
-
-export const selectComicBookReadCount = createSelector(
-  selectLastReadListState,
-  state => state.readCount
-);
-
-export const selectComicBookUnreadCount = createSelector(
-  selectLastReadListState,
-  state => state.unreadCount
-);
+export interface LoadUnreadComicBookCountResponse {
+  readCount: number;
+  unreadCount: number;
+}

--- a/comixed-webui/src/app/comic-books/pages/comic-book-page/comic-book-page.component.ts
+++ b/comixed-webui/src/app/comic-books/pages/comic-book-page/comic-book-page.component.ts
@@ -56,7 +56,7 @@ import {
   selectComicBook,
   selectComicBookBusy
 } from '@app/comic-books/selectors/comic-book.selectors';
-import { selectLastReadEntries } from '@app/comic-books/selectors/last-read-list.selectors';
+import { selectComicBookLastReadEntries } from '@app/comic-books/selectors/last-read-list.selectors';
 import { LastRead } from '@app/comic-books/models/last-read';
 import { TitleService } from '@app/core/services/title.service';
 import { MessagingSubscription, WebSocketService } from '@app/messaging';
@@ -180,7 +180,7 @@ export class ComicBookPageComponent
       .select(selectVolumeMetadata)
       .subscribe(volumes => (this.volumes = volumes));
     this.lastReadSubscription = this.store
-      .select(selectLastReadEntries)
+      .select(selectComicBookLastReadEntries)
       .subscribe(entries => {
         this.isRead = entries
           .map(entry => entry.comicDetail.comicId)

--- a/comixed-webui/src/app/comic-books/reducers/last-read-list.reducer.spec.ts
+++ b/comixed-webui/src/app/comic-books/reducers/last-read-list.reducer.spec.ts
@@ -39,6 +39,7 @@ import {
 
 describe('LastReadList Reducer', () => {
   const UNREAD_COUNT = 416;
+  const READ_COUNT = 320;
   const ENTRIES = [LAST_READ_1, LAST_READ_3, LAST_READ_5];
 
   let state: LastReadListState;
@@ -56,6 +57,10 @@ describe('LastReadList Reducer', () => {
       expect(state.busy).toBeFalse();
     });
 
+    it('has an read count of 0', () => {
+      expect(state.readCount).toEqual(0);
+    });
+
     it('has an unread count of 0', () => {
       expect(state.unreadCount).toEqual(0);
     });
@@ -68,6 +73,10 @@ describe('LastReadList Reducer', () => {
   describe('resetting the feature state', () => {
     beforeEach(() => {
       state = reducer({ ...state, entries: ENTRIES }, resetLastReadList());
+    });
+
+    it('resets the read count', () => {
+      expect(state.readCount).toEqual(0);
     });
 
     it('resets the unread count', () => {
@@ -91,13 +100,20 @@ describe('LastReadList Reducer', () => {
     describe('success', () => {
       beforeEach(() => {
         state = reducer(
-          { ...state, busy: true },
-          loadUnreadComicBookCountSuccess({ unreadCount: UNREAD_COUNT })
+          { ...state, busy: true, readCount: 0, unreadCount: 0 },
+          loadUnreadComicBookCountSuccess({
+            readCount: READ_COUNT,
+            unreadCount: UNREAD_COUNT
+          })
         );
       });
 
       it('clears the busy flag', () => {
         expect(state.busy).toBeFalse();
+      });
+
+      it('sets the read count', () => {
+        expect(state.readCount).toEqual(READ_COUNT);
       });
 
       it('sets the unread count', () => {

--- a/comixed-webui/src/app/comic-books/reducers/last-read-list.reducer.ts
+++ b/comixed-webui/src/app/comic-books/reducers/last-read-list.reducer.ts
@@ -32,12 +32,14 @@ export const LAST_READ_LIST_FEATURE_KEY = 'last_read_list_state';
 
 export interface LastReadListState {
   busy: boolean;
+  readCount: number;
   unreadCount: number;
   entries: LastRead[];
 }
 
 export const initialState: LastReadListState = {
   busy: false,
+  readCount: 0,
   unreadCount: 0,
   entries: []
 };
@@ -49,6 +51,7 @@ export const reducer = createReducer(
   on(loadUnreadComicBookCountSuccess, (state, action) => ({
     ...state,
     busy: false,
+    readCount: action.readCount,
     unreadCount: action.unreadCount
   })),
   on(loadUnreadComicBookCountFailure, state => ({ ...state, busy: false })),

--- a/comixed-webui/src/app/comic-books/selectors/last-read-list.selectors.spec.ts
+++ b/comixed-webui/src/app/comic-books/selectors/last-read-list.selectors.spec.ts
@@ -21,9 +21,10 @@ import {
   LastReadListState
 } from '../reducers/last-read-list.reducer';
 import {
-  selectLastReadEntries,
-  selectLastReadListState,
-  selectLastUnreadCount
+  selectComicBookLastReadEntries,
+  selectComicBookReadCount,
+  selectComicBookUnreadCount,
+  selectLastReadListState
 } from './last-read-list.selectors';
 import {
   LAST_READ_1,
@@ -33,13 +34,16 @@ import {
 
 describe('LastReadDates Selectors', () => {
   const ENTRIES = [LAST_READ_1, LAST_READ_3, LAST_READ_5];
+  const READ_COUNT = Math.floor(Math.random() * 30000);
+  const UNREAD_COUNT = Math.floor(Math.random() * 30000);
 
   let state: LastReadListState;
 
   beforeEach(() => {
     state = {
       busy: Math.random() > 0.5,
-      unreadCount: Math.floor(Math.random() * 30000),
+      readCount: READ_COUNT,
+      unreadCount: UNREAD_COUNT,
       entries: ENTRIES
     };
   });
@@ -54,15 +58,23 @@ describe('LastReadDates Selectors', () => {
 
   it('should select the last read entries', () => {
     expect(
-      selectLastReadEntries({
+      selectComicBookLastReadEntries({
         [LAST_READ_LIST_FEATURE_KEY]: state
       })
     ).toEqual(state.entries);
   });
 
+  it('should select the read count', () => {
+    expect(
+      selectComicBookReadCount({
+        [LAST_READ_LIST_FEATURE_KEY]: state
+      })
+    ).toEqual(state.readCount);
+  });
+
   it('should select the unread count', () => {
     expect(
-      selectLastUnreadCount({
+      selectComicBookUnreadCount({
         [LAST_READ_LIST_FEATURE_KEY]: state
       })
     ).toEqual(state.unreadCount);

--- a/comixed-webui/src/app/comic-books/services/last-read.service.spec.ts
+++ b/comixed-webui/src/app/comic-books/services/last-read.service.spec.ts
@@ -21,10 +21,7 @@ import { TestBed } from '@angular/core/testing';
 import { LastReadService } from './last-read.service';
 import {
   COMIC_DETAIL_4,
-  LAST_READ_1,
-  LAST_READ_3,
-  LAST_READ_4,
-  LAST_READ_5
+  LAST_READ_4
 } from '@app/comic-books/comic-books.fixtures';
 import {
   HttpClientTestingModule,
@@ -55,12 +52,12 @@ import {
   LAST_READ_LIST_FEATURE_KEY
 } from '@app/comic-books/reducers/last-read-list.reducer';
 import { HttpResponse } from '@angular/common/http';
+import { LoadUnreadComicBookCountResponse } from '@app/comic-books/models/net/load-unread-comic-book-count-response';
 
 describe('LastReadService', () => {
-  const ENTRIES = [LAST_READ_1, LAST_READ_3, LAST_READ_5];
-  const LAST_PAYLOAD = Math.random() > 0.5;
-  const LAST_ID = 23;
   const COMIC = COMIC_DETAIL_4;
+  const READ_COUNT = Math.floor(Math.random() * 30000);
+  const UNREAD_COUNT = Math.floor(Math.random() * 30000);
   const initialState = {
     [MESSAGING_FEATURE_KEY]: initialMessagingState,
     [LAST_READ_LIST_FEATURE_KEY]: initialLastReadListState
@@ -99,7 +96,10 @@ describe('LastReadService', () => {
   });
 
   it('loads the unread comic book count', () => {
-    const serverResponse = Math.floor(Math.random() * 30000);
+    const serverResponse = {
+      readCount: READ_COUNT,
+      unreadCount: UNREAD_COUNT
+    } as LoadUnreadComicBookCountResponse;
 
     service
       .loadUnreadComicBookCount()

--- a/comixed-webui/src/app/components/footer/footer.component.ts
+++ b/comixed-webui/src/app/components/footer/footer.component.ts
@@ -20,7 +20,7 @@ import { Component, Input } from '@angular/core';
 import { LoggerModule } from '@angular-ru/cdk/logger';
 import { Store } from '@ngrx/store';
 import { User } from '@app/user/models/user';
-import { selectLastReadEntries } from '@app/comic-books/selectors/last-read-list.selectors';
+import { selectComicBookReadCount } from '@app/comic-books/selectors/last-read-list.selectors';
 import { selectLibraryState } from '@app/library/selectors/library.selectors';
 import { selectComicBookSelectionState } from '@app/comic-books/selectors/comic-book-selection.selectors';
 
@@ -45,8 +45,8 @@ export class FooterComponent {
       this.deletedCount = state.deletedComics;
     });
     this.store
-      .select(selectLastReadEntries)
-      .subscribe(entries => (this.readCount = entries.length));
+      .select(selectComicBookReadCount)
+      .subscribe(readCount => (this.readCount = readCount));
     this.store
       .select(selectComicBookSelectionState)
       .subscribe(state => (this.selectedCount = state.ids.length));

--- a/comixed-webui/src/app/components/side-navigation/side-navigation.component.ts
+++ b/comixed-webui/src/app/components/side-navigation/side-navigation.component.ts
@@ -24,7 +24,7 @@ import { BehaviorSubject, Subscription } from 'rxjs';
 import { Store } from '@ngrx/store';
 import { selectUserReadingLists } from '@app/lists/selectors/reading-lists.selectors';
 import { ReadingList } from '@app/lists/models/reading-list';
-import { selectLastUnreadCount } from '@app/comic-books/selectors/last-read-list.selectors';
+import { selectComicBookUnreadCount } from '@app/comic-books/selectors/last-read-list.selectors';
 import { selectLibraryState } from '@app/library/selectors/library.selectors';
 import { ComicState } from '@app/comic-books/models/comic-state';
 import { LibraryState } from '@app/library/reducers/library.reducer';
@@ -68,7 +68,7 @@ export class SideNavigationComponent implements OnDestroy {
         this.deletedComicBooks$.next(state.deletedComics);
       });
     this.lastReadUnreadCountSubscription = this.store
-      .select(selectLastUnreadCount)
+      .select(selectComicBookUnreadCount)
       .subscribe(count => this.unreadComicBooks$.next(count));
     this.readingListsSubscription = this.store
       .select(selectUserReadingLists)

--- a/comixed-webui/src/app/library/pages/library-page/library-page.component.ts
+++ b/comixed-webui/src/app/library/pages/library-page/library-page.component.ts
@@ -32,7 +32,7 @@ import {
 import { ActivatedRoute } from '@angular/router';
 import { SHOW_COMIC_COVERS_PREFERENCE } from '@app/library/library.constants';
 import { LastRead } from '@app/comic-books/models/last-read';
-import { selectLastReadEntries } from '@app/comic-books/selectors/last-read-list.selectors';
+import { selectComicBookLastReadEntries } from '@app/comic-books/selectors/last-read-list.selectors';
 import { ReadingList } from '@app/lists/models/reading-list';
 import { selectUserReadingLists } from '@app/lists/selectors/reading-lists.selectors';
 import { PAGE_SIZE_DEFAULT } from '@app/core';
@@ -179,7 +179,7 @@ export class LibraryPageComponent implements OnInit, OnDestroy {
         ) === `${true}`;
     });
     this.lastReadDatesSubscription = this.store
-      .select(selectLastReadEntries)
+      .select(selectComicBookLastReadEntries)
       .subscribe(lastReadDates => {
         this.lastReadDates = lastReadDates;
       });

--- a/comixed-webui/src/app/lists/pages/reading-list-detail-page/reading-list-detail-page.component.ts
+++ b/comixed-webui/src/app/lists/pages/reading-list-detail-page/reading-list-detail-page.component.ts
@@ -59,7 +59,7 @@ import { ComicDetail } from '@app/comic-books/models/comic-detail';
 import { MatTableDataSource } from '@angular/material/table';
 import { SelectableListItem } from '@app/core/models/ui/selectable-list-item';
 import { LastRead } from '@app/comic-books/models/last-read';
-import { selectLastReadEntries } from '@app/comic-books/selectors/last-read-list.selectors';
+import { selectComicBookLastReadEntries } from '@app/comic-books/selectors/last-read-list.selectors';
 import { selectComicBookSelectionIds } from '@app/comic-books/selectors/comic-book-selection.selectors';
 import { setMultipleComicBookByIdSelectionState } from '@app/comic-books/actions/comic-book-selection.actions';
 
@@ -143,7 +143,7 @@ export class ReadingListDetailPageComponent implements OnDestroy {
         this.selectedIds = selections;
       });
     this.lastReadDataSubscription = this.store
-      .select(selectLastReadEntries)
+      .select(selectComicBookLastReadEntries)
       .subscribe(lastReadDates => (this.lastReadDates = lastReadDates));
     this.messagingSubscription = this.store
       .select(selectMessagingState)


### PR DESCRIPTION
Also added a unique constraint to the last read table to prevent multiple records for a single comic for a user.

## Status
READY

## Does this PR contain migrations?
YES

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

