### PR TITLE
Added normalizing filenames and directories [#1659]

### DIFF
--- a/comixed-adaptors/src/main/java/org/comixedproject/adaptors/comicbooks/ComicFileAdaptor.java
+++ b/comixed-adaptors/src/main/java/org/comixedproject/adaptors/comicbooks/ComicFileAdaptor.java
@@ -43,7 +43,7 @@ import org.springframework.util.StringUtils;
 @Log4j2
 public class ComicFileAdaptor {
   private static final String FORBIDDEN_RULE_CHARACTERS = "[\"':\\\\*?|<>]";
-  private static final String FORBIDDEN_PROPERTY_CHARACTERS = "[\"':\\\\/*?|<>]";
+  private static final String FORBIDDEN_PROPERTY_CHARACTERS = "[\"':\\\\/*?|<>{}:%]";
   static final String UNKNOWN_VALUE = "Unknown";
   public static final String NO_COVER_DATE = "No Cover Date";
   public static final String PLACEHOLDER_PUBLISHER = "$PUBLISHER";
@@ -178,10 +178,27 @@ public class ComicFileAdaptor {
             .replace(PLACEHOLDER_COVER_DATE, coverDate)
             .replace(PLACEHOLDER_PUBLISHED_YEAR, publishedYear)
             .replace(PLACEHOLDER_PUBLISHED_MONTH, publishedMonth);
+    final String directory = FilenameUtils.getPath(result);
+    final String filename = FilenameUtils.getName(result);
 
-    result = String.format("%s/%s", targetDirectory, result);
+    result =
+        FilenameUtils.normalize(
+            String.format(
+                "%s%s%s%s%s",
+                targetDirectory,
+                File.separator,
+                directory,
+                File.separator,
+                sanitizeFilename(filename)));
     log.trace("Relative comicBook filename: {}", result);
     return result;
+  }
+
+  private String sanitizeFilename(final String filename) {
+    return filename
+        .trim()
+        .replaceAll("[\\.|\\/|\\\\|\\*|\\:|\\||\"|\'|\\<|\\>|\\{|\\}|\\?|\\%|,]", "_")
+        .replaceAll("\\s+", " ");
   }
 
   private String checkForPadding(final String rule, final String placeholder, final String value) {

--- a/comixed-adaptors/src/test/java/org/comixedproject/adaptors/comicbooks/ComicFileAdaptorTest.java
+++ b/comixed-adaptors/src/test/java/org/comixedproject/adaptors/comicbooks/ComicFileAdaptorTest.java
@@ -67,10 +67,12 @@ public class ComicFileAdaptorTest {
   private static final Date TEST_STORE_DATE = new Date(120, 5, 1);
   private static final String TEST_PUBLISHED_MONTH = "5";
   private static final String TEST_PUBLISHED_YEAR = "2020";
-  private static final String TEST_PUBLISHER_WITH_UNSUPPORTED_CHARACTERS = "\"?Publisher*'";
-  private static final String TEST_PUBLISHER_WITH_UNSUPPORTED_CHARACTERS_SCRUBBED = "__Publisher__";
-  private static final String TEST_SERIES_WITH_UNSUPPORTED_CHARACTERS = "<|Series?>";
-  private static final String TEST_SERIES_WITH_UNSUPPORTED_CHARACTERS_SCRUBBED = "__Series__";
+  private static final String TEST_PUBLISHER_WITH_UNSUPPORTED_CHARACTERS =
+      "\"?/\\:|'{}?%Publisher*'";
+  private static final String TEST_PUBLISHER_WITH_UNSUPPORTED_CHARACTERS_SCRUBBED =
+      "___________Publisher__";
+  private static final String TEST_SERIES_WITH_UNSUPPORTED_CHARACTERS = "<|{:}Series?>";
+  private static final String TEST_SERIES_WITH_UNSUPPORTED_CHARACTERS_SCRUBBED = "_____Series__";
   private static final String TEST_ISSUE_WITH_UNSUPPORTED_CHARACTERS = "\\/717:";
   private static final String TEST_ISSUE_WITH_UNSUPPORTED_CHARACTERS_SCRUBBED = "__717_";
   private static final String TEST_RENAMING_RULE_WITH_UNSUPPORTED_CHARACTERS =


### PR DESCRIPTION
 * Normalize the filename when moving comics during consoliation.
 * Added normalizing the import root directory when being saved.
 * Added additionally stripped characters to allowed comic filenames.

Closes #1659 

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

