### PR TITLE
Fixed slashes in file tests when developing on Windows machines

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,3 +12,4 @@ what it is today.
  * Arturo Pérez <theotocopulitos@gmail.com>
  * J Fine <jfine@jfine.com>
  * Natalie Stroud @natastro
+ * Heather Anderson <heath@odysseus.anderson.name>

--- a/comixed-adaptors/src/test/java/org/comixedproject/adaptors/comicbooks/ComicFileAdaptorTest.java
+++ b/comixed-adaptors/src/test/java/org/comixedproject/adaptors/comicbooks/ComicFileAdaptorTest.java
@@ -79,7 +79,8 @@ public class ComicFileAdaptorTest {
       "?*$PUBLISHER/<|?>$SERIES/\\:$VOLUME/$SERIES v$VOLUME #$ISSUE ($COVERDATE) $IMPRINT";
   private static final String TEST_ORIGINAL_FILENAME = "src/test/resources/available.cbz";
   private static final String TEST_EXISTING_FILENAME = "src/test/resources/example.cbz";
-  private static final String TEST_TARGET_DIRECTORY = "target/test-classes/library";
+  private static final String TEST_TARGET_DIRECTORY =
+      String.join(File.separator, new String[] {"target", "test-classes", "library"});
 
   @InjectMocks private ComicFileAdaptor adaptor;
   @Mock private ComicBook comicBook;
@@ -155,7 +156,9 @@ public class ComicFileAdaptorTest {
 
     assertEquals(
         String.format(
-            "%s/__%s/____%s/__%s/%s v%s #%s (%s) %s",
+            String.join(
+                File.separator,
+                new String[] {"%s", "__%s", "____%s", "__%s", "%s v%s #%s (%s) %s"}),
             TEST_TARGET_DIRECTORY,
             TEST_PUBLISHER,
             TEST_SERIES,
@@ -337,7 +340,8 @@ public class ComicFileAdaptorTest {
       final String publishedMonth,
       final String publishedYear) {
     return String.format(
-        "%s/%s/%s/%s/%s v%s #%s %s %s %s %s %s",
+        String.join(
+            File.separator, new String[] {"%s", "%s", "%s", "%s", "%s v%s #%s %s %s %s %s %s"}),
         targetDirectory,
         publisher,
         series,


### PR DESCRIPTION
The tests have been assuming the results would contain forward slashes, however on Windows machines they were universally failing with backslashes. This uses String.join(File.separator) on the failing tests to (hopefully) make the code more platform-independent.

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [X] Have you announced your PR on the comixed-dev mailing list?
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

