### PR TITLE
Fixed Spring Boot dependency for compatibility with JDK 21

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,3 +12,4 @@ what it is today.
  * Arturo Pérez <theotocopulitos@gmail.com>
  * J Fine <jfine@jfine.com>
  * Natalie Stroud @natastro
+ * Heather Anderson <heath@odysseus.anderson.name>

--- a/comixed-metadata-comicvine/pom.xml
+++ b/comixed-metadata-comicvine/pom.xml
@@ -16,14 +16,14 @@
     <properties>
         <spring-plugin.version>2.0.0.RELEASE</spring-plugin.version>
         <java.version>17</java.version>
-        <lombok.version>1.18.22</lombok.version>
+        <lombok.version>1.18.30</lombok.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>1.18.30</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Attempting to compile this under JDK 21 resulted in the following error: Class com.sun.tools.javac.tree.JCTree$JCImport does not have member field 'com.sun.tools.javac.tree.JCTree qualid'

This error is in the Lombok library and was resolved in v1.18.30: https://github.com/projectlombok/lombok/issues/3393

This project uses the latest version of Lombok which is compatible with JDK 21, however it also uses Spring Boot which has its own dependency which is to a specific version of JDK.

This patch updates the version of Lombok specified to be the minimum version supported by JDK 21.  The result compiles, but I have not done significant testing of the result (yet) to ensure there are no latent issues.

Related Stack Overflow discussion:
https://stackoverflow.com/questions/77171270/compilation-error-after-upgrading-to-jdk-21-nosuchfielderror-jcimport-does-n

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

