### PR TITLE
Added using publisher in place of imprint for renaming [#1856]

### DIFF
--- a/comixed-adaptors/src/test/java/org/comixedproject/adaptors/comicbooks/ComicFileAdaptorTest.java
+++ b/comixed-adaptors/src/test/java/org/comixedproject/adaptors/comicbooks/ComicFileAdaptorTest.java
@@ -247,6 +247,29 @@ public class ComicFileAdaptorTest {
         formattedName(
             TEST_TARGET_DIRECTORY,
             TEST_PUBLISHER,
+            TEST_PUBLISHER,
+            TEST_SERIES,
+            TEST_VOLUME,
+            TEST_ISSUE,
+            TEST_TITLE,
+            TEST_FORMATTED_COVER_DATE,
+            TEST_PUBLISHED_MONTH,
+            TEST_PUBLISHED_YEAR),
+        result);
+  }
+
+  @Test
+  public void testCreateFileFromRuleNoImprintOrPublisher() {
+    Mockito.when(comicDetail.getPublisher()).thenReturn(null);
+    Mockito.when(comicDetail.getImprint()).thenReturn(null);
+
+    final String result =
+        adaptor.createFilenameFromRule(comicBook, TEST_RENAMING_RULE, TEST_TARGET_DIRECTORY);
+
+    assertEquals(
+        formattedName(
+            TEST_TARGET_DIRECTORY,
+            UNKNOWN_VALUE,
             UNKNOWN_VALUE,
             TEST_SERIES,
             TEST_VOLUME,


### PR DESCRIPTION
When the imprint is not defined but the publisher is, then the publisher is used when applying the renaming rules.

Closes #1856 

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

