### PR TITLE
Added using the extension to find the archive adaptor [#437]

### DIFF
--- a/comixed-adaptors/src/main/resources/comixed-adaptors.properties
+++ b/comixed-adaptors/src/main/resources/comixed-adaptors.properties
@@ -2,12 +2,15 @@
 file-type.archiveAdaptors[0].format=zip
 file-type.archiveAdaptors[0].name=cbzArchiveAdaptor
 file-type.archiveAdaptors[0].archiveType=CBZ
+file-type.archiveAdaptors[0].extension=cbz
 file-type.archiveAdaptors[1].format=x-7z-compressed
 file-type.archiveAdaptors[1].name=cb7ArchiveAdaptor
 file-type.archiveAdaptors[1].archiveType=CB7
+file-type.archiveAdaptors[1].extension=cb7
 file-type.archiveAdaptors[2].format=x-rar-compressed
 file-type.archiveAdaptors[2].name=cbrArchiveAdaptor
 file-type.archiveAdaptors[2].archiveType=CBR
+file-type.archiveAdaptors[2].extension=cbr
 
 # ComicBook entry loaders
 file-type.entryTypeLoaders[0].type=xml


### PR DESCRIPTION
If the archive type cannot be determined by the content of the file, then the fallback is to use the extension.

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

