### PR TITLE
Added a unique constraint to comic metadata sources [#1911]

### DIFF
--- a/comixed-model/src/main/java/org/comixedproject/model/comicbooks/ComicMetadataSource.java
+++ b/comixed-model/src/main/java/org/comixedproject/model/comicbooks/ComicMetadataSource.java
@@ -43,7 +43,7 @@ public class ComicMetadataSource {
   private Long id;
 
   @OneToOne
-  @JoinColumn(name = "comic_book_id", nullable = false, updatable = false)
+  @JoinColumn(name = "comic_book_id", nullable = false, updatable = false, unique = true)
   @Getter
   @NonNull
   private ComicBook comicBook;

--- a/comixed-model/src/main/resources/db/migrations/2.0/007_1911_one_metadata_source_per_comic_book.xml
+++ b/comixed-model/src/main/resources/db/migrations/2.0/007_1911_one_metadata_source_per_comic_book.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+  <changeSet id="007_1911_one_metadata_source_per_comic_book.xml" author="mcpierce">
+
+    <sql>
+      DELETE
+      FROM comic_metadata_sources
+      WHERE comic_book_id IN (SELECT comic_book_id
+                              FROM (SELECT comic_book_id, count(*) AS counter
+                                    FROM comic_metadata_sources
+                                    GROUP BY comic_book_id) AS subq
+                              WHERE counter > 1);
+    </sql>
+
+    <addUniqueConstraint tableName="comic_metadata_sources" constraintName="comic_metadata_source_unique_comic_book_id"
+                         columnNames="comic_book_id"/>
+
+  </changeSet>
+</databaseChangeLog>

--- a/comixed-model/src/main/resources/db/migrations/2.0/changelog-2.0.xml
+++ b/comixed-model/src/main/resources/db/migrations/2.0/changelog-2.0.xml
@@ -19,5 +19,6 @@
     <include file="/db/migrations/2.0/004_370_add_plugins_table.xml"/>
     <include file="/db/migrations/2.0/005_1697_add_blocked_pages_feature_flag.xml"/>
     <include file="/db/migrations/2.0/006_1905_renamed_consolidating_to_organizing.xml"/>
+    <include file="/db/migrations/2.0/007_1911_one_metadata_source_per_comic_book.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
Enforcing at the database level that a comic book can only have a single comic metadata source of truth.

Closes #1911 

## Status
READY

## Does this PR contain migrations?
YES

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

