### PR TITLE
Changed loading comic contents to look at state only [#1929]

### DIFF
--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/processors/LoadFileContentsProcessor.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/processors/LoadFileContentsProcessor.java
@@ -51,6 +51,10 @@ public class LoadFileContentsProcessor
 
   @Override
   public ComicBook process(final ComicBook comicBook) {
+    if (comicBook.isFileContentsLoaded()) {
+      log.debug("Comic book contents already loaded: id={}", comicBook.getId());
+      return comicBook;
+    }
     final ContentAdaptorRules rules = new ContentAdaptorRules();
     rules.setSkipMetadata(
         (this.jobParameters.getParameters().containsKey(PARAM_SKIP_METADATA)

--- a/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/LoadFileContentsReader.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/comicbooks/readers/LoadFileContentsReader.java
@@ -39,6 +39,6 @@ public class LoadFileContentsReader extends AbstractComicReader {
 
   @Override
   protected List<ComicBook> doLoadComics() {
-    return this.comicBookService.findUnprocessedComicsWithoutContent(this.getBatchChunkSize());
+    return this.comicBookService.findComicsWithContentToLoad(this.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/main/java/org/comixedproject/batch/initiators/ProcessComicBooksInitiator.java
+++ b/comixed-batch/src/main/java/org/comixedproject/batch/initiators/ProcessComicBooksInitiator.java
@@ -64,7 +64,7 @@ public class ProcessComicBooksInitiator {
       log.debug("No comic books to be processed");
       return;
     }
-    if (!this.batchProcessesService.hasActiveExecutions(PROCESS_COMIC_BOOKS_STARTED_JOB)) {
+    if (!this.batchProcessesService.hasActiveExecutions(PROCESS_COMIC_BOOKS_JOB)) {
       log.info("Starting process comics job");
       try {
         this.jobLauncher.run(

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/processors/LoadFileContentsProcessorTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/processors/LoadFileContentsProcessorTest.java
@@ -61,6 +61,7 @@ public class LoadFileContentsProcessorTest {
 
   @Before
   public void setUp() throws ContentAdaptorException, AdaptorException {
+    Mockito.when(comicBook.isFileContentsLoaded()).thenReturn(false);
     Mockito.when(comicBookAdaptor.getMetadataFilename(Mockito.any(ComicBook.class)))
         .thenReturn(TEST_METADATA_FILENAME);
     Mockito.doNothing()
@@ -108,6 +109,20 @@ public class LoadFileContentsProcessorTest {
     Mockito.verify(pageList, Mockito.times(1)).sort(Mockito.any());
     Mockito.verify(comicMetadataContentAdaptor, Mockito.times(1))
         .loadContent(comicBook, "", content, contentRules);
+  }
+
+  @Test
+  public void testProcessContentsAlreadyLoaded() throws Exception {
+    Mockito.when(comicBook.isFileContentsLoaded()).thenReturn(true);
+
+    final ComicBook result = processor.process(comicBook);
+
+    assertNotNull(result);
+    assertSame(comicBook, result);
+
+    Mockito.verify(comicBookAdaptor, Mockito.never()).load(Mockito.any(), Mockito.any());
+    Mockito.verify(comicMetadataContentAdaptor, Mockito.never())
+        .loadContent(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
   }
 
   @Test

--- a/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/LoadFileContentsReaderTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/comicbooks/readers/LoadFileContentsReaderTest.java
@@ -45,7 +45,7 @@ public class LoadFileContentsReaderTest {
   public void testReadNoneLoadedManyFound() {
     for (int index = 0; index < MAX_RECORDS; index++) comicBookList.add(comicBook);
 
-    Mockito.when(comicBookService.findUnprocessedComicsWithoutContent(Mockito.anyInt()))
+    Mockito.when(comicBookService.findComicsWithContentToLoad(Mockito.anyInt()))
         .thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
@@ -56,12 +56,12 @@ public class LoadFileContentsReaderTest {
     assertEquals(MAX_RECORDS - 1, comicBookList.size());
 
     Mockito.verify(comicBookService, Mockito.times(1))
-        .findUnprocessedComicsWithoutContent(reader.getBatchChunkSize());
+        .findComicsWithContentToLoad(reader.getBatchChunkSize());
   }
 
   @Test
   public void testReadNoneRemaining() {
-    Mockito.when(comicBookService.findUnprocessedComicsWithoutContent(Mockito.anyInt()))
+    Mockito.when(comicBookService.findComicsWithContentToLoad(Mockito.anyInt()))
         .thenReturn(comicBookList);
 
     reader.comicBookList = comicBookList;
@@ -72,12 +72,12 @@ public class LoadFileContentsReaderTest {
     assertNull(reader.comicBookList);
 
     Mockito.verify(comicBookService, Mockito.times(1))
-        .findUnprocessedComicsWithoutContent(reader.getBatchChunkSize());
+        .findComicsWithContentToLoad(reader.getBatchChunkSize());
   }
 
   @Test
   public void testReadNoneLoadedNoneFound() {
-    Mockito.when(comicBookService.findUnprocessedComicsWithoutContent(Mockito.anyInt()))
+    Mockito.when(comicBookService.findComicsWithContentToLoad(Mockito.anyInt()))
         .thenReturn(comicBookList);
 
     final ComicBook result = reader.read();
@@ -86,6 +86,6 @@ public class LoadFileContentsReaderTest {
     assertNull(reader.comicBookList);
 
     Mockito.verify(comicBookService, Mockito.times(1))
-        .findUnprocessedComicsWithoutContent(reader.getBatchChunkSize());
+        .findComicsWithContentToLoad(reader.getBatchChunkSize());
   }
 }

--- a/comixed-batch/src/test/java/org/comixedproject/batch/initiators/ProcessComicBooksInitiatorTest.java
+++ b/comixed-batch/src/test/java/org/comixedproject/batch/initiators/ProcessComicBooksInitiatorTest.java
@@ -18,6 +18,7 @@
 
 package org.comixedproject.batch.initiators;
 
+import static org.comixedproject.batch.comicbooks.ProcessComicBooksConfiguration.PROCESS_COMIC_BOOKS_JOB;
 import static org.comixedproject.batch.comicbooks.ProcessComicBooksConfiguration.PROCESS_COMIC_BOOKS_STARTED_JOB;
 import static org.junit.Assert.*;
 
@@ -63,6 +64,8 @@ public class ProcessComicBooksInitiatorTest {
           JobExecutionAlreadyRunningException,
           JobParametersInvalidException,
           JobRestartException {
+    Mockito.when(batchProcessesService.hasActiveExecutions(PROCESS_COMIC_BOOKS_JOB))
+        .thenReturn(false);
     for (int index = 0; index < 100; index++) comicBookList.add(Mockito.mock(ComicBook.class));
     Mockito.when(jobLauncher.run(Mockito.any(Job.class), jobParametersArgumentCaptor.capture()))
         .thenReturn(jobExecution);
@@ -150,5 +153,19 @@ public class ProcessComicBooksInitiatorTest {
     assertFalse(jobParameters.isEmpty());
 
     Mockito.verify(jobLauncher, Mockito.times(1)).run(addPageToImageCacheJob, jobParameters);
+  }
+
+  @Test
+  public void testExecuteHasActiveJob()
+      throws JobInstanceAlreadyCompleteException,
+          JobExecutionAlreadyRunningException,
+          JobParametersInvalidException,
+          JobRestartException {
+    Mockito.when(batchProcessesService.hasActiveExecutions(PROCESS_COMIC_BOOKS_JOB))
+        .thenReturn(true);
+
+    initiator.execute();
+
+    Mockito.verify(jobLauncher, Mockito.never()).run(Mockito.any(), Mockito.any());
   }
 }

--- a/comixed-repositories/src/main/java/org/comixedproject/repositories/comicbooks/ComicBookRepository.java
+++ b/comixed-repositories/src/main/java/org/comixedproject/repositories/comicbooks/ComicBookRepository.java
@@ -127,14 +127,13 @@ public interface ComicBookRepository extends JpaRepository<ComicBook, Long> {
   List<ComicBook> findUnprocessedComicsWithCreateMetadataFlagSet(Pageable pageable);
 
   /**
-   * Returns unprocessed comics that have their file loaded flag turned off.
+   * Returns comics that have their file content loaded flag turned off.
    *
    * @param pageable the page request
    * @return the list of comics
    */
-  @Query(
-      "SELECT c FROM ComicBook c WHERE c.comicDetail.comicState = 'UNPROCESSED' AND c.fileContentsLoaded = false")
-  List<ComicBook> findUnprocessedComicsWithoutContent(Pageable pageable);
+  @Query("SELECT c FROM ComicBook c WHERE c.comicDetail.comicState = 'UNPROCESSED'")
+  List<ComicBook> findUnprocessedComics(Pageable pageable);
 
   /**
    * Returns the number of unprocessed comics without file contents loaded.

--- a/comixed-services/src/main/java/org/comixedproject/service/comicbooks/ComicBookService.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/comicbooks/ComicBookService.java
@@ -377,9 +377,8 @@ public class ComicBookService implements InitializingBean, ComicStateChangeListe
    *
    * @return the comics
    */
-  public List<ComicBook> findUnprocessedComicsWithoutContent(final int batchSize) {
-    return this.comicBookRepository.findUnprocessedComicsWithoutContent(
-        PageRequest.of(0, batchSize));
+  public List<ComicBook> findComicsWithContentToLoad(final int batchSize) {
+    return this.comicBookRepository.findUnprocessedComics(PageRequest.of(0, batchSize));
   }
 
   /**

--- a/comixed-services/src/test/java/org/comixedproject/service/comicbooks/ComicBookServiceTest.java
+++ b/comixed-services/src/test/java/org/comixedproject/service/comicbooks/ComicBookServiceTest.java
@@ -571,11 +571,11 @@ public class ComicBookServiceTest {
   }
 
   @Test
-  public void testFindUnprocessedComicsWithoutContent() {
-    Mockito.when(comicBookRepository.findUnprocessedComicsWithoutContent(pageableCaptor.capture()))
+  public void testFindComicsWithContentToLoad() {
+    Mockito.when(comicBookRepository.findUnprocessedComics(pageableCaptor.capture()))
         .thenReturn(comicBookList);
 
-    final List<ComicBook> result = service.findUnprocessedComicsWithoutContent(TEST_MAXIMUM_COMICS);
+    final List<ComicBook> result = service.findComicsWithContentToLoad(TEST_MAXIMUM_COMICS);
 
     assertNotNull(result);
     assertSame(comicBookList, result);
@@ -585,8 +585,7 @@ public class ComicBookServiceTest {
     assertEquals(0, pageable.getPageNumber());
     assertEquals(TEST_MAXIMUM_COMICS, pageable.getPageSize());
 
-    Mockito.verify(comicBookRepository, Mockito.times(1))
-        .findUnprocessedComicsWithoutContent(pageable);
+    Mockito.verify(comicBookRepository, Mockito.times(1)).findUnprocessedComics(pageable);
   }
 
   @Test


### PR DESCRIPTION
The contents loaded flag is now only considered when actually processing the comic.

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

