### PR TITLE
Changed metadata source list for missing adaptors [#2022]

### DIFF
--- a/comixed-webui/src/app/admin/components/metadata-source-list/metadata-source-list.component.html
+++ b/comixed-webui/src/app/admin/components/metadata-source-list/metadata-source-list.component.html
@@ -105,19 +105,11 @@
       {{ "metadata-source-list.label.version" | translate }}
     </mat-header-cell>
     <mat-cell *matCellDef="let entry">
-      <span class="cx-width-100 cx-text-nowrap">
+      <span *ngIf="entry.available" class="cx-width-100 cx-text-nowrap">
         {{ entry.version }}
       </span>
-    </mat-cell>
-  </ng-container>
-
-  <ng-container matColumnDef="available">
-    <mat-header-cell mat-sort-header *matHeaderCellDef>
-      {{ "metadata-source-list.label.available" | translate }}
-    </mat-header-cell>
-    <mat-cell *matCellDef="let entry">
-      <span class="cx-width-100 cx-text-nowrap">
-        {{ entry.available | yesNo | translate }}
+      <span *ngIf="!entry.available" class="cx-width-100 cx-text-nowrap">
+        {{ "metadata-source-list.text.not-installed" | translate }}
       </span>
     </mat-cell>
   </ng-container>

--- a/comixed-webui/src/app/admin/components/metadata-source-list/metadata-source-list.component.scss
+++ b/comixed-webui/src/app/admin/components/metadata-source-list/metadata-source-list.component.scss
@@ -18,13 +18,7 @@
   resize: none;
 }
 
-.mat-column-homepge {
-}
-
-.mat-column-available {
-  width: $cx-column-medium;
-  max-width: $cx-column-medium;
-  resize: none;
+.mat-column-homepage {
 }
 
 .mat-column-property-count {

--- a/comixed-webui/src/app/admin/components/metadata-source-list/metadata-source-list.component.ts
+++ b/comixed-webui/src/app/admin/components/metadata-source-list/metadata-source-list.component.ts
@@ -64,7 +64,6 @@ export class MetadataSourceListComponent
     'actions',
     'name',
     'version',
-    'available',
     'property-count',
     'homepage'
   ];

--- a/comixed-webui/src/assets/i18n/en/comic-metadata.json
+++ b/comixed-webui/src/assets/i18n/en/comic-metadata.json
@@ -82,13 +82,15 @@
   "metadata-source-list": {
     "label": {
       "actions": "",
-      "available": "Available?",
       "homepage": "Project Homepage",
       "name": "Source Name",
       "no-rows-loaded": "No sources loaded",
       "preferred": "Preferred",
       "property-count": "# of Properties",
       "version": "Version"
+    },
+    "text": {
+      "not-installed": "Not Installed"
     },
     "tooltip": {
       "preferred-source": "This is the preferred metadata source."


### PR DESCRIPTION
Now, instead of a separate column for the available status, if the adaptor is not present, it's version will say "Not Installed".

Closes #2022 

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

