### PR TITLE
Fixed filter text not applying all detail list pages [#2186]

### DIFF
--- a/comixed-services/src/main/java/org/comixedproject/service/comicbooks/ComicDetailExampleBuilder.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/comicbooks/ComicDetailExampleBuilder.java
@@ -64,23 +64,6 @@ public class ComicDetailExampleBuilder {
     detail.setComicType(null);
     detail.setUnscraped(null);
 
-    if (StringUtils.hasLength(searchText)) {
-      log.debug("Returning comics with filter text: {}", searchText);
-      detail.setPublisher(searchText);
-      detail.setSeries(searchText);
-      detail.setVolume(searchText);
-      detail.setTitle(searchText);
-      return Example.of(
-          detail,
-          ExampleMatcher.matchingAny()
-              .withMatcher(
-                  "publisher", ExampleMatcher.GenericPropertyMatchers.ignoreCase().contains())
-              .withMatcher("series", ExampleMatcher.GenericPropertyMatchers.ignoreCase().contains())
-              .withMatcher("volume", ExampleMatcher.GenericPropertyMatchers.ignoreCase().contains())
-              .withMatcher(
-                  "title", ExampleMatcher.GenericPropertyMatchers.ignoreCase().contains()));
-    }
-
     ExampleMatcher matcher = ExampleMatcher.matching();
 
     if (coverYear != null) {
@@ -115,7 +98,7 @@ public class ComicDetailExampleBuilder {
 
     if (unscrapedState) {
       log.debug("Enabling unscraped filter");
-      detail.setUnscraped(true);
+      detail.setUnscraped(Boolean.TRUE);
       matcher = matcher.withMatcher("unscraped", ExampleMatcher.GenericPropertyMatchers.exact());
     }
 
@@ -135,6 +118,14 @@ public class ComicDetailExampleBuilder {
       log.debug("Enabling volume filter");
       detail.setVolume(volume);
       matcher = matcher.withMatcher("volume", ExampleMatcher.GenericPropertyMatchers.exact());
+    }
+
+    if (StringUtils.hasLength(searchText)) {
+      log.debug("Returning comics with filter text: {}", searchText);
+      detail.setSeries(searchText);
+      matcher =
+          matcher.withMatcher(
+              "series", ExampleMatcher.GenericPropertyMatchers.ignoreCase().contains());
     }
 
     return Example.of(detail, matcher);


### PR DESCRIPTION
The issue was due to the filter text being exclusive to the rest of the example query code.

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

