### PR TITLE
Fixed scraping comics with a hypen in the issue number [#2206]

### DIFF
--- a/comixed-metadata/src/main/java/org/comixedproject/metadata/adaptors/AbstractMetadataAdaptor.java
+++ b/comixed-metadata/src/main/java/org/comixedproject/metadata/adaptors/AbstractMetadataAdaptor.java
@@ -79,7 +79,7 @@ public abstract class AbstractMetadataAdaptor implements MetadataAdaptor {
     String issue = issueNumber;
     while (!issue.isEmpty()
         && !issue.equals("0")
-        && "123456789%ABCDEFGHIJKLMNOPQRSTUVWXYZ".indexOf(issue.toUpperCase().substring(0, 1))
+        && "-123456789%ABCDEFGHIJKLMNOPQRSTUVWXYZ".indexOf(issue.toUpperCase().substring(0, 1))
             == -1) {
       issue = issue.substring(1);
     }

--- a/comixed-webui/src/app/comic-books/components/comic-scraping/comic-scraping.component.html
+++ b/comixed-webui/src/app/comic-books/components/comic-scraping/comic-scraping.component.html
@@ -111,6 +111,7 @@
     </mat-label>
     <input
       id="metadata-source-id-input"
+      #referenceId
       type="number"
       matInput
       formControlName="referenceId"
@@ -120,7 +121,7 @@
       id="scrape-with-metadata-source-id-button"
       mat-icon-button
       matSuffix
-      [disabled]="!this.metadataSource || !comic?.metadata?.referenceId"
+      [disabled]="!this.metadataSource || referenceId.size === 0"
       [matTooltip]="'scraping.tooltip.use-metadata-source-id' | translate"
       (click)="onScrapeWithReferenceId()"
     >


### PR DESCRIPTION
The problem was that that "-" was getting filtered out of the issue number due to how issue numbers are scrubbed.

This also exposed a bug with entering issue numbers with odd characters or which are not simple ASCII. And the work around for those is to have the admin find the reference id manually, enter it, and then scrape using that id rather than searching.

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

