### PR TITLE
Added a user-configurable external properties file [#2437]

### DIFF
--- a/comixed-app/src/main/java/org/comixedproject/ComiXedConfiguration.java
+++ b/comixed-app/src/main/java/org/comixedproject/ComiXedConfiguration.java
@@ -20,6 +20,7 @@ package org.comixedproject;
 
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -38,4 +39,5 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableAsync
 @EnableCaching
 @EnableMethodSecurity(prePostEnabled = true)
+@PropertySource("classpath:/comixed-core.properties")
 public class ComiXedConfiguration {}

--- a/comixed-app/src/main/resources/application.properties
+++ b/comixed-app/src/main/resources/application.properties
@@ -1,14 +1,4 @@
-spring.application.name=ComiXed
-
-# turn off banner
-spring.main.banner-mode=off
-
-# web configuration
-server.port=7171
-server.servlet.context-path=/
-spring.h2.console.enabled=false
-spring.h2.console.path=/dbconsole
-comixed.auth.jwt-signing-key=comixed-project
+# The user-configured properties for ComiXed
 
 # ssl configuration
 server.ssl.key-store-type=PKCS12
@@ -19,21 +9,8 @@ server.ssl.enabled=false
 server.ssl.trust-store=classpath:keystore/comixed-trust.jks
 server.ssl.trust-store-password=c0m1X3d
 
-# runtime management settings
-management.endpoints.web.exposure.include=health,info,shutdown,metrics
-management.endpoint.shutdown.enabled=true
-management.endpoint.health.show-details=always
-
 # image caching directory
 comixed.images.cache.location=${user.home}/.comixed/image-cache
-
-# Common JPA Configuration
-spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true
-spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
-spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-spring.jpa.show-sql=true
-spring.jpa.generate-ddl=false
-spring.jpa.hibernate.ddl-auto=none
 
 # To select another database in place of the embedded server, simply
 # comment out the H2 configuration below and uncomment the options
@@ -59,50 +36,6 @@ spring.datasource.url=jdbc:h2:file:~/.comixed/comixed
 
 spring.datasource.username=sa
 spring.database.password=
-
-# Hikari Connection Pool Settings
-spring.datasource.hikari.connection-timeout=30000
-spring.datasource.hikari.idle-timeout=30000
-spring.datasource.hikari.pool-name=CX-Conn-Pool
-
-# Session storage
-spring.session.store-type=jdbc
-spring.session.jdbc.initialize-schema=always
-
-# Batch processing
-spring.batch.jdbc.initialize-schema=always
-spring.batch.job.enabled=true
-spring.batch.job.name=processUnhashedComicsJob
-spring.batch.jdbc.isolation-level-for-create=repeatable_read
-comixed.batch.thread-pool-size=-1
-comixed.batch.page-reader.chunk-size=1
-comixed.batch.add-image-cache-entries.chunk-size=1
-comixed.batch.metadata-process.chunk-size=10
-comixed.batch.purge-library.period=60000
-comixed.batch.purge-library.chunk-size=1
-comixed.batch.recreate-comic-files.period=60000
-comixed.batch.recreate-comic-files.chunk-size=1
-comixed.batch.update-comic-metadata.chunk-size=1
-comixed.batch.add-cover-to-image-cache.schedule=0 0 * * * *
-comixed.batch.add-cover-to-image-cache.chunk-size=1
-comixed.batch.process-comic-books.period=60000
-comixed.batch.process-comic-books.chunk-size=10
-comixed.batch.load-page-hashes.period=60000
-comixed.batch.load-page-hashes.chunk-size=10
-comixed.batch.mark-blocked-pages.period=60000
-comixed.batch.mark-blocked-pages.chunk-size=1
-comixed.batch.organize-library.period=60000
-comixed.batch.organize-library.chunk-size=1
-comixed.batch.scrape-metadata.schedule=0 0 3 * * *
-comixed.batch.scrape-metadata.chunk-size=10
-comixed.batch.update-metadata.period=60000
-comixed.batch.update-metadata.chunk-size=10
-
-# Liquibase changelog
-spring.liquibase.change-log=classpath:db/liquibase-changelog.xml
-
-# Jackson JSON handling
-spring.jackson.deserialization.fail-on-unknown-properties=false
 
 # Logging
 logging.file.name=${user.home}/.comixed/comixed.log

--- a/comixed-app/src/main/resources/comixed-core.properties
+++ b/comixed-app/src/main/resources/comixed-core.properties
@@ -1,0 +1,68 @@
+spring.application.name=ComiXed
+
+# turn off banner
+spring.main.banner-mode=off
+
+# web configuration
+server.port=7171
+server.servlet.context-path=/
+spring.h2.console.enabled=false
+spring.h2.console.path=/dbconsole
+comixed.auth.jwt-signing-key=comixed-project
+
+# runtime management settings
+management.endpoints.web.exposure.include=health,info,shutdown,metrics
+management.endpoint.shutdown.access=unrestricted
+management.endpoint.health.show-details=always
+
+# Common JPA Configuration
+spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true
+spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
+spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+spring.jpa.show-sql=true
+spring.jpa.generate-ddl=false
+spring.jpa.hibernate.ddl-auto=none
+
+# Hikari Connection Pool Settings
+spring.datasource.hikari.connection-timeout=30000
+spring.datasource.hikari.idle-timeout=30000
+spring.datasource.hikari.pool-name=CX-Conn-Pool
+
+# Session storage
+spring.session.store-type=jdbc
+spring.session.jdbc.initialize-schema=always
+
+# Batch processing
+spring.batch.jdbc.initialize-schema=always
+spring.batch.job.enabled=true
+spring.batch.job.name=processUnhashedComicsJob
+spring.batch.jdbc.isolation-level-for-create=repeatable_read
+comixed.batch.thread-pool-size=-1
+comixed.batch.page-reader.chunk-size=1
+comixed.batch.add-image-cache-entries.chunk-size=1
+comixed.batch.metadata-process.chunk-size=10
+comixed.batch.purge-library.period=60000
+comixed.batch.purge-library.chunk-size=1
+comixed.batch.recreate-comic-files.period=60000
+comixed.batch.recreate-comic-files.chunk-size=1
+comixed.batch.update-comic-metadata.chunk-size=1
+comixed.batch.add-cover-to-image-cache.schedule=0 0 * * * *
+comixed.batch.add-cover-to-image-cache.chunk-size=1
+comixed.batch.process-comic-books.period=60000
+comixed.batch.process-comic-books.chunk-size=10
+comixed.batch.load-page-hashes.period=60000
+comixed.batch.load-page-hashes.chunk-size=10
+comixed.batch.mark-blocked-pages.period=60000
+comixed.batch.mark-blocked-pages.chunk-size=1
+comixed.batch.organize-library.period=60000
+comixed.batch.organize-library.chunk-size=1
+comixed.batch.scrape-metadata.schedule=0 0 3 * * *
+comixed.batch.scrape-metadata.chunk-size=10
+comixed.batch.update-metadata.period=60000
+comixed.batch.update-metadata.chunk-size=10
+
+# Liquibase changelog
+spring.liquibase.change-log=classpath:db/liquibase-changelog.xml
+
+# Jackson JSON handling
+spring.jackson.deserialization.fail-on-unknown-properties=false


### PR DESCRIPTION
Moved the properties that users shouldn't touch into an internal properties file to make it easier to add new features without requiring the user to update their configuration.

Closes #2437 

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Updates runtime dependencies but does not add new functionality
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

