### PR TITLE
Changed importing comics to use server-side selections [#2489]

### DIFF
--- a/comixed-model/src/main/java/org/comixedproject/model/net/comicfiles/ImportComicFilesRequest.java
+++ b/comixed-model/src/main/java/org/comixedproject/model/net/comicfiles/ImportComicFilesRequest.java
@@ -18,13 +18,7 @@
 
 package org.comixedproject.model.net.comicfiles;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.ArrayList;
-import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 /**
  * <code>ImportComicFilesRequest</code> represents the payload for a request to import comics into
@@ -33,20 +27,4 @@ import lombok.Setter;
  * @author Darryl L. Pierce
  */
 @NoArgsConstructor
-@AllArgsConstructor
-public class ImportComicFilesRequest {
-  @JsonProperty("filenames")
-  @Getter
-  @Setter
-  private List<String> filenames = new ArrayList<>();
-
-  @JsonProperty("skipMetadata")
-  @Getter
-  @Setter
-  private Boolean skipMetadata;
-
-  @JsonProperty("skipBlockingPages")
-  @Getter
-  @Setter
-  private Boolean skipBlockingPages;
-}
+public class ImportComicFilesRequest {}

--- a/comixed-webui/src/app/comic-files/actions/comic-file-list.actions.ts
+++ b/comixed-webui/src/app/comic-files/actions/comic-file-list.actions.ts
@@ -19,6 +19,10 @@
 import { createAction, props } from '@ngrx/store';
 import { ComicFileGroup } from '@app/comic-files/models/comic-file-group';
 
+export const resetComicFileList = createAction(
+  '[Comic File List] Reset the local list of comic files'
+);
+
 export const loadComicFilesFromSession = createAction('[Comic File List]');
 
 export const loadComicFileLists = createAction(

--- a/comixed-webui/src/app/comic-files/actions/import-comic-files.actions.ts
+++ b/comixed-webui/src/app/comic-files/actions/import-comic-files.actions.ts
@@ -16,22 +16,16 @@
  * along with this program. If not, see <http://www.gnu.org/licenses>
  */
 
-import { createAction, props } from '@ngrx/store';
-import { ComicFile } from '@app/comic-files/models/comic-file';
+import { createAction } from '@ngrx/store';
 
-export const sendComicFiles = createAction(
-  '[Import ComicBook Files] Begin importing the selected comic files',
-  props<{
-    files: ComicFile[];
-    skipMetadata: boolean;
-    skipBlockingPages: boolean;
-  }>()
+export const importComicFiles = createAction(
+  '[Import Comic Files] Begin importing the selected comic files'
 );
 
-export const sendComicFilesSuccess = createAction(
-  '[Import ComicBook Files] Importing comic files has started'
+export const importComicFilesSuccess = createAction(
+  '[Import Comic Files] Importing comic files has started'
 );
 
-export const sendComicFilesFailure = createAction(
-  '[Import ComicBook Files] Failed to begin importing comic files'
+export const importComicFilesFailure = createAction(
+  '[Import Comic Files] Failed to begin importing comic files'
 );

--- a/comixed-webui/src/app/comic-files/effects/import-comic-files.effects.spec.ts
+++ b/comixed-webui/src/app/comic-files/effects/import-comic-files.effects.spec.ts
@@ -33,11 +33,12 @@ import { LoggerModule } from '@angular-ru/cdk/logger';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import {
-  sendComicFiles,
-  sendComicFilesFailure,
-  sendComicFilesSuccess
+  importComicFiles,
+  importComicFilesFailure,
+  importComicFilesSuccess
 } from '@app/comic-files/actions/import-comic-files.actions';
 import { hot } from 'jasmine-marbles';
+import { resetComicFileList } from '@app/comic-files/actions/comic-file-list.actions';
 
 describe('ImportComicFilesEffects', () => {
   const FILES = [COMIC_FILE_1, COMIC_FILE_2, COMIC_FILE_3, COMIC_FILE_4];
@@ -83,47 +84,30 @@ describe('ImportComicFilesEffects', () => {
     expect(effects).toBeTruthy();
   });
 
-  describe('sending comic files', () => {
+  describe('importing comic files', () => {
     it('fires an action on success', () => {
       const serviceResponse = new HttpResponse({ status: 200 });
-      const action = sendComicFiles({
-        files: FILES,
-        skipMetadata: SKIP_METADATA,
-        skipBlockingPages: SKIP_BLOCKING_PAGES
-      });
-      const outcome = sendComicFilesSuccess();
+      const action = importComicFiles();
+      const outcome1 = importComicFilesSuccess();
+      const outcome2 = resetComicFileList();
 
       actions$ = hot('-a', { a: action });
-      comicImportService.sendComicFiles
-        .withArgs({
-          files: FILES,
-          skipMetadata: SKIP_METADATA,
-          skipBlockingPages: SKIP_BLOCKING_PAGES
-        })
-        .and.returnValue(of(serviceResponse));
+      comicImportService.sendComicFiles.and.returnValue(of(serviceResponse));
 
-      const expected = hot('-b', { b: outcome });
+      const expected = hot('-(bc)', { b: outcome1, c: outcome2 });
       expect(effects.sendComicFiles$).toBeObservable(expected);
       expect(alertService.info).toHaveBeenCalledWith(jasmine.any(String));
     });
 
     it('fires an action on service failure', () => {
       const serviceResponse = new HttpErrorResponse({});
-      const action = sendComicFiles({
-        files: FILES,
-        skipMetadata: SKIP_METADATA,
-        skipBlockingPages: SKIP_BLOCKING_PAGES
-      });
-      const outcome = sendComicFilesFailure();
+      const action = importComicFiles();
+      const outcome = importComicFilesFailure();
 
       actions$ = hot('-a', { a: action });
-      comicImportService.sendComicFiles
-        .withArgs({
-          files: FILES,
-          skipMetadata: SKIP_METADATA,
-          skipBlockingPages: SKIP_BLOCKING_PAGES
-        })
-        .and.returnValue(throwError(serviceResponse));
+      comicImportService.sendComicFiles.and.returnValue(
+        throwError(serviceResponse)
+      );
 
       const expected = hot('-b', { b: outcome });
       expect(effects.sendComicFiles$).toBeObservable(expected);
@@ -131,21 +115,11 @@ describe('ImportComicFilesEffects', () => {
     });
 
     it('fires an action on general failure', () => {
-      const action = sendComicFiles({
-        files: FILES,
-        skipMetadata: SKIP_METADATA,
-        skipBlockingPages: SKIP_BLOCKING_PAGES
-      });
-      const outcome = sendComicFilesFailure();
+      const action = importComicFiles();
+      const outcome = importComicFilesFailure();
 
       actions$ = hot('-a', { a: action });
-      comicImportService.sendComicFiles
-        .withArgs({
-          files: FILES,
-          skipMetadata: SKIP_METADATA,
-          skipBlockingPages: SKIP_BLOCKING_PAGES
-        })
-        .and.throwError('expected');
+      comicImportService.sendComicFiles.and.throwError('expected');
 
       const expected = hot('-(b|)', { b: outcome });
       expect(effects.sendComicFiles$).toBeObservable(expected);

--- a/comixed-webui/src/app/comic-files/pages/import-comics-page/import-comics-page.component.html
+++ b/comixed-webui/src/app/comic-files/pages/import-comics-page/import-comics-page.component.html
@@ -33,35 +33,6 @@
     <mat-icon>check_box_outline_blank</mat-icon>
   </button>
   <button
-    id="skip-metadata-button"
-    class="cx-margin-right-5"
-    mat-fab
-    [color]="skipMetadata ? 'warn' : 'accent'"
-    [disabled]="showFinderForm"
-    [matTooltip]="
-      'comic-files.tooltip.skip-metadata' | translate: { skipMetadata }
-    "
-    (click)="onSkipMetadata(!skipMetadata)"
-  >
-    <mat-icon>description</mat-icon>
-  </button>
-  @if (blockedPagesEnabled) {
-    <button
-      id="skip-blocking-pages-button"
-      class="cx-margin-right-5"
-      mat-fab
-      [color]="skipBlockingPages ? 'warn' : 'accent'"
-      [disabled]="showFinderForm"
-      [matTooltip]="
-        'comic-files.tooltip.skip-blocking-pages'
-          | translate: { skipBlockingPages }
-      "
-      (click)="onSkipBlockingPages(!skipBlockingPages)"
-    >
-      <mat-icon>block</mat-icon>
-    </button>
-  }
-  <button
     id="start-import-button"
     class="cx-margin-right-5"
     mat-fab

--- a/comixed-webui/src/app/comic-files/pages/import-comics-page/import-comics-page.component.spec.ts
+++ b/comixed-webui/src/app/comic-files/pages/import-comics-page/import-comics-page.component.spec.ts
@@ -36,9 +36,7 @@ import {
   COMIC_FILE_3,
   COMIC_FILE_4
 } from '@app/comic-files/comic-file.fixtures';
-import { sendComicFiles } from '@app/comic-files/actions/import-comic-files.actions';
-import { USER_ADMIN, USER_READER } from '@app/user/user.fixtures';
-import { User } from '@app/user/models/user';
+import { USER_READER } from '@app/user/user.fixtures';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
@@ -70,19 +68,15 @@ import { MatPaginatorModule } from '@angular/material/paginator';
 import { ComicFileLoaderComponent } from '@app/comic-files/components/comic-file-loader/comic-file-loader.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MatSortModule } from '@angular/material/sort';
-import {
-  PREFERENCE_SKIP_BLOCKING_PAGES,
-  PREFERENCE_SKIP_METADATA
-} from '@app/comic-files/comic-file.constants';
 import { Router } from '@angular/router';
 import { toggleComicFileSelections } from '@app/comic-files/actions/comic-file-list.actions';
-import { saveUserPreference } from '@app/user/actions/user.actions';
 import {
   FEATURE_ENABLED_FEATURE_KEY,
   initialState as initialFeatureEnabledState
 } from '@app/admin/reducers/feature-enabled.reducer';
 import { getFeatureEnabled } from '@app/admin/actions/feature-enabled.actions';
 import { BLOCKED_PAGES_ENABLED } from '@app/admin/admin.constants';
+import { importComicFiles } from '@app/comic-files/actions/import-comic-files.actions';
 
 describe('ImportComicsPageComponent', () => {
   const USER = USER_READER;
@@ -97,8 +91,6 @@ describe('ImportComicsPageComponent', () => {
   ];
   const FILE = COMIC_FILE_3;
   const PAGE_SIZE = 400;
-  const SKIP_METADATA = Math.random() > 0.5;
-  const SKIP_BLOCKING_PAGES = Math.random() > 0.5;
   const BLOCKED_PAGES_ENABLED_FEATURE_ENABLED = Math.random() > 0.5;
 
   const initialState = {
@@ -181,41 +173,6 @@ describe('ImportComicsPageComponent', () => {
     });
   });
 
-  describe('loading user preferences', () => {
-    beforeEach(() => {
-      component.skipMetadata = !SKIP_METADATA;
-      component.skipBlockingPages = !SKIP_BLOCKING_PAGES;
-      const user = {
-        ...USER_ADMIN,
-        preferences: [
-          {
-            name: PREFERENCE_SKIP_METADATA,
-            value: `${SKIP_METADATA}`
-          },
-          {
-            name: PREFERENCE_SKIP_BLOCKING_PAGES,
-            value: `${SKIP_BLOCKING_PAGES}`
-          }
-        ]
-      } as User;
-      store.setState({
-        ...initialState,
-        [USER_FEATURE_KEY]: {
-          ...initialUserState,
-          user
-        }
-      });
-    });
-
-    it('sets the skip metadata flag', () => {
-      expect(component.skipMetadata).toEqual(SKIP_METADATA);
-    });
-
-    it('sets the skip blocking pages flag', () => {
-      expect(component.skipBlockingPages).toEqual(SKIP_BLOCKING_PAGES);
-    });
-  });
-
   describe('when loading files', () => {
     describe('when loading stops', () => {
       beforeEach(() => {
@@ -292,69 +249,12 @@ describe('ImportComicsPageComponent', () => {
       spyOn(confirmationService, 'confirm').and.callFake(
         (confirm: Confirmation) => confirm.confirm()
       );
+
+      component.onStartImport();
     });
 
-    describe('not skipping metadata', () => {
-      beforeEach(() => {
-        component.skipMetadata = false;
-        component.onStartImport();
-      });
-
-      it('confirms with the user', () => {
-        expect(confirmationService.confirm).toHaveBeenCalled();
-      });
-
-      it('fires an action', () => {
-        expect(store.dispatch).toHaveBeenCalledWith(
-          sendComicFiles({
-            files: FILES,
-            skipMetadata: false,
-            skipBlockingPages: false
-          })
-        );
-      });
-    });
-
-    describe('skipping metadata', () => {
-      beforeEach(() => {
-        component.skipMetadata = true;
-        component.onStartImport();
-      });
-
-      it('confirms with the user', () => {
-        expect(confirmationService.confirm).toHaveBeenCalled();
-      });
-
-      it('fires an action', () => {
-        expect(store.dispatch).toHaveBeenCalledWith(
-          sendComicFiles({
-            files: FILES,
-            skipMetadata: true,
-            skipBlockingPages: false
-          })
-        );
-      });
-    });
-
-    describe('skipping blcoking pages', () => {
-      beforeEach(() => {
-        component.skipBlockingPages = true;
-        component.onStartImport();
-      });
-
-      it('confirms with the user', () => {
-        expect(confirmationService.confirm).toHaveBeenCalled();
-      });
-
-      it('fires an action', () => {
-        expect(store.dispatch).toHaveBeenCalledWith(
-          sendComicFiles({
-            files: FILES,
-            skipMetadata: false,
-            skipBlockingPages: true
-          })
-        );
-      });
+    it('fires an action', () => {
+      expect(store.dispatch).toHaveBeenCalledWith(importComicFiles());
     });
   });
 
@@ -432,36 +332,6 @@ describe('ImportComicsPageComponent', () => {
           })
         );
       });
-    });
-  });
-
-  describe('toggling the skip metadata flag', () => {
-    beforeEach(() => {
-      component.onSkipMetadata(SKIP_METADATA);
-    });
-
-    it('saves the user preference', () => {
-      expect(store.dispatch).toHaveBeenCalledWith(
-        saveUserPreference({
-          name: PREFERENCE_SKIP_METADATA,
-          value: `${SKIP_METADATA}`
-        })
-      );
-    });
-  });
-
-  describe('toggling the skip blocking pages flag', () => {
-    beforeEach(() => {
-      component.onSkipBlockingPages(SKIP_BLOCKING_PAGES);
-    });
-
-    it('saves the user preference', () => {
-      expect(store.dispatch).toHaveBeenCalledWith(
-        saveUserPreference({
-          name: PREFERENCE_SKIP_BLOCKING_PAGES,
-          value: `${SKIP_BLOCKING_PAGES}`
-        })
-      );
     });
   });
 

--- a/comixed-webui/src/app/comic-files/reducers/comic-file-list.reducer.spec.ts
+++ b/comixed-webui/src/app/comic-files/reducers/comic-file-list.reducer.spec.ts
@@ -32,6 +32,7 @@ import {
   loadComicFileLists,
   loadComicFileListSuccess,
   loadComicFilesFromSession,
+  resetComicFileList,
   toggleComicFileSelections,
   toggleComicFileSelectionsFailure,
   toggleComicFileSelectionsSuccess
@@ -68,6 +69,23 @@ describe('ComicFileList Reducer', () => {
 
     it('has an empty set of files', () => {
       expect(state.files).toEqual([]);
+    });
+  });
+
+  describe('resetting the comic file list', () => {
+    beforeEach(() => {
+      state = reducer(
+        { ...state, files: FILES, groups: GROUPS },
+        resetComicFileList()
+      );
+    });
+
+    it('clears the list of comic files', () => {
+      expect(state.files).toEqual([]);
+    });
+
+    it('clears the group list', () => {
+      expect(state.groups).toEqual([]);
     });
   });
 

--- a/comixed-webui/src/app/comic-files/reducers/comic-file-list.reducer.ts
+++ b/comixed-webui/src/app/comic-files/reducers/comic-file-list.reducer.ts
@@ -23,6 +23,7 @@ import {
   loadComicFileLists,
   loadComicFileListSuccess,
   loadComicFilesFromSession,
+  resetComicFileList,
   toggleComicFileSelections,
   toggleComicFileSelectionsFailure,
   toggleComicFileSelectionsSuccess
@@ -46,6 +47,7 @@ export const initialState: ComicFileListState = {
 export const reducer = createReducer(
   initialState,
 
+  on(resetComicFileList, state => ({ ...state, files: [], groups: [] })),
   on(loadComicFilesFromSession, state => ({ ...state, busy: true })),
   on(loadComicFileLists, state => ({ ...state, busy: true })),
   on(loadComicFileListSuccess, (state, action) => {

--- a/comixed-webui/src/app/comic-files/reducers/import-comic-files.reducer.spec.ts
+++ b/comixed-webui/src/app/comic-files/reducers/import-comic-files.reducer.spec.ts
@@ -27,9 +27,9 @@ import {
   COMIC_FILE_3
 } from '@app/comic-files/comic-file.fixtures';
 import {
-  sendComicFiles,
-  sendComicFilesFailure,
-  sendComicFilesSuccess
+  importComicFiles,
+  importComicFilesFailure,
+  importComicFilesSuccess
 } from '@app/comic-files/actions/import-comic-files.actions';
 
 describe('ImportComicFiles Reducer', () => {
@@ -55,14 +55,7 @@ describe('ImportComicFiles Reducer', () => {
 
   describe('sending comic files', () => {
     beforeEach(() => {
-      state = reducer(
-        { ...state, sending: false },
-        sendComicFiles({
-          files: FILES,
-          skipMetadata: SKIP_METADATA,
-          skipBlockingPages: SKIP_BLOCKING_PAGES
-        })
-      );
+      state = reducer({ ...state, sending: false }, importComicFiles());
     });
 
     it('sets the sending flag', () => {
@@ -71,7 +64,7 @@ describe('ImportComicFiles Reducer', () => {
 
     describe('success', () => {
       beforeEach(() => {
-        state = reducer({ ...state, sending: true }, sendComicFilesSuccess());
+        state = reducer({ ...state, sending: true }, importComicFilesSuccess());
       });
 
       it('clears the sending flag', () => {
@@ -81,7 +74,7 @@ describe('ImportComicFiles Reducer', () => {
 
     describe('failure', () => {
       beforeEach(() => {
-        state = reducer({ ...state, sending: true }, sendComicFilesFailure());
+        state = reducer({ ...state, sending: true }, importComicFilesFailure());
       });
 
       it('clears the sending flag', () => {

--- a/comixed-webui/src/app/comic-files/reducers/import-comic-files.reducer.ts
+++ b/comixed-webui/src/app/comic-files/reducers/import-comic-files.reducer.ts
@@ -18,9 +18,9 @@
 
 import { createFeature, createReducer, on } from '@ngrx/store';
 import {
-  sendComicFilesSuccess,
-  sendComicFiles,
-  sendComicFilesFailure
+  importComicFilesSuccess,
+  importComicFiles,
+  importComicFilesFailure
 } from '@app/comic-files/actions/import-comic-files.actions';
 
 export const IMPORT_COMIC_FILES_FEATURE_KEY = 'import_comic_files_state';
@@ -36,9 +36,9 @@ export const initialState: ImportComicFilesState = {
 export const reducer = createReducer(
   initialState,
 
-  on(sendComicFiles, state => ({ ...state, sending: true })),
-  on(sendComicFilesSuccess, state => ({ ...state, sending: false })),
-  on(sendComicFilesFailure, state => ({ ...state, sending: false }))
+  on(importComicFiles, state => ({ ...state, sending: true })),
+  on(importComicFilesSuccess, state => ({ ...state, sending: false })),
+  on(importComicFilesFailure, state => ({ ...state, sending: false }))
 );
 
 export const comicFilesFeature = createFeature({

--- a/comixed-webui/src/app/comic-files/services/comic-import.service.spec.ts
+++ b/comixed-webui/src/app/comic-files/services/comic-import.service.spec.ts
@@ -62,9 +62,6 @@ describe('ComicImportService', () => {
       files: [COMIC_FILE_2]
     }
   ];
-  const FILES = [COMIC_FILE_1, COMIC_FILE_2, COMIC_FILE_3];
-  const SKIP_METADATA = Math.random() > 0.5;
-  const SKIP_BLOCKING_PAGES = Math.random() > 0.5;
   const MAXIMUM = 100;
   const FILENAME = COMIC_DETAIL_2.baseFilename;
   const SERIES = COMIC_DETAIL_2.series;
@@ -147,20 +144,12 @@ describe('ComicImportService', () => {
   it('can send comic files', () => {
     const serviceResponse = new HttpResponse({ status: 200 });
     service
-      .sendComicFiles({
-        files: FILES,
-        skipMetadata: SKIP_METADATA,
-        skipBlockingPages: SKIP_BLOCKING_PAGES
-      })
+      .sendComicFiles()
       .subscribe(response => expect(response).toEqual(serviceResponse));
 
     const req = httpMock.expectOne(interpolate(SEND_COMIC_FILES_URL));
     expect(req.request.method).toEqual('POST');
-    expect(req.request.body).toEqual({
-      filenames: FILES.map(file => file.filename),
-      skipMetadata: SKIP_METADATA,
-      skipBlockingPages: SKIP_BLOCKING_PAGES
-    } as ImportComicFilesRequest);
+    expect(req.request.body).toEqual({} as ImportComicFilesRequest);
     req.flush(serviceResponse);
   });
 

--- a/comixed-webui/src/app/comic-files/services/comic-import.service.ts
+++ b/comixed-webui/src/app/comic-files/services/comic-import.service.ts
@@ -19,7 +19,6 @@
 import { inject, Injectable } from '@angular/core';
 import { LoggerService } from '@angular-ru/cdk/logger';
 import { Observable } from 'rxjs';
-import { ComicFile } from '@app/comic-files/models/comic-file';
 import { HttpClient } from '@angular/common/http';
 import { interpolate } from '@app/core';
 import { LoadComicFilesRequest } from '@app/library/models/net/load-comic-files-request';
@@ -78,21 +77,13 @@ export class ComicImportService {
 
   /**
    * Sends the supplied comic files to the backend to be imported.
-   * @param args.files the comic files
-   * @param args.ignoreMetadata flag to ignore metadata
-   * @param args.deleteBlockedPages flag to mark blocked pages as deleted
    */
-  sendComicFiles(args: {
-    files: ComicFile[];
-    skipMetadata: boolean;
-    skipBlockingPages: boolean;
-  }): Observable<any> {
-    this.logger.debug('Sending comic files:', args);
-    return this.http.post(interpolate(SEND_COMIC_FILES_URL), {
-      filenames: args.files.map(file => file.filename),
-      skipMetadata: args.skipMetadata,
-      skipBlockingPages: args.skipBlockingPages
-    } as ImportComicFilesRequest);
+  sendComicFiles(): Observable<any> {
+    this.logger.debug('Sending comic files');
+    return this.http.post(
+      interpolate(SEND_COMIC_FILES_URL),
+      {} as ImportComicFilesRequest
+    );
   }
 
   scrapeFilename(args: { filename: string }): Observable<any> {

--- a/comixed-webui/src/app/library/models/net/import-comic-files-request.ts
+++ b/comixed-webui/src/app/library/models/net/import-comic-files-request.ts
@@ -16,8 +16,4 @@
  * along with this program. If not, see <http://www.gnu.org/licenses>
  */
 
-export interface ImportComicFilesRequest {
-  filenames: string[];
-  skipMetadata: boolean;
-  skipBlockingPages: boolean;
-}
+export interface ImportComicFilesRequest {}

--- a/comixed-webui/src/assets/i18n/en/comic-files.json
+++ b/comixed-webui/src/assets/i18n/en/comic-files.json
@@ -20,8 +20,8 @@
     "import-comic-files": {
       "confirmation-message": "Are you sure you want to import the selected {count, plural, =1{comic} other{# comics}}?",
       "confirmation-title": "Import Selected Comics",
-      "effect-failure": "Failed to send comic files for import.",
-      "effect-success": "Submitted {count, plural, =1{one comic file} other{# comic files}} for import."
+      "effect-failure": "Failed to import comic files.",
+      "effect-success": "Import comic files started...."
     },
     "label": {
       "base-filename": "Filename",
@@ -82,8 +82,6 @@
       "find-files": "Load files under this directory (shift+ctrl+f).",
       "select-all": "Select all comic files for import (ctrl+a).",
       "show-finder-form": "Find comic files to import...",
-      "skip-blocking-pages": "Skip marked blocked pages as deleted (currently {skipBlockingPages, select, true{ON} other{OFF}})",
-      "skip-metadata": "Skip processing metadata (currently {skipMetadata, select, true{ON} other{OFF}})",
       "start-import": "Start importing the selected comic files (ctrl+i).",
       "toggle-file-lookup-form": "Toggle the comic file lookup form."
     }


### PR DESCRIPTION
 * Renamed sendComicFiles => importComicFiles.
 * Removed fields from the importComicFiles action.
 * Changed the backend to use the session's list of filenames.
 * Added resetting the comic file list on successful import start.

Closes #2489 

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Updates runtime dependencies but does not add new functionality
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

