### PR TITLE
Added Windows service support using WinSW [#2430]

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,3 +14,5 @@ what it is today.
  * Natalie Stroud @natastro
  * Heather Anderson <heath@odysseus.anderson.name>
  * Sathwik Hejamady Bhat <sathwikhbhat@gmail.com>
+ * Muhammad Fakhr-Eddin <muhammadfakhr73@gmail.com>
+

--- a/comixed-release/src/main/windows/comixed.nsi
+++ b/comixed-release/src/main/windows/comixed.nsi
@@ -22,6 +22,17 @@ File ..\..\..\..\comixed-app\target\comixed-app-3.2-SNAPSHOT.jar
 File ..\..\..\target\classes\org\comixedproject\modules\windows_agent_installer\comixed-service.exe
 File .\comixed-service.xml
 
+ExecWait '"$INSTDIR\bin\comixed-service.exe" install' $0
+IntCmp $0 0 +3
+  MessageBox MB_OK|MB_ICONSTOP "Failed to install the ComiXed service (exit code $0)."
+  Abort
+
+ExecWait '"$INSTDIR\bin\comixed-service.exe" start' $0
+IntCmp $0 0 +4
+  MessageBox MB_OK|MB_ICONSTOP "ComiXed service failed to start (exit code $0). Verify Java is installed and retry."
+  ExecWait '"$INSTDIR\bin\comixed-service.exe" uninstall'
+  Abort
+
 SetOutPath $INSTDIR\lib
 File ..\..\..\target\lib\h2*jar
 


### PR DESCRIPTION
## Status
READY

## Does this PR contain migrations?
NO

## Description
This PR addresses issue #2430 by adding support for running ComiXed as a Windows service. 

- Integrated **WinSW** (Windows Service Wrapper) to handle the Java executable as a service.
- Updated the **NSIS installer** (`comixed.nsi`) to automatically install and start the service.
- Added exit code validation in the installer to notify users and abort if the service fails to start (e.g., due to missing JRE).
- Included `comixed-service.xml` configuration for WinSW.


