### PR TITLE
Fixed not being able to delete discovered comics [#2634]

### DIFF
--- a/comixed-state/src/main/java/org/comixedproject/state/comicbooks/ComicStateMachineConfiguration.java
+++ b/comixed-state/src/main/java/org/comixedproject/state/comicbooks/ComicStateMachineConfiguration.java
@@ -278,11 +278,17 @@ public class ComicStateMachineConfiguration
         .source(ComicState.CHANGED)
         .target(ComicState.DELETED)
         .event(ComicEvent.deleteComic)
+        // the discovered comic was marked for deletion
+        .and()
+        .withExternal()
+        .source(ComicState.DISCOVERED)
+        .target(ComicState.DELETED)
+        .event(ComicEvent.deleteComic)
         // the comic was unmarked for deletion
         .and()
         .withExternal()
         .source(ComicState.DELETED)
-        .target(ComicState.CHANGED)
+        .target(ComicState.UNPROCESSED)
         .event(ComicEvent.undeleteComic)
         .action(undeleteComicAction)
         // the comic record was actually deleted


### PR DESCRIPTION
Additionally, changes unmarking comics for deletion to move them back to being unprocessed rather than changed.

Closes #2634 

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Updates runtime dependencies but does not add new functionality
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

