### PR TITLE
Changed JWT dependencies to v0.13.0 [#2424]

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,3 +15,4 @@ what it is today.
  * Heather Anderson <heath@odysseus.anderson.name>
  * Sathwik Hejamady Bhat <sathwikhbhat@gmail.com>
  * Joran Van Belle <joran.vanbelle@live.be>
+ * Ayush Thakur <ayushwork0@gmail.com>

--- a/comixed-app/src/main/resources/application.properties
+++ b/comixed-app/src/main/resources/application.properties
@@ -42,3 +42,4 @@ comixed.batch.thread-pool-size=3
 logging.file.name=${user.home}/.comixed/comixed.log
 logging.level.root=OFF
 logging.level.org.comixedproject=INFO
+comixed.auth.jwt-signing-key=comixed-secured-jwt-signing-key!

--- a/comixed-app/src/main/resources/comixed-core.properties
+++ b/comixed-app/src/main/resources/comixed-core.properties
@@ -8,7 +8,6 @@ server.port=7171
 server.servlet.context-path=/
 spring.h2.console.enabled=false
 spring.h2.console.path=/dbconsole
-comixed.auth.jwt-signing-key=comixed-project
 
 # ssl configuration
 server.ssl.key-store-type=PKCS12

--- a/comixed-auth/pom.xml
+++ b/comixed-auth/pom.xml
@@ -20,8 +20,20 @@
     </dependency>
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
-      <artifactId>jjwt</artifactId>
-      <version>0.9.1</version>
+      <artifactId>jjwt-api</artifactId>
+      <version>0.13.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>0.13.0</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>0.13.0</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.comixedproject</groupId>

--- a/comixed-auth/src/main/java/org/comixedproject/auth/JwtTokenUtil.java
+++ b/comixed-auth/src/main/java/org/comixedproject/auth/JwtTokenUtil.java
@@ -20,11 +20,13 @@ package org.comixedproject.auth;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.function.Function;
+import javax.crypto.SecretKey;
 import lombok.extern.log4j.Log4j2;
 import org.comixedproject.model.user.ComiXedRole;
 import org.comixedproject.model.user.ComiXedUser;
@@ -46,7 +48,7 @@ import org.springframework.stereotype.Component;
 public class JwtTokenUtil {
   private static final String ROLE_PREFIX = "ROLE_";
 
-  @Value("${comixed.auth.jwt-signing-key:comixed-project}")
+  @Value("${comixed.auth.jwt-signing-key:comixed-secured-jwt-signing-key!}")
   String signingKey;
 
   @Autowired private ComiXedUserRepository userRepository;
@@ -65,7 +67,8 @@ public class JwtTokenUtil {
   }
 
   private Claims getAllClaimsFromToken(String token) {
-    return Jwts.parser().setSigningKey(this.signingKey).parseClaimsJws(token).getBody();
+    SecretKey key = Keys.hmacShaKeyFor(this.signingKey.getBytes(StandardCharsets.UTF_8));
+    return Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
   }
 
   private Boolean isTokenExpired(String token) {
@@ -78,8 +81,6 @@ public class JwtTokenUtil {
   }
 
   String doGenerateToken(String email) {
-
-    var claims = Jwts.claims().setSubject(email);
     List<GrantedAuthority> authorities = new ArrayList<>();
 
     ComiXedUser user = this.userRepository.findByEmail(email);
@@ -89,14 +90,15 @@ public class JwtTokenUtil {
       }
     }
 
-    claims.put("scopes", authorities);
+    SecretKey key = Keys.hmacShaKeyFor(this.signingKey.getBytes(StandardCharsets.UTF_8));
 
     return Jwts.builder()
-        .setClaims(claims)
-        .setIssuer("http://www.comixedproject.org")
-        .setIssuedAt(new Date(System.currentTimeMillis()))
-        .setExpiration(new Date(System.currentTimeMillis() + (5 * 60 * 60) * 1000))
-        .signWith(SignatureAlgorithm.HS256, this.signingKey)
+        .subject(email)
+        .claim("scopes", authorities)
+        .issuer("http://www.comixedproject.org")
+        .issuedAt(new Date(System.currentTimeMillis()))
+        .expiration(new Date(System.currentTimeMillis() + (5 * 60 * 60) * 1000))
+        .signWith(key) // Alg (HS256) is inferred automatically based on key length!
         .compact();
   }
 

--- a/comixed-auth/src/test/java/org/comixedproject/auth/JwtTokenUtilTest.java
+++ b/comixed-auth/src/test/java/org/comixedproject/auth/JwtTokenUtilTest.java
@@ -33,7 +33,7 @@ class JwtTokenUtilTest {
     Mockito.when(user.getEmail()).thenReturn(TEST_EMAIL);
     Mockito.when(userDetails.getUsername()).thenReturn(TEST_EMAIL);
 
-    tokenUtil.signingKey = "the-testing-key";
+    tokenUtil.signingKey = "comixed-secured-jwt-signing-key!";
     this.token = tokenUtil.doGenerateToken(TEST_EMAIL);
   }
 


### PR DESCRIPTION
Upgraded the io.jsonwebtoken library from version 0.9.1 to 0.13.0 inside the comixed-auth module to fulfill security requirements. Closes #2424.

- Replaced the legacy unified jar with jjwt-api, jjwt-impl, and jjwt-jackson.
- Refactored JwtTokenUtil to use modern verifyWith and claim chains.
- Updated JwtTokenUtilTest with a secure 256-bit signing mock key.
- Updated the default JWT signing key to meet the minimum 32-byte requirement.
- Moved the JWT signing key configuration to application.properties.
- Added contributor information.

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [x] Updates runtime dependencies but does not add new functionality
- [x] My code follows the code style of this project.
- [x] My read of the **CONTRIBUTING** document is complete.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.