### PR TITLE
Changed how comic removals are published [#2780]

### DIFF
--- a/comixed-messaging/src/main/java/org/comixedproject/messaging/comicbooks/PublishComicBookRemovalAction.java
+++ b/comixed-messaging/src/main/java/org/comixedproject/messaging/comicbooks/PublishComicBookRemovalAction.java
@@ -21,7 +21,7 @@ package org.comixedproject.messaging.comicbooks;
 import lombok.extern.log4j.Log4j2;
 import org.comixedproject.messaging.AbstractPublishAction;
 import org.comixedproject.messaging.PublishingException;
-import org.comixedproject.model.comicbooks.ComicBook;
+import org.comixedproject.model.library.DisplayableComic;
 import org.comixedproject.views.View;
 import org.springframework.stereotype.Component;
 
@@ -33,7 +33,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @Log4j2
-public class PublishComicBookRemovalAction extends AbstractPublishAction<ComicBook> {
+public class PublishComicBookRemovalAction extends AbstractPublishAction<DisplayableComic> {
   /** Topic which receives comic list removals in real time. */
   public static final String COMIC_LIST_REMOVAL_TOPIC = "/topic/comic-list.removal";
 
@@ -41,13 +41,13 @@ public class PublishComicBookRemovalAction extends AbstractPublishAction<ComicBo
   public static final String COMIC_BOOK_REMOVAL_TOPIC = "/topic/comic-book.%d.removal";
 
   @Override
-  public void publish(final ComicBook comicBook) throws PublishingException {
+  public void publish(final DisplayableComic comic) throws PublishingException {
     log.trace("Publishing comicBook list removal");
-    this.doPublish(COMIC_LIST_REMOVAL_TOPIC, comicBook, View.ComicDetailsView.class);
+    this.doPublish(COMIC_LIST_REMOVAL_TOPIC, comic, View.ComicDetailsView.class);
     log.trace("Publishing comicBook book removal");
     this.doPublish(
-        String.format(COMIC_BOOK_REMOVAL_TOPIC, comicBook.getComicBookId()),
-        comicBook,
+        String.format(COMIC_BOOK_REMOVAL_TOPIC, comic.getComicBookId()),
+        comic,
         View.ComicDetailsView.class);
   }
 }

--- a/comixed-messaging/src/test/java/org/comixedproject/messaging/comicbooks/PublishComicBookRemovalActionTest.java
+++ b/comixed-messaging/src/test/java/org/comixedproject/messaging/comicbooks/PublishComicBookRemovalActionTest.java
@@ -19,16 +19,16 @@
 package org.comixedproject.messaging.comicbooks;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
 
 import org.comixedproject.messaging.PublishingException;
-import org.comixedproject.model.comicbooks.ComicBook;
+import org.comixedproject.model.library.DisplayableComic;
 import org.comixedproject.views.View;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -47,33 +47,33 @@ class PublishComicBookRemovalActionTest {
   @Mock private SimpMessagingTemplate messagingTemplate;
   @Mock private ObjectMapper objectMapper;
   @Mock private ObjectWriter objectWriter;
-  @Mock private ComicBook comicBook;
+  @Mock private DisplayableComic comic;
 
   @BeforeEach
-  public void setUp() throws JacksonException {
-    Mockito.when(objectMapper.writerWithView(Mockito.any())).thenReturn(objectWriter);
-    Mockito.when(objectWriter.writeValueAsString(Mockito.any())).thenReturn(TEST_COMIC_AS_JSON);
-    Mockito.when(comicBook.getComicBookId()).thenReturn(TEST_COMIC_ID);
+  void setUp() throws JacksonException {
+    when(objectMapper.writerWithView(any())).thenReturn(objectWriter);
+    when(objectWriter.writeValueAsString(any())).thenReturn(TEST_COMIC_AS_JSON);
+    when(comic.getComicBookId()).thenReturn(TEST_COMIC_ID);
   }
 
   @Test
   void publish_JacksonException() throws JacksonException {
-    Mockito.when(objectWriter.writeValueAsString(Mockito.any())).thenThrow(JacksonException.class);
+    when(objectWriter.writeValueAsString(any())).thenThrow(JacksonException.class);
 
-    assertThrows(PublishingException.class, () -> action.publish(comicBook));
+    assertThrows(PublishingException.class, () -> action.publish(comic));
   }
 
   @Test
   void publish() throws JacksonException, PublishingException {
-    Mockito.when(objectWriter.writeValueAsString(Mockito.any())).thenReturn(TEST_COMIC_AS_JSON);
+    when(objectWriter.writeValueAsString(any())).thenReturn(TEST_COMIC_AS_JSON);
 
-    action.publish(comicBook);
+    action.publish(comic);
 
-    Mockito.verify(objectMapper, Mockito.times(2)).writerWithView(View.ComicDetailsView.class);
-    Mockito.verify(objectWriter, Mockito.times(2)).writeValueAsString(comicBook);
-    Mockito.verify(messagingTemplate, Mockito.times(1))
+    verify(objectMapper, times(2)).writerWithView(View.ComicDetailsView.class);
+    verify(objectWriter, times(2)).writeValueAsString(comic);
+    verify(messagingTemplate)
         .convertAndSend(PublishComicBookRemovalAction.COMIC_LIST_REMOVAL_TOPIC, TEST_COMIC_AS_JSON);
-    Mockito.verify(messagingTemplate, Mockito.times(1))
+    verify(messagingTemplate)
         .convertAndSend(
             String.format(PublishComicBookRemovalAction.COMIC_BOOK_REMOVAL_TOPIC, TEST_COMIC_ID),
             TEST_COMIC_AS_JSON);

--- a/comixed-services/src/main/java/org/comixedproject/service/comicbooks/ComicStateChangeAdaptor.java
+++ b/comixed-services/src/main/java/org/comixedproject/service/comicbooks/ComicStateChangeAdaptor.java
@@ -21,7 +21,6 @@ package org.comixedproject.service.comicbooks;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
-import lombok.NonNull;
 import lombok.extern.log4j.Log4j2;
 import org.comixedproject.messaging.PublishingException;
 import org.comixedproject.messaging.comicbooks.PublishComicBookRemovalAction;
@@ -58,11 +57,12 @@ public class ComicStateChangeAdaptor implements InitializingBean, ComicStateChan
   }
 
   @Override
-  public void onComicStateChanged(final @NonNull ComicBook comicBook) {
+  public void onComicStateChanged(final ComicBook comicBook) {
     try {
       if (comicBook.getState().equals(ComicState.REMOVED)) {
         log.debug("Comic book deleted");
-        this.publishComicBookRemovalAction.publish(comicBook);
+        this.publishComicBookRemovalAction.publish(
+            this.displayableComicService.getForComicBookId(comicBook.getComicBookId()));
       } else {
         log.debug("Saving updated comic book");
         comicBook.setLastModifiedOn(new Date());

--- a/comixed-services/src/test/java/org/comixedproject/service/comicbooks/ComicStateChangeAdaptorTest.java
+++ b/comixed-services/src/test/java/org/comixedproject/service/comicbooks/ComicStateChangeAdaptorTest.java
@@ -1,6 +1,7 @@
 package org.comixedproject.service.comicbooks;
 
 import static junit.framework.TestCase.assertNotNull;
+import static org.mockito.Mockito.*;
 
 import java.util.Date;
 import java.util.HashSet;
@@ -12,18 +13,15 @@ import org.comixedproject.model.comicbooks.*;
 import org.comixedproject.model.library.DisplayableComic;
 import org.comixedproject.service.library.DisplayableComicService;
 import org.comixedproject.state.comicbooks.ComicBookStateAdaptor;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 class ComicStateChangeAdaptorTest {
   private static final ComicState TEST_STATE = ComicState.CHANGED;
+  private static final long TEST_COMIC_BOOK_ID = 710129L;
 
   @InjectMocks private ComicStateChangeAdaptor adaptor;
   @Mock private ComicBookStateAdaptor comicBookStateAdaptor;
@@ -40,69 +38,66 @@ class ComicStateChangeAdaptorTest {
 
   private Set<ComicTag> comicTagList = new HashSet<>();
 
-  @BeforeEach
-  void setUp() throws ComicBookException {
-    Mockito.when(comicDetail.getTags()).thenReturn(comicTagList);
-    Mockito.when(comicBook.getComicDetail()).thenReturn(comicDetail);
-    Mockito.when(comicBookRecord.getComicDetail()).thenReturn(comicDetail);
-    Mockito.when(displayableComicService.getForComicBookId(Mockito.anyLong()))
-        .thenReturn(displayableComicBook);
-  }
-
   @Test
   void afterPropertiesSet() throws Exception {
     adaptor.afterPropertiesSet();
 
-    Mockito.verify(comicBookStateAdaptor, Mockito.times(1)).addListener(adaptor);
+    verify(comicBookStateAdaptor).addListener(adaptor);
   }
 
   @Test
-  void onComicStateChange_purgeEvent() throws PublishingException {
-    Mockito.when(comicBook.getState()).thenReturn(ComicState.REMOVED);
+  void onComicStateChange_comicDeleted() throws PublishingException, ComicBookException {
+    when(comicBook.getState()).thenReturn(ComicState.REMOVED);
+    when(comicBook.getComicBookId()).thenReturn(TEST_COMIC_BOOK_ID);
+    when(displayableComicService.getForComicBookId(anyLong())).thenReturn(displayableComicBook);
 
     adaptor.onComicStateChanged(comicBook);
 
-    Mockito.verify(comicRemovalPublishAction, Mockito.times(1)).publish(comicBook);
+    verify(displayableComicService).getForComicBookId(TEST_COMIC_BOOK_ID);
+    verify(comicRemovalPublishAction).publish(displayableComicBook);
   }
 
   @Test
-  void onComicStateChange_purgeEventPublishingException() throws PublishingException {
-    Mockito.when(comicBook.getState()).thenReturn(ComicState.REMOVED);
-    Mockito.doThrow(PublishingException.class)
+  void onComicStateChange_comicDeleted_publishingException()
+      throws PublishingException, ComicBookException {
+    when(comicBook.getState()).thenReturn(ComicState.REMOVED);
+    when(comicBook.getComicBookId()).thenReturn(TEST_COMIC_BOOK_ID);
+    when(displayableComicService.getForComicBookId(anyLong())).thenReturn(displayableComicBook);
+    doThrow(PublishingException.class)
         .when(comicRemovalPublishAction)
-        .publish(Mockito.any(ComicBook.class));
-    Mockito.doNothing()
-        .when(comicUpdatePublishAction)
-        .publish(comicBookDataArgumentCaptor.capture());
+        .publish(any(DisplayableComic.class));
 
     adaptor.onComicStateChanged(comicBook);
 
-    Mockito.verify(comicRemovalPublishAction, Mockito.times(1)).publish(comicBook);
+    verify(displayableComicService).getForComicBookId(TEST_COMIC_BOOK_ID);
+    verify(comicRemovalPublishAction).publish(displayableComicBook);
   }
 
   @Test
   void onComicStateChange() throws PublishingException {
-    Mockito.when(comicBook.getState()).thenReturn(TEST_STATE);
-    Mockito.when(comicBookService.save(Mockito.any(ComicBook.class))).thenReturn(comicBookRecord);
-    Mockito.doNothing()
-        .when(comicUpdatePublishAction)
-        .publish(comicBookDataArgumentCaptor.capture());
+    when(comicBook.getState()).thenReturn(TEST_STATE);
+    when(comicBookService.save(any(ComicBook.class))).thenReturn(comicBookRecord);
+    when(comicBookRecord.getComicDetail()).thenReturn(comicDetail);
+    when(comicDetail.getTags()).thenReturn(comicTagList);
+    doNothing().when(comicUpdatePublishAction).publish(comicBookDataArgumentCaptor.capture());
 
     adaptor.onComicStateChanged(comicBook);
 
     final ComicBookData comicBookData = comicBookDataArgumentCaptor.getValue();
     assertNotNull(comicBookData);
 
-    Mockito.verify(comicBook, Mockito.times(1)).setLastModifiedOn(Mockito.any(Date.class));
-    Mockito.verify(comicBookService, Mockito.times(1)).save(comicBook);
-    Mockito.verify(comicUpdatePublishAction, Mockito.times(1)).publish(comicBookData);
+    verify(comicBook).setLastModifiedOn(any(Date.class));
+    verify(comicBookService).save(comicBook);
+    verify(comicUpdatePublishAction).publish(comicBookData);
   }
 
   @Test
   void onComicStateChange_publishingError() throws PublishingException {
-    Mockito.when(comicBook.getState()).thenReturn(TEST_STATE);
-    Mockito.when(comicBookService.save(Mockito.any(ComicBook.class))).thenReturn(comicBookRecord);
-    Mockito.doThrow(PublishingException.class)
+    when(comicBook.getState()).thenReturn(TEST_STATE);
+    when(comicBookService.save(any(ComicBook.class))).thenReturn(comicBookRecord);
+    when(comicBookRecord.getComicDetail()).thenReturn(comicDetail);
+    when(comicDetail.getTags()).thenReturn(comicTagList);
+    doThrow(PublishingException.class)
         .when(comicUpdatePublishAction)
         .publish(comicBookDataArgumentCaptor.capture());
 
@@ -111,8 +106,8 @@ class ComicStateChangeAdaptorTest {
     final ComicBookData comicBookData = comicBookDataArgumentCaptor.getValue();
     assertNotNull(comicBookData);
 
-    Mockito.verify(comicBook, Mockito.times(1)).setLastModifiedOn(Mockito.any(Date.class));
-    Mockito.verify(comicBookService, Mockito.times(1)).save(comicBook);
-    Mockito.verify(comicUpdatePublishAction, Mockito.times(1)).publish(comicBookData);
+    verify(comicBook).setLastModifiedOn(any(Date.class));
+    verify(comicBookService).save(comicBook);
+    verify(comicUpdatePublishAction).publish(comicBookData);
   }
 }

--- a/comixed-webui/src/app/comic-books/models/comic-book-data.ts
+++ b/comixed-webui/src/app/comic-books/models/comic-book-data.ts
@@ -21,7 +21,7 @@ import { ComicMetadataSource } from '@app/comic-books/models/comic-metadata-sour
 import { ComicPage } from '@app/comic-books/models/comic-page';
 
 export interface ComicBookData {
-  details: DisplayableComic;
+  detail: DisplayableComic;
   metadata?: ComicMetadataSource;
   pages: ComicPage[];
 }

--- a/comixed-webui/src/app/comic-books/services/displayable-comic.service.spec.ts
+++ b/comixed-webui/src/app/comic-books/services/displayable-comic.service.spec.ts
@@ -34,8 +34,6 @@ import { ArchiveType } from '@app/comic-books/models/archive-type.enum';
 import { ComicType } from '@app/comic-books/models/comic-type';
 import { ComicState } from '@app/comic-books/models/comic-state';
 import {
-  COMIC_BOOK_1,
-  COMIC_BOOK_2,
   DISPLAYABLE_COMIC_1,
   DISPLAYABLE_COMIC_2,
   DISPLAYABLE_COMIC_3,
@@ -69,12 +67,12 @@ import {
   comicRemoved,
   comicUpdated
 } from '@app/comic-books/actions/comic-list.actions';
-import { DisplayableComic } from '@app/comic-books/models/displayable-comic';
 import {
   provideHttpClient,
   withInterceptorsFromDi
 } from '@angular/common/http';
 import { ComicTagType } from '@app/comic-books/models/comic-tag-type';
+import { ComicBookData } from '@app/comic-books/models/comic-book-data';
 
 describe('DisplayableComicService', () => {
   const PAGE_SIZE = 25;
@@ -149,8 +147,8 @@ describe('DisplayableComicService', () => {
   });
 
   describe('when messaging starts', () => {
-    const COMIC_ADDED = COMIC_BOOK_1;
-    const COMIC_REMOVED = COMIC_BOOK_2;
+    const COMIC_ADDED = DISPLAYABLE_COMIC_1;
+    const COMIC_REMOVED = DISPLAYABLE_COMIC_2;
 
     beforeEach(() => {
       webSocketService.requestResponse.and.callFake(
@@ -162,7 +160,11 @@ describe('DisplayableComicService', () => {
       webSocketService.subscribe
         .withArgs(COMIC_LIST_UPDATE_TOPIC, jasmine.anything())
         .and.callFake((destination, callback) => {
-          callback(COMIC_ADDED as any);
+          callback({
+            detail: COMIC_ADDED,
+            pages: [],
+            metadata: null
+          } as ComicBookData as any);
           return {} as Subscription;
         });
       webSocketService.subscribe
@@ -194,26 +196,7 @@ describe('DisplayableComicService', () => {
     it('processes comic updates', () => {
       expect(store.dispatch).toHaveBeenCalledWith(
         comicUpdated({
-          comic: {
-            comicBookId: COMIC_ADDED.detail.comicBookId,
-            comicDetailId: COMIC_ADDED.detail.comicDetailId,
-            archiveType: COMIC_ADDED.detail.archiveType,
-            comicState: COMIC_ADDED.detail.comicState,
-            unscraped: COMIC_ADDED.detail.unscraped,
-            comicType: COMIC_ADDED.detail.comicType,
-            publisher: COMIC_ADDED.detail.publisher,
-            series: COMIC_ADDED.detail.series,
-            volume: COMIC_ADDED.detail.volume,
-            issueNumber: COMIC_ADDED.detail.issueNumber,
-            sortableIssueNumber: COMIC_ADDED.detail.sortableIssueNumber,
-            title: COMIC_ADDED.detail.title,
-            pageCount: COMIC_ADDED.detail.pageCount,
-            coverDate: COMIC_ADDED.detail.coverDate,
-            yearPublished: COMIC_ADDED.detail.publishedYear,
-            monthPublished: COMIC_ADDED.detail.publishedMonth,
-            storeDate: COMIC_ADDED.detail.storeDate,
-            addedDate: COMIC_ADDED.detail.addedDate
-          } as DisplayableComic
+          comic: COMIC_ADDED
         })
       );
     });
@@ -221,26 +204,7 @@ describe('DisplayableComicService', () => {
     it('processes comic removals', () => {
       expect(store.dispatch).toHaveBeenCalledWith(
         comicRemoved({
-          comic: {
-            comicBookId: COMIC_REMOVED.detail.comicBookId,
-            comicDetailId: COMIC_REMOVED.detail.comicDetailId,
-            archiveType: COMIC_REMOVED.detail.archiveType,
-            comicState: COMIC_REMOVED.detail.comicState,
-            unscraped: COMIC_REMOVED.detail.unscraped,
-            comicType: COMIC_REMOVED.detail.comicType,
-            publisher: COMIC_REMOVED.detail.publisher,
-            series: COMIC_REMOVED.detail.series,
-            volume: COMIC_REMOVED.detail.volume,
-            issueNumber: COMIC_REMOVED.detail.issueNumber,
-            sortableIssueNumber: COMIC_REMOVED.detail.sortableIssueNumber,
-            title: COMIC_REMOVED.detail.title,
-            pageCount: COMIC_REMOVED.detail.pageCount,
-            coverDate: COMIC_REMOVED.detail.coverDate,
-            yearPublished: COMIC_REMOVED.detail.publishedYear,
-            monthPublished: COMIC_REMOVED.detail.publishedMonth,
-            storeDate: COMIC_REMOVED.detail.storeDate,
-            addedDate: COMIC_REMOVED.detail.addedDate
-          } as DisplayableComic
+          comic: COMIC_REMOVED
         })
       );
     });

--- a/comixed-webui/src/app/comic-books/services/displayable-comic.service.ts
+++ b/comixed-webui/src/app/comic-books/services/displayable-comic.service.ts
@@ -26,7 +26,6 @@ import { ComicState } from '@app/comic-books/models/comic-state';
 import { Store } from '@ngrx/store';
 import { WebSocketService } from '@app/messaging';
 import { selectMessagingStarted } from '@app/messaging/selectors/messaging.selectors';
-import { ComicBook } from '@app/comic-books/models/comic-book';
 import {
   COMIC_LIST_REMOVAL_TOPIC,
   COMIC_LIST_UPDATE_TOPIC
@@ -47,7 +46,6 @@ import { LoadComicsByIdRequest } from '@app/comic-books/models/net/load-comics-b
 import { LoadComicsForCollectionRequest } from '@app/comic-books/models/net/load-comics-for-collection-request';
 import { LoadComicsByReadStateRequest } from '@app/comic-books/models/net/load-comics-by-read-state-request';
 import { LoadComicsForListRequest } from '@app/comic-books/models/net/load-comics-for-list-request';
-import { ComicDetail } from '@app/comic-books/models/comic-detail';
 import { DisplayableComic } from '@app/comic-books/models/displayable-comic';
 import {
   comicRemoved,
@@ -55,6 +53,7 @@ import {
 } from '@app/comic-books/actions/comic-list.actions';
 import { ComicTagType } from '@app/comic-books/models/comic-tag-type';
 import { filter, tap } from 'rxjs/operators';
+import { ComicBookData } from '@app/comic-books/models/comic-book-data';
 
 @Injectable({
   providedIn: 'root'
@@ -72,26 +71,18 @@ export class DisplayableComicService {
         filter(started => started),
         tap(() => {
           this.logger.trace('Subscribing to comic list updates');
-          this.webSocketService.subscribe<ComicBook>(
+          this.webSocketService.subscribe<ComicBookData>(
             COMIC_LIST_UPDATE_TOPIC,
             comic => {
               this.logger.debug('Received comic list update:', comic);
-              this.store.dispatch(
-                comicUpdated({
-                  comic: this.doConvertToDisplayableComic(comic.detail)
-                })
-              );
+              this.store.dispatch(comicUpdated({ comic: comic.detail }));
             }
           );
-          this.webSocketService.subscribe<ComicBook>(
+          this.webSocketService.subscribe<DisplayableComic>(
             COMIC_LIST_REMOVAL_TOPIC,
             comic => {
               this.logger.debug('Received comic removal update:', comic);
-              this.store.dispatch(
-                comicRemoved({
-                  comic: this.doConvertToDisplayableComic(comic.detail)
-                })
-              );
+              this.store.dispatch(comicRemoved({ comic }));
             }
           );
         })
@@ -224,28 +215,5 @@ export class DisplayableComicService {
         sortDirection: args.sortDirection
       } as LoadComicsForListRequest
     );
-  }
-
-  private doConvertToDisplayableComic(detail: ComicDetail): DisplayableComic {
-    return {
-      comicBookId: detail.comicBookId,
-      comicDetailId: detail.comicDetailId,
-      archiveType: detail.archiveType,
-      comicState: detail.comicState,
-      unscraped: detail.unscraped,
-      comicType: detail.comicType,
-      publisher: detail.publisher,
-      series: detail.series,
-      volume: detail.volume,
-      issueNumber: detail.issueNumber,
-      sortableIssueNumber: detail.sortableIssueNumber,
-      title: detail.title,
-      pageCount: detail.pageCount,
-      coverDate: detail.coverDate,
-      yearPublished: detail.publishedYear,
-      monthPublished: detail.publishedMonth,
-      storeDate: detail.storeDate,
-      addedDate: detail.addedDate
-    } as DisplayableComic;
   }
 }


### PR DESCRIPTION
Instead of a ComicBook it now sends the DisplayableComic when a comic was removed.

Closes #2780 

## Status
READY

## Does this PR contain migrations?
NO

## Before You Submit Your PR:
- [ ] Have you announced your PR on the comixed-dev mailing list?
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactors existing code (code changes for efficiency or maintainability)
- [ ] Updates runtime dependencies but does not add new functionality
- [ ] Security fix (be sure to include the CVE in the commit message) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

